### PR TITLE
chore(docs): add shared agent memory from radiologist-etl sessions

### DIFF
--- a/.claude/agent-memory/shared/MEMORY.md
+++ b/.claude/agent-memory/shared/MEMORY.md
@@ -1,0 +1,4 @@
+# Memory Index — Shared (all agents)
+
+- [TDD feedback](feedback_tdd.md) — Always write failing tests first, watch them fail, then implement — no exceptions
+- [gh CLI feedback](feedback_gh_cli.md) — Use `gh pr create` directly; pr-open skill hits sandbox command_substitution error

--- a/.claude/agent-memory/shared/feedback_gh_cli.md
+++ b/.claude/agent-memory/shared/feedback_gh_cli.md
@@ -1,0 +1,12 @@
+---
+name: feedback-gh-cli
+description: Use gh CLI directly for GitHub operations — the pr-open skill hits a sandbox permission error on command substitution
+metadata:
+  type: feedback
+---
+
+Use `gh pr create` directly instead of the pr-open skill for this project.
+
+**Why:** The pr-open skill fails with "Shell command permission check failed: Contains command_substitution" in this sandbox.
+
+**How to apply:** When opening PRs, call `gh pr create --title "..." --body "$(cat <<'EOF'...EOF)"` directly. Check `gh pr list` first to avoid duplicates.

--- a/.claude/agent-memory/shared/feedback_tdd.md
+++ b/.claude/agent-memory/shared/feedback_tdd.md
@@ -1,0 +1,12 @@
+---
+name: feedback-tdd
+description: Always write failing tests before implementing any feature or change — strict TDD, no exceptions
+metadata:
+  type: feedback
+---
+
+Write the failing test first. Watch it fail. Only then write the implementation that makes it pass.
+
+**Why:** The user enforces strict TDD. Writing tests after implementation produces tests that fit existing code rather than tests that specify intended behaviour.
+
+**How to apply:** For every new function, class, or behaviour change: write (or update) the test file first, run the suite and confirm the new tests fail with the expected error, then implement the production code. Applies even to small additions like a new helper inside an existing module.

--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -1,0 +1,10 @@
+# Memory Index — tdd-developer agent
+
+- [Numpy bool assertions](feedback_numpy_bool_assertions.md) — use `== True/False` not `is True/False` for pandas/numpy cells from Parquet/DataFrame
+- [Output dir creation](feedback_pipeline_dir_creation.md) — functions that write to caller-supplied paths must mkdir before writing; fsspec local does not auto-create parents
+- [WebDataset TarWriter](feedback_webdataset_tarwriter.md) — use `wds.TarWriter` not `wds.ShardWriter` for predetermined shard paths
+- [Write files via Python](feedback_write_files_via_python.md) — use `python3 -c` or Write tool for files containing `!=` or shell-special chars
+- [ETL implementation patterns](project_etl_implementation.md) — scikit-image import scope, functools.partial pickling, fsspec normalization, Prefect import guard, ParquetWriter guard, workers sentinel
+- [Pipeline architecture](project_pipeline_architecture.md) — ops.py/prefect.py split pattern, compute_run_id hashing contract, Prefect 3 API facts
+
+See also: [[shared/MEMORY.md]] for cross-agent rules (TDD, gh CLI, uv venv).

--- a/.claude/agent-memory/tdd-developer/feedback_numpy_bool_assertions.md
+++ b/.claude/agent-memory/tdd-developer/feedback_numpy_bool_assertions.md
@@ -1,0 +1,12 @@
+---
+name: feedback-numpy-bool-assertions
+description: Use == True/False not `is True/False` when asserting on pandas/numpy booleans from parquet or DataFrame cells
+metadata:
+  type: feedback
+---
+
+Use `== True` and `== False` (value equality) rather than `is True` / `is False` when asserting on values read back from pandas DataFrames or Parquet files.
+
+**Why:** pandas and pyarrow return `np.True_` / `np.False_` (numpy scalars), not Python builtins. `np.True_ is True` evaluates to `False` even though the value is correct, causing spurious test failures.
+
+**How to apply:** In any test that reads from `pd.read_parquet`, `df.iloc[n][col]`, or any pandas cell, always use `== True`, `== False`, or `pd.isna()` — never identity checks with `is`.

--- a/.claude/agent-memory/tdd-developer/feedback_pipeline_dir_creation.md
+++ b/.claude/agent-memory/tdd-developer/feedback_pipeline_dir_creation.md
@@ -1,0 +1,12 @@
+---
+name: feedback-output-dir-creation
+description: Code that writes to a user-specified output path must create parent directories itself — never assume they exist
+metadata:
+  type: feedback
+---
+
+Any function that writes files to a caller-supplied output directory must call `Path(output_dir).mkdir(parents=True, exist_ok=True)` before the first write.
+
+**Why:** The caller controls the path and may pass a directory that does not yet exist (e.g. a fresh `tmp_path` subdirectory in tests, or a first run in CI). Backends like fsspec's local filesystem raise `FileNotFoundError` if parent directories are absent — they do not auto-create them.
+
+**How to apply:** Wherever a new output path parameter is introduced, add the `mkdir` call at the top of the write block. Do not rely on the caller or the filesystem backend to create parents.

--- a/.claude/agent-memory/tdd-developer/feedback_webdataset_tarwriter.md
+++ b/.claude/agent-memory/tdd-developer/feedback_webdataset_tarwriter.md
@@ -1,0 +1,12 @@
+---
+name: feedback-webdataset-tarwriter
+description: Use wds.TarWriter not wds.ShardWriter when writing a single predetermined shard path
+metadata:
+  type: feedback
+---
+
+Use `wds.TarWriter(shard_path)` instead of `wds.ShardWriter(shard_path, ...)` when you already know the exact output tar path.
+
+**Why:** `ShardWriter` treats its first argument as a `%`-style format string and calls `pattern % self.shard` internally. Any path without a `%d`-style placeholder raises `TypeError: not all arguments converted during string formatting`. When the caller controls grouping and index offsets manually, `TarWriter` is the correct primitive.
+
+**How to apply:** Whenever a shard path is already fully computed before the write loop, use `wds.TarWriter(shard_path)` as a context manager. Reserve `ShardWriter` only for cases where the library should manage shard rotation and naming via a `%d`-style pattern.

--- a/.claude/agent-memory/tdd-developer/feedback_write_files_via_python.md
+++ b/.claude/agent-memory/tdd-developer/feedback_write_files_via_python.md
@@ -1,0 +1,12 @@
+---
+name: feedback-write-files-via-python
+description: When writing source files that contain != or other shell-special chars, use python3 -c or a Python script instead of heredoc cat
+metadata:
+  type: feedback
+---
+
+Use `python3 -c` (with a PYEOF delimiter) or the Write tool to write source files that contain `!=`, `!`, or other shell metacharacters.
+
+**Why:** bash heredocs process `!` as a history-expansion character even inside single-quoted delimiters in some shell configs, turning `!=` into `\!=` which is a Python syntax error.
+
+**How to apply:** Whenever a file to be written contains `!=`, `!`, or `\` sequences, write it via the Python `open()` approach: `python3 - << 'PYEOF' ... PYEOF` with the content as a Python string literal. If the Edit tool is available for the path, prefer it for surgical fixes.

--- a/.claude/agent-memory/tdd-developer/project_etl_implementation.md
+++ b/.claude/agent-memory/tdd-developer/project_etl_implementation.md
@@ -1,0 +1,27 @@
+---
+name: project-etl-implementation
+description: radiologist-etl key constraints and gotchas for stats, processors, filters, manifest, shards
+metadata:
+  type: project
+---
+
+Package lives at `radiologist-etl/src/radiologist/etl/`. Tests in `radiologist-etl/tests/`.
+
+**scikit-image import constraint:** all `from skimage.feature import ...` calls must stay inside function bodies in `stats.py` — never at module level. This keeps the import lazy and avoids circular issues.
+
+**Multiprocessing pickling:** any callable submitted to a process pool must be picklable — use `functools.partial` of a top-level function; closures are not picklable on OSes that use `spawn` instead of `fork` (e.g. macOS).
+
+**fsspec path normalization in `_resolve_mask`:** `fsspec.unstrip_protocol` on local paths returns `file:///path/...` URIs. Raw string prefix-stripping fails silently. Always normalize both sides through `fsspec.url_to_fs` before computing relative paths:
+```python
+_, norm_image = fsspec.url_to_fs(image_path, **opts)
+_, norm_root = fsspec.url_to_fs(images_root, **opts)
+rel = norm_image[len(norm_root):].lstrip("/")
+```
+
+**Prefect import guard + mypy:** Wrap all `from prefect import ...` in `try/except ImportError` with stub no-ops (in `prefect.py`). The stubs need `# type: ignore[misc, no-redef]` (not just `[misc]`) because mypy sees the try-branch import and the except-branch `def` as a redefinition.
+
+**ParquetWriter empty guard:** `ParquetWriter.write` raises `ValueError("Cannot write an empty manifest — no records to persist.")` when called with an empty list. Never skip this guard — a schema-less Parquet breaks all downstream steps.
+
+**StatsProcessor.workers sentinel:** `workers` parameter is `int | None = None`; resolved at runtime as `self._workers = workers or os.cpu_count() or 1`. Never use `os.cpu_count()` as a default argument value — it is evaluated once at import time.
+
+**build_shards storage_options:** `build_shards` accepts `storage_options: dict | None = None` and forwards it to the underlying fsspec calls.

--- a/.claude/agent-memory/tdd-developer/project_pipeline_architecture.md
+++ b/.claude/agent-memory/tdd-developer/project_pipeline_architecture.md
@@ -1,0 +1,30 @@
+---
+name: project-pipeline-architecture
+description: ETL ops.py/prefect.py split pattern, compute_run_id contract, Prefect 3 API facts
+metadata:
+  type: project
+---
+
+## ops.py / prefect.py split
+
+Portable pipeline logic lives in `ops.py` — pure Python functions with zero Prefect imports.
+Prefect orchestration shells live in `prefect.py` — `@task` / `@flow` decorators that delegate entirely to `ops.py` functions; no logic inside the decorated bodies beyond calling the core and creating artifacts.
+
+`ops.py` is importable without `prefect` installed. `prefect.py` guards all Prefect imports with `try/except ImportError` stub no-ops.
+
+Use `OmegaConf.select(cfg, "key")` (not `cfg.get("key")`) for optional `DictConfig` keys. Cast `OmegaConf.to_container()` result to `dict()` explicitly to satisfy mypy.
+
+## compute_run_id contract
+
+`run_label` is always included in the SHA-256 fingerprint, never returned verbatim.
+Same label + same data → same ID (idempotent). Different label → different ID (forces new artifacts).
+
+**Why:** prevents silent artifact overwrite when `run_label` is reused across different dataset versions.
+
+**How to apply:** Any future change to `compute_run_id` must preserve this hashing behaviour. Tests verify both divergence (`label != no_label`) and stability (`same label twice → same ID`).
+
+## Prefect 3 API facts
+
+- `create_link_artifact` is **not** a coroutine — call it synchronously inside task bodies.
+- `cache_policy=INPUTS` (from `prefect.cache_policies`) enables task-level idempotency.
+- Calling `etl_flow(cfg)` directly without a runner spins up a temporary Prefect server inline — valid for testing.


### PR DESCRIPTION
## Summary
- Add `.claude/agent-memory/shared/` — cross-agent rules (TDD, gh CLI workaround)
- Add `.claude/agent-memory/tdd-developer/` — session learnings: numpy bool assertions, output dir creation, WebDataset TarWriter, fsspec path normalization, Prefect 3 API facts, ops.py/prefect.py split pattern, ETL implementation constraints

## Test plan
- [ ] Files visible in repo for team members to load as agent context

🤖 Generated with [Claude Code](https://claude.com/claude-code)