### PR TITLE
feat(utils): add Logger helper and expose it as the public API

### DIFF
--- a/radiologist-utils/pyproject.toml
+++ b/radiologist-utils/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "gcsfs>=2025.3.0",
     "numpy>=1.24.0",
     "Pillow>=10.0.0",
+    "rich>=13.0.0",
 ]
 
 [tool.uv.build-backend]

--- a/radiologist-utils/src/radiologist/utils/__init__.py
+++ b/radiologist-utils/src/radiologist/utils/__init__.py
@@ -1,5 +1,27 @@
 # MIT License
 #
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+# MIT License
+#
 # Copyright (c) 2025 @CedrickArmel, @samarita22, @TaxelleT & @Yeyecodes
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/radiologist-utils/src/radiologist/utils/__init__.py
+++ b/radiologist-utils/src/radiologist/utils/__init__.py
@@ -1,6 +1,6 @@
 # MIT License
 #
-# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+# Copyright (c) 2025 @CedrickArmel, @samarita22, @TaxelleT & @Yeyecodes
 #
 # Permission is hereby granted, free of charge, to any person obtaining a copy
 # of this software and associated documentation files (the "Software"), to deal
@@ -20,18 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from radiologist.utils.readers import (
-    BaseImageReader,
-    ImageReader,
-    LocalImageReader,
-    RemoteImageReader,
-    read_image,
-)
+from .loggers import Logger
 
 __all__ = [
-    "BaseImageReader",
-    "ImageReader",
-    "LocalImageReader",
-    "RemoteImageReader",
-    "read_image",
+    "Logger",
 ]

--- a/radiologist-utils/src/radiologist/utils/loggers.py
+++ b/radiologist-utils/src/radiologist/utils/loggers.py
@@ -1,5 +1,28 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 import logging
 from typing import Mapping, Optional
+
 
 class Logger(logging.LoggerAdapter):
     """A plain python command line logger."""

--- a/radiologist-utils/src/radiologist/utils/loggers.py
+++ b/radiologist-utils/src/radiologist/utils/loggers.py
@@ -1,0 +1,20 @@
+import logging
+from typing import Mapping, Optional
+
+class Logger(logging.LoggerAdapter):
+    """A plain python command line logger."""
+
+    def __init__(
+        self,
+        name: str = __name__,
+        extra: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        logger = logging.getLogger(name)
+        super().__init__(logger=logger, extra=extra)
+
+    def log(  # type: ignore[override]
+        self, level: int, msg: str, *args, **kwargs
+    ) -> None:
+        if self.isEnabledFor(level):
+            msg, kwargs = self.process(msg, kwargs)  # type: ignore[assignment]
+            self.logger.log(level, msg, *args, **kwargs)


### PR DESCRIPTION
## Summary

- Add `radiologist/utils/loggers.py`: `Logger` class subclassing `logging.LoggerAdapter` for consistent pipeline logging
- Export `Logger` as the sole public symbol from `radiologist.utils`
- Add `rich>=13.0.0` runtime dependency (used for progress bars in the ETL pipeline)

## Test plan

- [ ] `from radiologist.utils import Logger` works
- [ ] `uv run pytest radiologist-utils/tests -q` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)