### PR TITLE
feat(utils): expose image reader classes in public API

### DIFF
--- a/radiologist-utils/src/radiologist/utils/__init__.py
+++ b/radiologist-utils/src/radiologist/utils/__init__.py
@@ -43,7 +43,19 @@
 # SOFTWARE.
 
 from .loggers import Logger
+from .readers import (
+    BaseImageReader,
+    ImageReader,
+    LocalImageReader,
+    RemoteImageReader,
+    read_image,
+)
 
 __all__ = [
+    "BaseImageReader",
+    "ImageReader",
+    "LocalImageReader",
     "Logger",
+    "RemoteImageReader",
+    "read_image",
 ]


### PR DESCRIPTION
## Summary
- Add `BaseImageReader`, `ImageReader`, `LocalImageReader`, `RemoteImageReader`, and `read_image` to `radiologist.utils.__all__`

## Test plan
- [ ] `from radiologist.utils import ImageReader` resolves without error
- [ ] Existing utils tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)