### PR TITLE
feat(utils): add radiologist.utils.ml scaffold — seeding & weight-init helpers

### DIFF
--- a/radiologist-utils/src/radiologist/utils/ml/__init__.py
+++ b/radiologist-utils/src/radiologist/utils/ml/__init__.py
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 from .distributed import balance_data_world_size, worker_balanced_n_samples
 from .hydra_utils import extras, get_metric_value, task_wrapper
 from .instantiators import (
@@ -17,4 +18,36 @@ __all__ = [
     "sequential_scheduler",
     "task_wrapper",
     "worker_balanced_n_samples",
+=======
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from .nn import initialize_weights
+from .seeding import get_seeded_generator, seed_worker, set_seed
+
+__all__ = [
+    "get_seeded_generator",
+    "initialize_weights",
+    "seed_worker",
+    "set_seed",
+>>>>>>> 24a3c85 (feat(utils): add ml submodule with weight init and seeding utilities)
 ]

--- a/radiologist-utils/src/radiologist/utils/ml/__init__.py
+++ b/radiologist-utils/src/radiologist/utils/ml/__init__.py
@@ -1,24 +1,3 @@
-<<<<<<< HEAD
-from .distributed import balance_data_world_size, worker_balanced_n_samples
-from .hydra_utils import extras, get_metric_value, task_wrapper
-from .instantiators import (
-    instantiate_callbacks,
-    instantiate_loggers,
-    sequential_scheduler,
-)
-from .logging_utils import log_hyperparameters
-
-__all__ = [
-    "balance_data_world_size",
-    "extras",
-    "get_metric_value",
-    "instantiate_callbacks",
-    "instantiate_loggers",
-    "log_hyperparameters",
-    "sequential_scheduler",
-    "task_wrapper",
-    "worker_balanced_n_samples",
-=======
 # MIT License
 #
 # Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
@@ -41,13 +20,29 @@ __all__ = [
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from .distributed import balance_data_world_size, worker_balanced_n_samples
+from .hydra_utils import extras, get_metric_value, task_wrapper
+from .instantiators import (
+    instantiate_callbacks,
+    instantiate_loggers,
+    sequential_scheduler,
+)
+from .logging_utils import log_hyperparameters
 from .nn import initialize_weights
 from .seeding import get_seeded_generator, seed_worker, set_seed
 
 __all__ = [
+    "balance_data_world_size",
+    "extras",
+    "get_metric_value",
     "get_seeded_generator",
     "initialize_weights",
+    "instantiate_callbacks",
+    "instantiate_loggers",
+    "log_hyperparameters",
     "seed_worker",
+    "sequential_scheduler",
     "set_seed",
->>>>>>> 24a3c85 (feat(utils): add ml submodule with weight init and seeding utilities)
+    "task_wrapper",
+    "worker_balanced_n_samples",
 ]

--- a/radiologist-utils/src/radiologist/utils/ml/nn.py
+++ b/radiologist-utils/src/radiologist/utils/ml/nn.py
@@ -1,0 +1,81 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Literal
+
+import torch.nn as nn
+
+
+def initialize_weights(
+    module: nn.Module,
+    dist: str,
+    a: float = 0.1,
+    mode: Literal["fan_in", "fan_out"] = "fan_out",
+    nonlinearity: Literal[
+        "linear",
+        "conv1d",
+        "conv2d",
+        "conv3d",
+        "conv_transpose1d",
+        "conv_transpose2d",
+        "conv_transpose3d",
+        "sigmoid",
+        "tanh",
+        "relu",
+        "leaky_relu",
+        "selu",
+    ] = "leaky_relu",
+) -> None:
+    """Xavier-init Linear layers and kaiming-init Conv2d/Conv3d layers.
+
+    Args:
+        module: The network module whose submodules will be initialised.
+        dist: Distribution to use — "normal" or "uniform".
+        a: Negative slope for leaky_relu (kaiming only).
+        mode: Fan mode for kaiming init.
+        nonlinearity: Nonlinearity name for kaiming init.
+
+    Raises:
+        ValueError: If dist is not "normal" or "uniform".
+    """
+    if dist not in ("normal", "uniform"):
+        raise ValueError(f"dist must be 'normal' or 'uniform', got '{dist}'")
+
+    for m in module.modules():
+        if isinstance(m, (nn.Conv2d, nn.Conv3d)):
+            if dist == "normal":
+                nn.init.kaiming_normal_(
+                    m.weight, a=a, mode=mode, nonlinearity=nonlinearity
+                )
+            else:
+                nn.init.kaiming_uniform_(
+                    m.weight, a=a, mode=mode, nonlinearity=nonlinearity
+                )
+            if m.bias is not None:
+                nn.init.zeros_(m.bias)
+        elif isinstance(m, nn.Linear):
+            if dist == "normal":
+                nn.init.xavier_normal_(m.weight)
+            else:
+                nn.init.xavier_uniform_(m.weight)
+            if m.bias is not None:
+                nn.init.zeros_(m.bias)

--- a/radiologist-utils/src/radiologist/utils/ml/seeding.py
+++ b/radiologist-utils/src/radiologist/utils/ml/seeding.py
@@ -1,0 +1,82 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import os
+import random
+from typing import Optional
+
+import numpy as np
+import torch
+
+
+def set_seed(
+    seed: Optional[int] = 4294967295,
+    cudnn_backend: bool = False,
+    use_deterministic_algorithms: bool = False,
+    warn_only: bool = True,
+) -> None:
+    """Seed python/numpy/torch for reproducibility.
+
+    Args:
+        seed: Integer seed. None draws a fresh torch seed.
+        cudnn_backend: Whether to set deterministic cuDNN backend.
+        use_deterministic_algorithms: Whether to enforce deterministic algorithms.
+        warn_only: If True, warn instead of error on non-deterministic ops.
+    """
+    if seed is None:
+        seed = int(torch.seed())
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    os.environ["CUBLAS_WORKSPACE_CONFIG"] = ":4096:8"
+    random.seed(seed)
+    np.random.seed(seed % (2**32))
+    torch.manual_seed(seed)
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+    torch.backends.cudnn.deterministic = cudnn_backend
+    torch.backends.cudnn.benchmark = not cudnn_backend
+    if use_deterministic_algorithms:
+        torch.use_deterministic_algorithms(True, warn_only=warn_only)
+
+
+def seed_worker(worker_id: int) -> None:
+    """Seed numpy and random in a DataLoader worker from torch.initial_seed().
+
+    Args:
+        worker_id: The worker index (provided automatically by DataLoader).
+    """
+    worker_seed = torch.initial_seed() % (2**32)
+    np.random.seed(worker_seed)
+    random.seed(worker_seed)
+
+
+def get_seeded_generator(seed: int) -> torch.Generator:
+    """Return a torch.Generator manually seeded with seed mod 2**32.
+
+    Args:
+        seed: Integer seed value.
+
+    Returns:
+        A seeded torch.Generator.
+    """
+    generator = torch.Generator()
+    generator.manual_seed(seed % (2**32))
+    return generator

--- a/radiologist-utils/tests/test_ml_nn.py
+++ b/radiologist-utils/tests/test_ml_nn.py
@@ -1,0 +1,117 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+import torch
+import torch.nn as nn
+
+from radiologist.utils.ml import initialize_weights
+
+
+class _SmallNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.conv = nn.Conv2d(3, 8, kernel_size=3, padding=1)
+        self.linear = nn.Linear(8, 2)
+
+    def forward(self, x):
+        return x
+
+
+def test_initialize_weights_normal_changes_conv_weights():
+    torch.manual_seed(0)
+    net = _SmallNet()
+    original_conv = net.conv.weight.data.clone()
+    torch.manual_seed(0)
+    initialize_weights(net, dist="normal")
+    assert not torch.equal(net.conv.weight.data, original_conv)
+
+
+def test_initialize_weights_normal_changes_linear_weights():
+    torch.manual_seed(0)
+    net = _SmallNet()
+    original_linear = net.linear.weight.data.clone()
+    torch.manual_seed(0)
+    initialize_weights(net, dist="normal")
+    assert not torch.equal(net.linear.weight.data, original_linear)
+
+
+def test_initialize_weights_uniform_changes_conv_weights():
+    torch.manual_seed(0)
+    net = _SmallNet()
+    original_conv = net.conv.weight.data.clone()
+    torch.manual_seed(0)
+    initialize_weights(net, dist="uniform")
+    assert not torch.equal(net.conv.weight.data, original_conv)
+
+
+def test_initialize_weights_uniform_changes_linear_weights():
+    torch.manual_seed(0)
+    net = _SmallNet()
+    original_linear = net.linear.weight.data.clone()
+    torch.manual_seed(0)
+    initialize_weights(net, dist="uniform")
+    assert not torch.equal(net.linear.weight.data, original_linear)
+
+
+def test_initialize_weights_normal_is_deterministic_given_seed():
+    torch.manual_seed(7)
+    net1 = _SmallNet()
+    initialize_weights(net1, dist="normal")
+
+    torch.manual_seed(7)
+    net2 = _SmallNet()
+    initialize_weights(net2, dist="normal")
+
+    assert torch.equal(net1.conv.weight.data, net2.conv.weight.data)
+    assert torch.equal(net1.linear.weight.data, net2.linear.weight.data)
+
+
+def test_initialize_weights_uniform_is_deterministic_given_seed():
+    torch.manual_seed(7)
+    net1 = _SmallNet()
+    initialize_weights(net1, dist="uniform")
+
+    torch.manual_seed(7)
+    net2 = _SmallNet()
+    initialize_weights(net2, dist="uniform")
+
+    assert torch.equal(net1.conv.weight.data, net2.conv.weight.data)
+    assert torch.equal(net1.linear.weight.data, net2.linear.weight.data)
+
+
+def test_initialize_weights_raises_for_unknown_dist():
+    net = _SmallNet()
+    with pytest.raises(ValueError, match="dist"):
+        initialize_weights(net, dist="invalid")
+
+
+def test_initialize_weights_conv_bias_zeroed():
+    net = _SmallNet()
+    initialize_weights(net, dist="normal")
+    assert torch.all(net.conv.bias.data == 0)
+
+
+def test_initialize_weights_linear_bias_zeroed():
+    net = _SmallNet()
+    initialize_weights(net, dist="normal")
+    assert torch.all(net.linear.bias.data == 0)

--- a/radiologist-utils/tests/test_ml_seeding.py
+++ b/radiologist-utils/tests/test_ml_seeding.py
@@ -1,0 +1,97 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import random
+
+import numpy as np
+import torch
+
+from radiologist.utils.ml import get_seeded_generator, seed_worker, set_seed
+
+
+def test_set_seed_makes_torch_draws_reproducible():
+    set_seed(42)
+    t1 = torch.rand(4).tolist()
+    set_seed(42)
+    t2 = torch.rand(4).tolist()
+    assert t1 == t2
+
+
+def test_set_seed_makes_numpy_draws_reproducible():
+    set_seed(42)
+    a1 = np.random.rand(4).tolist()
+    set_seed(42)
+    a2 = np.random.rand(4).tolist()
+    assert a1 == a2
+
+
+def test_set_seed_makes_random_draws_reproducible():
+    set_seed(42)
+    r1 = [random.random() for _ in range(4)]
+    set_seed(42)
+    r2 = [random.random() for _ in range(4)]
+    assert r1 == r2
+
+
+def test_set_seed_none_draws_fresh_seed_each_call():
+    set_seed(None)
+    s1 = torch.initial_seed()
+    set_seed(None)
+    s2 = torch.initial_seed()
+    assert s1 != s2
+
+
+def test_get_seeded_generator_returns_torch_generator():
+    gen = get_seeded_generator(7)
+    assert isinstance(gen, torch.Generator)
+
+
+def test_get_seeded_generator_produces_deterministic_first_draw():
+    gen1 = get_seeded_generator(7)
+    gen2 = get_seeded_generator(7)
+    t1 = torch.rand(1, generator=gen1).item()
+    t2 = torch.rand(1, generator=gen2).item()
+    assert t1 == t2
+
+
+def test_get_seeded_generator_different_seeds_produce_different_draws():
+    gen_a = get_seeded_generator(7)
+    gen_b = get_seeded_generator(99)
+    t_a = torch.rand(1, generator=gen_a).item()
+    t_b = torch.rand(1, generator=gen_b).item()
+    assert t_a != t_b
+
+
+def test_seed_worker_seeds_numpy_and_random_from_torch_initial_seed():
+    # Simulate what DataLoader does in a worker: set torch seed, call seed_worker.
+    torch.manual_seed(12345)
+    seed_worker(0)
+    np_draw_1 = np.random.rand(4).tolist()
+    rand_draw_1 = [random.random() for _ in range(4)]
+
+    torch.manual_seed(12345)
+    seed_worker(0)
+    np_draw_2 = np.random.rand(4).tolist()
+    rand_draw_2 = [random.random() for _ in range(4)]
+
+    assert np_draw_1 == np_draw_2
+    assert rand_draw_1 == rand_draw_2


### PR DESCRIPTION
## Summary

- Add `radiologist.utils.ml` sub-package with `seeding.py` (`set_seed`, `seed_worker`, `get_seeded_generator`) and `nn.py` (`initialize_weights`)
- Public API re-exported from `ml/__init__.py` with `__all__`
- 17 new tests covering reproducibility, determinism, bias zeroing, and ValueError on bad `dist`

## Test plan

- [x] `uv run --active pytest radiologist-utils/tests/ -q` → 39 passed, 0 failed
- [x] `uv run --active mypy radiologist-utils/src/radiologist/utils/ml/` → clean
- [x] Pre-existing ETL cross-package failures confirmed pre-existing on `main` (8 failures unrelated to this change)

Closes #23
