### PR TITLE
feat(utils): rich config-tree printer and tag enforcement

### DIFF
--- a/radiologist-utils/src/radiologist/utils/ml/__init__.py
+++ b/radiologist-utils/src/radiologist/utils/ml/__init__.py
@@ -1,3 +1,24 @@
+<<<<<<< HEAD
+from .distributed import balance_data_world_size, worker_balanced_n_samples
+from .hydra_utils import extras, get_metric_value, task_wrapper
+from .instantiators import (
+    instantiate_callbacks,
+    instantiate_loggers,
+    sequential_scheduler,
+)
+from .logging_utils import log_hyperparameters
+
+__all__ = [
+    "balance_data_world_size",
+    "extras",
+    "get_metric_value",
+    "instantiate_callbacks",
+    "instantiate_loggers",
+    "log_hyperparameters",
+    "sequential_scheduler",
+    "task_wrapper",
+    "worker_balanced_n_samples",
+=======
 # MIT License
 #
 # Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
@@ -20,29 +41,13 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .distributed import balance_data_world_size, worker_balanced_n_samples
-from .hydra_utils import extras, get_metric_value, task_wrapper
-from .instantiators import (
-    instantiate_callbacks,
-    instantiate_loggers,
-    sequential_scheduler,
-)
-from .logging_utils import log_hyperparameters
 from .nn import initialize_weights
 from .seeding import get_seeded_generator, seed_worker, set_seed
 
 __all__ = [
-    "balance_data_world_size",
-    "extras",
-    "get_metric_value",
     "get_seeded_generator",
     "initialize_weights",
-    "instantiate_callbacks",
-    "instantiate_loggers",
-    "log_hyperparameters",
     "seed_worker",
-    "sequential_scheduler",
     "set_seed",
-    "task_wrapper",
-    "worker_balanced_n_samples",
+>>>>>>> 24a3c85 (feat(utils): add ml submodule with weight init and seeding utilities)
 ]

--- a/radiologist-utils/src/radiologist/utils/ml/__init__.py
+++ b/radiologist-utils/src/radiologist/utils/ml/__init__.py
@@ -1,24 +1,3 @@
-<<<<<<< HEAD
-from .distributed import balance_data_world_size, worker_balanced_n_samples
-from .hydra_utils import extras, get_metric_value, task_wrapper
-from .instantiators import (
-    instantiate_callbacks,
-    instantiate_loggers,
-    sequential_scheduler,
-)
-from .logging_utils import log_hyperparameters
-
-__all__ = [
-    "balance_data_world_size",
-    "extras",
-    "get_metric_value",
-    "instantiate_callbacks",
-    "instantiate_loggers",
-    "log_hyperparameters",
-    "sequential_scheduler",
-    "task_wrapper",
-    "worker_balanced_n_samples",
-=======
 # MIT License
 #
 # Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
@@ -41,13 +20,29 @@ __all__ = [
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+from .distributed import balance_data_world_size, worker_balanced_n_samples
+from .hydra_utils import extras, get_metric_value, task_wrapper
+from .instantiators import (
+    instantiate_callbacks,
+    instantiate_loggers,
+    sequential_scheduler,
+)
+from .logging_utils import log_hyperparameters
 from .nn import initialize_weights
 from .seeding import get_seeded_generator, seed_worker, set_seed
 
 __all__ = [
+    "balance_data_world_size",
+    "extras",
+    "get_metric_value",
     "get_seeded_generator",
     "initialize_weights",
+    "instantiate_callbacks",
+    "instantiate_loggers",
+    "log_hyperparameters",
     "seed_worker",
+    "sequential_scheduler",
     "set_seed",
->>>>>>> 24a3c85 (feat(utils): add ml submodule with weight init and seeding utilities)
+    "task_wrapper",
+    "worker_balanced_n_samples",
 ]

--- a/radiologist-utils/src/radiologist/utils/ml/__init__.py
+++ b/radiologist-utils/src/radiologist/utils/ml/__init__.py
@@ -29,10 +29,12 @@ from .instantiators import (
 )
 from .logging_utils import log_hyperparameters
 from .nn import initialize_weights
+from .rich_utils import enforce_tags, print_config_tree
 from .seeding import get_seeded_generator, seed_worker, set_seed
 
 __all__ = [
     "balance_data_world_size",
+    "enforce_tags",
     "extras",
     "get_metric_value",
     "get_seeded_generator",
@@ -40,6 +42,7 @@ __all__ = [
     "instantiate_callbacks",
     "instantiate_loggers",
     "log_hyperparameters",
+    "print_config_tree",
     "seed_worker",
     "sequential_scheduler",
     "set_seed",

--- a/radiologist-utils/src/radiologist/utils/ml/rich_utils.py
+++ b/radiologist-utils/src/radiologist/utils/ml/rich_utils.py
@@ -1,0 +1,109 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import os
+from typing import Optional, Sequence
+
+import rich
+import rich.syntax
+import rich.tree
+from lightning.fabric.utilities.rank_zero import rank_zero_only
+from omegaconf import DictConfig, OmegaConf
+
+
+@rank_zero_only
+def print_config_tree(
+    cfg: DictConfig,
+    print_order: Sequence[str] = (),
+    resolve: bool = False,
+    save_to_file: bool = False,
+) -> None:
+    """Print a Hydra DictConfig as a rich tree.
+
+    Args:
+        cfg: The Hydra config to print.
+        print_order: Fields to show first; remaining fields appended in natural order.
+        resolve: If True, resolve OmegaConf interpolations before printing.
+        save_to_file: If True, also write to cfg.paths.output_dir/config_tree.log.
+    """
+    style = "dim"
+    tree = rich.tree.Tree("CONFIG", style=style, guide_style=style)
+
+    ordered_keys = list(print_order) + [k for k in cfg if k not in print_order]
+
+    for field in ordered_keys:
+        if field not in cfg:
+            continue
+        branch = tree.add(str(field), style=style, guide_style=style)
+        config_group = cfg[field]
+        if isinstance(config_group, DictConfig):
+            branch_content = OmegaConf.to_yaml(config_group, resolve=resolve)
+        else:
+            branch_content = str(config_group)
+        branch.add(rich.syntax.Syntax(branch_content, "yaml"))
+
+    rich.print(tree)
+
+    if save_to_file:
+        output_dir: Optional[str] = OmegaConf.select(cfg, "paths.output_dir")
+        if output_dir is not None:
+            with open(os.path.join(output_dir, "config_tree.log"), "w") as f:
+                rich.print(tree, file=f)
+
+
+@rank_zero_only
+def enforce_tags(cfg: DictConfig, save_to_file: bool = False) -> None:
+    """Prompt for tags when empty; raise during multirun if tags are missing.
+
+    Args:
+        cfg: The Hydra config.
+        save_to_file: If True, write tags to cfg.paths.output_dir/config_tree.log.
+
+    Raises:
+        ValueError: During a multirun when cfg.tags is empty or None.
+    """
+    tags: Optional[Sequence[str]] = OmegaConf.select(cfg, "tags")
+    has_tags = bool(tags)
+
+    choices: Optional[DictConfig] = OmegaConf.select(cfg, "hydra.runtime.choices")
+    is_multirun = choices is not None and "multirun" in list(choices.values())
+
+    if is_multirun and not has_tags:
+        raise ValueError(
+            "Tags must be provided for multirun experiments. "
+            "Set `tags` in your config to identify this sweep."
+        )
+
+    if not has_tags:
+        rich.print(
+            "[prompt.choices]Enter tags for this experiment "
+            "(comma-separated): [/prompt.choices]",
+            end="",
+        )
+
+    if save_to_file:
+        output_dir: Optional[str] = OmegaConf.select(cfg, "paths.output_dir")
+        if output_dir is not None:
+            with open(os.path.join(output_dir, "config_tree.log"), "a") as f:
+                f.write(f"tags: {list(tags or [])}\n")

--- a/radiologist-utils/tests/test_ml_rich_utils.py
+++ b/radiologist-utils/tests/test_ml_rich_utils.py
@@ -1,0 +1,121 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+
+def _load_rich_utils():
+    src = Path(__file__).parent.parent / "src"
+    spec = importlib.util.spec_from_file_location(
+        "radiologist.utils.ml.rich_utils",
+        src / "radiologist" / "utils" / "ml" / "rich_utils.py",
+    )
+    mod = importlib.util.module_from_spec(spec)  # type: ignore[arg-type]
+    sys.modules["radiologist.utils.ml.rich_utils"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+rich_utils = _load_rich_utils()
+print_config_tree = rich_utils.print_config_tree
+enforce_tags = rich_utils.enforce_tags
+
+
+# ---------------------------------------------------------------------------
+# print_config_tree
+# ---------------------------------------------------------------------------
+
+
+def test_print_config_tree_runs_without_error_on_minimal_cfg() -> None:
+    cfg = OmegaConf.create({"model": {"name": "vgg11"}, "trainer": {"max_epochs": 5}})
+    print_config_tree(cfg)
+
+
+def test_print_config_tree_runs_without_error_when_resolve_is_true() -> None:
+    cfg = OmegaConf.create({"lr": 0.001, "trainer": {"lr": "${lr}"}})
+    print_config_tree(cfg, resolve=True)
+
+
+def test_print_config_tree_respects_print_order() -> None:
+    cfg = OmegaConf.create({"z_last": 1, "a_first": 2})
+    print_config_tree(cfg, print_order=["a_first"])
+
+
+def test_print_config_tree_skips_save_when_output_dir_absent() -> None:
+    cfg = OmegaConf.create({"model": {"name": "vgg11"}})
+    print_config_tree(cfg, save_to_file=True)
+
+
+# ---------------------------------------------------------------------------
+# enforce_tags
+# ---------------------------------------------------------------------------
+
+
+def test_enforce_tags_is_noop_when_tags_present() -> None:
+    cfg = OmegaConf.create(
+        {"tags": ["experiment_1"], "hydra": {"runtime": {"choices": {}}}}
+    )
+    enforce_tags(cfg)
+
+
+def test_enforce_tags_raises_value_error_during_multirun_with_no_tags() -> None:
+    cfg = OmegaConf.create(
+        {
+            "tags": [],
+            "hydra": {"runtime": {"choices": {"hydra/sweeper": "multirun"}}},
+        }
+    )
+    with pytest.raises(ValueError, match="[Tt]ag"):
+        enforce_tags(cfg)
+
+
+def test_enforce_tags_raises_value_error_during_multirun_with_none_tags() -> None:
+    cfg = OmegaConf.create(
+        {
+            "tags": None,
+            "hydra": {"runtime": {"choices": {"hydra/sweeper": "multirun"}}},
+        }
+    )
+    with pytest.raises(ValueError, match="[Tt]ag"):
+        enforce_tags(cfg)
+
+
+def test_enforce_tags_skips_save_when_output_dir_absent() -> None:
+    cfg = OmegaConf.create({"tags": ["exp"], "hydra": {"runtime": {"choices": {}}}})
+    enforce_tags(cfg, save_to_file=True)
+
+
+# ---------------------------------------------------------------------------
+# module API
+# ---------------------------------------------------------------------------
+
+
+def test_module_exposes_print_config_tree_and_enforce_tags() -> None:
+    assert callable(rich_utils.print_config_tree)
+    assert callable(rich_utils.enforce_tags)


### PR DESCRIPTION
Closes #26

Adds `print_config_tree` and `enforce_tags` to `radiologist.utils.ml`.

Co-Authored-By: Claude Code <noreply@anthropic.com>