### PR TITLE
feat(utils): add ml instantiators, hydra utils and distributed helpers

### DIFF
--- a/radiologist-utils/src/radiologist/utils/ml/__init__.py
+++ b/radiologist-utils/src/radiologist/utils/ml/__init__.py
@@ -1,25 +1,20 @@
-# MIT License
-#
-# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
-#
-# Permission is hereby granted, free of charge, to any person obtaining a copy
-# of this software and associated documentation files (the "Software"), to deal
-# in the Software without restriction, including without limitation the rights
-# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-# copies of the Software, and to permit persons to whom the Software is
-# furnished to do so, subject to the following conditions:
-#
-# The above copyright notice and this permission notice shall be included in all
-# copies or substantial portions of the Software.
-#
-# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-# SOFTWARE.
-
+from .distributed import balance_data_world_size, worker_balanced_n_samples
+from .hydra_utils import extras, get_metric_value, task_wrapper
+from .instantiators import (
+    instantiate_callbacks,
+    instantiate_loggers,
+    sequential_scheduler,
+)
 from .logging_utils import log_hyperparameters
 
-__all__ = ["log_hyperparameters"]
+__all__ = [
+    "balance_data_world_size",
+    "extras",
+    "get_metric_value",
+    "instantiate_callbacks",
+    "instantiate_loggers",
+    "log_hyperparameters",
+    "sequential_scheduler",
+    "task_wrapper",
+    "worker_balanced_n_samples",
+]

--- a/radiologist-utils/src/radiologist/utils/ml/distributed.py
+++ b/radiologist-utils/src/radiologist/utils/ml/distributed.py
@@ -1,0 +1,45 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import math
+import random
+from typing import Dict, List
+
+
+def worker_balanced_n_samples(n_samples: int, batch: int, worldsize: int) -> int:
+    """Round n_samples up to the next multiple of batch * worldsize."""
+    unit = batch * worldsize
+    return math.ceil(n_samples / unit) * unit
+
+
+def balance_data_world_size(
+    data: List[Dict],  # type: ignore[type-arg]
+    batch: int,
+    worldsize: int,
+) -> List[Dict]:  # type: ignore[type-arg]
+    """Pad data with random resamples so its length is a multiple of batch * worldsize."""
+    target = worker_balanced_n_samples(len(data), batch, worldsize)
+    shortfall = target - len(data)
+    padding = random.choices(data, k=shortfall) if shortfall > 0 else []
+    return list(data) + padding

--- a/radiologist-utils/src/radiologist/utils/ml/hydra_utils.py
+++ b/radiologist-utils/src/radiologist/utils/ml/hydra_utils.py
@@ -1,0 +1,99 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, Optional
+
+from omegaconf import DictConfig
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
+
+log = logging.getLogger(__name__)
+
+
+def extras(cfg: DictConfig) -> None:
+    """Apply optional run-time extras controlled by cfg.extras.
+
+    Currently supports: ignoring warnings, enforcing tags, printing config tree.
+    """
+    if not cfg.get("extras"):
+        return
+
+    extras_cfg = cfg.extras
+
+    if extras_cfg.get("ignore_warnings"):
+        import warnings
+
+        warnings.filterwarnings("ignore")
+
+    if extras_cfg.get("enforce_tags") and not cfg.get("tags"):
+        raise ValueError("You must specify tags for this run.")
+
+    if extras_cfg.get("print_config"):
+        log.info("Config:\n%s", cfg)
+
+
+def task_wrapper(task_func: Callable) -> Callable:
+    """Wrap a task function so that wandb is always finalised on exit.
+
+    Re-raises any exception after finalising wandb.
+    """
+
+    def wrap(cfg: Any) -> Any:
+        try:
+            return task_func(cfg)
+        except Exception:
+            log.exception("Task failed")
+            raise
+        finally:
+            try:
+                import wandb as _wandb
+
+                _wandb.finish()
+            except ImportError:
+                pass
+
+    return wrap
+
+
+def get_metric_value(
+    metric_dict: Dict[str, Any], metric_name: Optional[str]
+) -> Optional[float]:
+    """Return the scalar value of metric_name from metric_dict.
+
+    Returns 0 when metric_name is falsy.
+    Raises KeyError when metric_name is non-falsy but absent from metric_dict.
+    """
+    if not metric_name:
+        return 0
+    if metric_name not in metric_dict:
+        raise KeyError(
+            f"Metric '{metric_name}' not found in metric_dict. "
+            f"Available keys: {list(metric_dict.keys())}"
+        )
+    value = metric_dict[metric_name]
+    return value.item() if hasattr(value, "item") else float(value)

--- a/radiologist-utils/src/radiologist/utils/ml/instantiators.py
+++ b/radiologist-utils/src/radiologist/utils/ml/instantiators.py
@@ -1,0 +1,85 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+from functools import partial
+from typing import List, Optional
+
+from hydra.utils import instantiate
+from omegaconf import DictConfig
+from torch.optim import Optimizer
+from torch.optim.lr_scheduler import SequentialLR
+
+try:
+    from lightning.pytorch import Callback
+    from lightning.pytorch.loggers import Logger
+except ImportError:
+    Callback = object  # type: ignore[assignment,misc]
+    Logger = object  # type: ignore[assignment,misc]
+
+
+def instantiate_callbacks(
+    callbacks_cfg: Optional[DictConfig],
+) -> Optional[List[Callback]]:
+    """Instantiate Lightning callbacks from a DictConfig section.
+
+    Each top-level key must carry a ``_target_`` field.
+    Returns None when cfg is empty or falsy; raises TypeError for non-DictConfig.
+    """
+    if callbacks_cfg is None:
+        return None
+    if not isinstance(callbacks_cfg, DictConfig):
+        raise TypeError(
+            f"callbacks_cfg must be a DictConfig, got {type(callbacks_cfg).__name__}"
+        )
+    if not callbacks_cfg:
+        return None
+    return [instantiate(v) for v in callbacks_cfg.values()]
+
+
+def instantiate_loggers(
+    logger_cfg: Optional[DictConfig],
+) -> Optional[List[Logger]]:
+    """Instantiate Lightning loggers from a DictConfig section.
+
+    Returns None when cfg is empty or falsy; raises TypeError for non-DictConfig.
+    """
+    if logger_cfg is None:
+        return None
+    if not isinstance(logger_cfg, DictConfig):
+        raise TypeError(
+            f"logger_cfg must be a DictConfig, got {type(logger_cfg).__name__}"
+        )
+    if not logger_cfg:
+        return None
+    return [instantiate(v) for v in logger_cfg.values()]
+
+
+def sequential_scheduler(
+    optimizer: Optimizer,
+    schedulers: List[partial],  # type: ignore[type-arg]
+    milestones: List[int],
+) -> SequentialLR:
+    """Build a SequentialLR from partial scheduler factories and milestone epochs."""
+    materialized = [s(optimizer) for s in schedulers]
+    return SequentialLR(optimizer, schedulers=materialized, milestones=milestones)

--- a/radiologist-utils/tests/test_ml.py
+++ b/radiologist-utils/tests/test_ml.py
@@ -1,0 +1,221 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import sys
+import types
+from functools import partial
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+from torch.optim import SGD
+from torch.optim.lr_scheduler import ConstantLR, SequentialLR
+
+from radiologist.utils.ml import (
+    balance_data_world_size,
+    get_metric_value,
+    instantiate_callbacks,
+    instantiate_loggers,
+    sequential_scheduler,
+    task_wrapper,
+    worker_balanced_n_samples,
+)
+
+# ---------------------------------------------------------------------------
+# instantiate_callbacks
+# ---------------------------------------------------------------------------
+
+
+def test_instantiate_callbacks_returns_none_for_none_cfg() -> None:
+    assert instantiate_callbacks(None) is None
+
+
+def test_instantiate_callbacks_returns_none_for_empty_dictconfig() -> None:
+    cfg = OmegaConf.create({})
+    assert instantiate_callbacks(cfg) is None
+
+
+def test_instantiate_callbacks_returns_list_for_valid_cfg() -> None:
+    from lightning.pytorch.callbacks import ModelCheckpoint
+
+    cfg = OmegaConf.create(
+        {"ckpt": {"_target_": "lightning.pytorch.callbacks.ModelCheckpoint"}}
+    )
+    result = instantiate_callbacks(cfg)
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], ModelCheckpoint)
+
+
+def test_instantiate_callbacks_raises_type_error_for_non_dictconfig() -> None:
+    with pytest.raises(TypeError):
+        instantiate_callbacks("not a DictConfig")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# instantiate_loggers
+# ---------------------------------------------------------------------------
+
+
+def test_instantiate_loggers_returns_none_for_none_cfg() -> None:
+    assert instantiate_loggers(None) is None
+
+
+def test_instantiate_loggers_returns_none_for_empty_dictconfig() -> None:
+    cfg = OmegaConf.create({})
+    assert instantiate_loggers(cfg) is None
+
+
+def test_instantiate_loggers_returns_list_for_valid_cfg() -> None:
+    from lightning.pytorch.loggers import CSVLogger
+
+    cfg = OmegaConf.create(
+        {
+            "csv": {
+                "_target_": "lightning.pytorch.loggers.CSVLogger",
+                "save_dir": "/tmp",
+            }
+        }
+    )
+    result = instantiate_loggers(cfg)
+    assert isinstance(result, list)
+    assert len(result) == 1
+    assert isinstance(result[0], CSVLogger)
+
+
+# ---------------------------------------------------------------------------
+# sequential_scheduler
+# ---------------------------------------------------------------------------
+
+
+def test_sequential_scheduler_returns_sequential_lr() -> None:
+    model = torch.nn.Linear(2, 2)
+    opt = SGD(model.parameters(), lr=0.01)
+    sched_a = partial(ConstantLR, factor=1.0, total_iters=500)
+    sched_b = partial(ConstantLR, factor=0.1, total_iters=500)
+    result = sequential_scheduler(opt, [sched_a, sched_b], milestones=[500])
+    assert isinstance(result, SequentialLR)
+
+
+# ---------------------------------------------------------------------------
+# get_metric_value
+# ---------------------------------------------------------------------------
+
+
+def test_get_metric_value_returns_zero_for_falsy_name() -> None:
+    assert get_metric_value({}, None) == 0
+    assert get_metric_value({"val_loss": torch.tensor(0.5)}, "") == 0
+
+
+def test_get_metric_value_returns_float_for_existing_key() -> None:
+    metrics = {"val_loss": torch.tensor(0.5)}
+    result = get_metric_value(metrics, "val_loss")
+    assert result == pytest.approx(0.5)
+
+
+def test_get_metric_value_raises_for_missing_key() -> None:
+    with pytest.raises(Exception):
+        get_metric_value({}, "val_loss")
+
+
+# ---------------------------------------------------------------------------
+# task_wrapper
+# ---------------------------------------------------------------------------
+
+
+def test_task_wrapper_reraises_exception_and_finalizes_wandb() -> None:
+    stub_wandb = types.ModuleType("wandb")
+    finish_called = []
+
+    def fake_finish() -> None:
+        finish_called.append(True)
+
+    stub_wandb.finish = fake_finish  # type: ignore[attr-defined]
+
+    original = sys.modules.get("wandb")
+    sys.modules["wandb"] = stub_wandb
+    try:
+
+        @task_wrapper
+        def failing_task(cfg: object) -> None:
+            raise ValueError("boom")
+
+        with pytest.raises(ValueError, match="boom"):
+            failing_task(object())
+
+        assert finish_called, "wandb.finish was not called"
+    finally:
+        if original is None:
+            del sys.modules["wandb"]
+        else:
+            sys.modules["wandb"] = original
+
+
+# ---------------------------------------------------------------------------
+# worker_balanced_n_samples
+# ---------------------------------------------------------------------------
+
+
+def test_worker_balanced_n_samples_rounds_up_to_next_multiple() -> None:
+    assert worker_balanced_n_samples(10, batch=4, worldsize=2) == 16
+
+
+def test_worker_balanced_n_samples_already_multiple_unchanged() -> None:
+    assert worker_balanced_n_samples(8, batch=4, worldsize=2) == 8
+
+
+# ---------------------------------------------------------------------------
+# balance_data_world_size
+# ---------------------------------------------------------------------------
+
+
+def test_balance_data_world_size_len_is_multiple_of_batch_times_worldsize() -> None:
+    data = [{"x": i} for i in range(10)]
+    result = balance_data_world_size(data, batch=4, worldsize=2)
+    assert len(result) % (4 * 2) == 0
+
+
+def test_balance_data_world_size_preserves_original_items() -> None:
+    data = [{"x": i} for i in range(10)]
+    result = balance_data_world_size(data, batch=4, worldsize=2)
+    originals = result[:10]
+    assert originals == data
+
+
+# ---------------------------------------------------------------------------
+# public API re-export
+# ---------------------------------------------------------------------------
+
+
+def test_public_api_imports_resolve() -> None:
+    from radiologist.utils.ml import (  # noqa: F401
+        balance_data_world_size,
+        extras,
+        get_metric_value,
+        instantiate_callbacks,
+        instantiate_loggers,
+        sequential_scheduler,
+        task_wrapper,
+        worker_balanced_n_samples,
+    )


### PR DESCRIPTION
## Summary

- Add `radiologist.utils.ml` submodule with `instantiators.py`, `hydra_utils.py`, and `distributed.py`
- Implement `instantiate_callbacks`, `instantiate_loggers`, `sequential_scheduler`, `task_wrapper`, `extras`, `get_metric_value`, `worker_balanced_n_samples`, `balance_data_world_size`
- Re-export all symbols via `ml/__init__.py` `__all__`

## Test plan

- [x] `instantiate_callbacks(None)` → `None`
- [x] `instantiate_callbacks({})` → `None`
- [x] `instantiate_callbacks(cfg with _target_)` → list of `ModelCheckpoint`
- [x] `instantiate_callbacks("str")` → raises `TypeError`
- [x] `instantiate_loggers(None/empty)` → `None`; valid cfg → `[CSVLogger]`
- [x] `sequential_scheduler(opt, [partialA, partialB], [500])` → `SequentialLR`
- [x] `get_metric_value({}, None/empty)` → `0`; existing key → float; missing key → raises
- [x] `task_wrapper` re-raises + calls `wandb.finish` via stub
- [x] `worker_balanced_n_samples(10, 4, 2)` → `16`; already-multiple → unchanged
- [x] `balance_data_world_size` → len is multiple of `batch*worldsize`, originals preserved
- [x] All 8 public symbols importable from `radiologist.utils.ml`
- [x] 88 tests pass, mypy clean

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)
