### PR TITLE
feat(core): registry — pull_checkpoint & promote_to_registry (ONNX + W&B)

### DIFF
--- a/radiologist-core/pyproject.toml
+++ b/radiologist-core/pyproject.toml
@@ -17,6 +17,14 @@ dependencies = [
     "torchmetrics>=1.0.0",
     "hydra-core>=1.3.0",
     "omegaconf>=2.3.0",
+    "onnxscript>=0.1.0",
+]
+
+[project.optional-dependencies]
+registry = [
+    "onnx>=1.14.0",
+    "onnxruntime>=1.18.0,<1.24.0",
+    "wandb>=0.18.0",
 ]
 
 [tool.commitizen]

--- a/radiologist-core/src/radiologist/core/callbacks/__init__.py
+++ b/radiologist-core/src/radiologist/core/callbacks/__init__.py
@@ -1,3 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
 from .attribution import AttributionCallback
 from .best_metric import BestMetricCallback
 from .wandb_summary import WandbDefineSummaryCallback

--- a/radiologist-core/src/radiologist/core/configs/callbacks/attribution.yaml
+++ b/radiologist-core/src/radiologist/core/configs/callbacks/attribution.yaml
@@ -1,0 +1,7 @@
+# @package callbacks
+attribution:
+  _target_: radiologist.core.AttributionCallback
+  target_layer: layer4.1.conv2
+  every_n_val_epochs: 5
+  n_test_batches: 1
+  n_samples_per_batch: 4

--- a/radiologist-core/src/radiologist/core/configs/callbacks/best_metric.yaml
+++ b/radiologist-core/src/radiologist/core/configs/callbacks/best_metric.yaml
@@ -1,0 +1,5 @@
+# @package callbacks
+best_metric:
+  _target_: radiologist.core.BestMetricCallback
+  monitor: val_score
+  mode: max

--- a/radiologist-core/src/radiologist/core/configs/callbacks/default.yaml
+++ b/radiologist-core/src/radiologist/core/configs/callbacks/default.yaml
@@ -1,0 +1,7 @@
+# @package callbacks
+defaults:
+  - best_metric
+  - wandb_summary
+  - attribution
+  - model_checkpoint
+  - lr_monitor

--- a/radiologist-core/src/radiologist/core/configs/callbacks/lr_monitor.yaml
+++ b/radiologist-core/src/radiologist/core/configs/callbacks/lr_monitor.yaml
@@ -1,0 +1,4 @@
+# @package callbacks
+lr_monitor:
+  _target_: lightning.pytorch.callbacks.LearningRateMonitor
+  logging_interval: step

--- a/radiologist-core/src/radiologist/core/configs/callbacks/model_checkpoint.yaml
+++ b/radiologist-core/src/radiologist/core/configs/callbacks/model_checkpoint.yaml
@@ -1,0 +1,16 @@
+# @package callbacks
+model_checkpoint:
+  _target_: lightning.pytorch.callbacks.ModelCheckpoint
+  dirpath: ${paths.output_dir}/checkpoints
+  filename: epoch={epoch}-step={step}
+  monitor: val_score
+  verbose: false
+  save_last: true
+  save_top_k: 1
+  mode: max
+  auto_insert_metric_name: false
+  save_weights_only: false
+  every_n_train_steps: null
+  train_time_interval: null
+  every_n_epochs: null
+  save_on_train_epoch_end: null

--- a/radiologist-core/src/radiologist/core/configs/callbacks/wandb_summary.yaml
+++ b/radiologist-core/src/radiologist/core/configs/callbacks/wandb_summary.yaml
@@ -1,0 +1,5 @@
+# @package callbacks
+wandb_summary:
+  _target_: radiologist.core.WandbDefineSummaryCallback
+  monitor: val_score
+  mode: max

--- a/radiologist-core/src/radiologist/core/configs/datamodule/default.yaml
+++ b/radiologist-core/src/radiologist/core/configs/datamodule/default.yaml
@@ -1,0 +1,40 @@
+# @package _global_
+datamodule:
+  _target_: radiologist.core.WebDatasetDataModule
+  shard_root: ???
+  seed: ${seed}
+  shardshuffle: 100
+  label_map:
+    NORMAL: healthy
+    PNEUMONIA: sick
+    COVID: sick
+  classes: [healthy, sick]
+  class_weights: null
+  priors: null
+  train_transform:
+    _target_: torchvision.transforms.v2.Compose
+    _partial_: false
+    transforms:
+      - {_target_: torchvision.transforms.v2.ToImage}
+      - {_target_: torchvision.transforms.v2.RandomResizedCrop, size: 224}
+      - {_target_: torchvision.transforms.v2.ToDtype, dtype: {_target_: torch.float32, _args_: []}, scale: true}
+  eval_transform:
+    _target_: torchvision.transforms.v2.Compose
+    _partial_: false
+    transforms:
+      - {_target_: torchvision.transforms.v2.ToImage}
+      - {_target_: torchvision.transforms.v2.Resize, size: 256}
+      - {_target_: torchvision.transforms.v2.CenterCrop, size: 224}
+      - {_target_: torchvision.transforms.v2.ToDtype, dtype: {_target_: torch.float32, _args_: []}, scale: true}
+  train_loader:
+    _target_: webdataset.WebLoader
+    _partial_: true
+    batch_size: ???
+    num_workers: 4
+    pin_memory: true
+  eval_loader:
+    _target_: webdataset.WebLoader
+    _partial_: true
+    batch_size: ???
+    num_workers: 4
+    pin_memory: true

--- a/radiologist-core/src/radiologist/core/configs/eval.yaml
+++ b/radiologist-core/src/radiologist/core/configs/eval.yaml
@@ -1,0 +1,24 @@
+# @package _global_
+defaults:
+  - paths
+  - extras
+  - hydra: default
+  - trainer
+  - module: resnet50
+  - module/loss: focal_loss
+  - module/metric: fbeta_score
+  - datamodule: default
+  - strategy: auto
+  - loggers: null
+  - callbacks: default
+  - debug: null
+  - profiler: null
+  - _self_
+
+stage: eval
+ckpt_path: ???
+seed: 42
+tags: null
+train: false
+test: true
+optimized_metric: test_score

--- a/radiologist-core/src/radiologist/core/configs/extras.yaml
+++ b/radiologist-core/src/radiologist/core/configs/extras.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+extras:
+  ignore_warnings: false
+  enforce_tags: true
+  print_config: true

--- a/radiologist-core/src/radiologist/core/configs/hydra/default.yaml
+++ b/radiologist-core/src/radiologist/core/configs/hydra/default.yaml
@@ -1,0 +1,9 @@
+# @package _global_
+hydra:
+  run:
+    dir: outputs/${now:%Y-%m-%d}/${now:%H-%M-%S}
+  sweep:
+    dir: multirun/${now:%Y-%m-%d}/${now:%H-%M-%S}
+    subdir: ${hydra.job.num}
+  job:
+    chdir: true

--- a/radiologist-core/src/radiologist/core/configs/loggers/wandb.yaml
+++ b/radiologist-core/src/radiologist/core/configs/loggers/wandb.yaml
@@ -1,0 +1,16 @@
+# @package _global_
+loggers:
+  wandb:
+    _target_: lightning.pytorch.loggers.WandbLogger
+    _partial_: false
+    project: radiologist
+    name: null
+    save_dir: ${paths.output_dir}
+    offline: false
+    id: null
+    anonymous: null
+    log_model: false
+    prefix: ""
+    group: ""
+    tags: ${tags}
+    job_type: ""

--- a/radiologist-core/src/radiologist/core/configs/module/loss/focal_loss.yaml
+++ b/radiologist-core/src/radiologist/core/configs/module/loss/focal_loss.yaml
@@ -1,0 +1,8 @@
+# @package module
+loss:
+  _target_: radiologist.core.FocalLoss
+  to_onehot_y: false
+  gamma: 2
+  alpha: 1
+  reduction: mean
+  use_softmax: true

--- a/radiologist-core/src/radiologist/core/configs/module/metric/fbeta_score.yaml
+++ b/radiologist-core/src/radiologist/core/configs/module/metric/fbeta_score.yaml
@@ -1,0 +1,16 @@
+# @package module
+metric:
+  _target_: torchmetrics.classification.MulticlassFBetaScore
+  _partial_: true
+  beta: 1.0
+  num_classes: ${datamodule.num_classes}
+  average: macro
+  multidim_average: global
+  top_k: 1
+  ignore_index: null
+  validate_args: true
+  zero_division: 0.0
+  compute_on_cpu: true
+  dist_sync_on_step: false
+  sync_on_compute: true
+  compute_with_cache: true

--- a/radiologist-core/src/radiologist/core/configs/module/optimizer/adamw.yaml
+++ b/radiologist-core/src/radiologist/core/configs/module/optimizer/adamw.yaml
@@ -1,0 +1,8 @@
+# @package module
+optimizer:
+  _target_: torch.optim.AdamW
+  _partial_: true
+  lr: 1e-3
+  weight_decay: 1e-2
+  betas: [0.9, 0.999]
+  eps: 1e-8

--- a/radiologist-core/src/radiologist/core/configs/module/resnet50.yaml
+++ b/radiologist-core/src/radiologist/core/configs/module/resnet50.yaml
@@ -1,0 +1,7 @@
+# @package module
+_target_: radiologist.core.LModule
+net:
+  _target_: torchvision.models.resnet50
+  num_classes: ${datamodule.num_classes}
+trainable_layers: null
+priors: null

--- a/radiologist-core/src/radiologist/core/configs/module/scheduler/sequential.yaml
+++ b/radiologist-core/src/radiologist/core/configs/module/scheduler/sequential.yaml
@@ -1,0 +1,8 @@
+# @package module
+scheduler:
+  _target_: radiologist.utils.ml.sequential_scheduler
+  _partial_: true
+  schedulers:
+    - {_target_: torch.optim.lr_scheduler.LinearLR, _partial_: true, start_factor: 0.1, total_iters: 500}
+    - {_target_: torch.optim.lr_scheduler.CosineAnnealingLR, _partial_: true, T_max: 10000}
+  milestones: [500]

--- a/radiologist-core/src/radiologist/core/configs/paths.yaml
+++ b/radiologist-core/src/radiologist/core/configs/paths.yaml
@@ -1,0 +1,7 @@
+# @package _global_
+paths:
+  root_dir: ${hydra:runtime.cwd}
+  data_dir: ${paths.root_dir}/data/
+  log_dir: ${paths.root_dir}/logs/
+  output_dir: ${hydra:runtime.output_dir}
+  work_dir: ${paths.root_dir}

--- a/radiologist-core/src/radiologist/core/configs/strategy/auto.yaml
+++ b/radiologist-core/src/radiologist/core/configs/strategy/auto.yaml
@@ -1,0 +1,2 @@
+# @package _global_
+strategy: auto

--- a/radiologist-core/src/radiologist/core/configs/train.yaml
+++ b/radiologist-core/src/radiologist/core/configs/train.yaml
@@ -1,0 +1,26 @@
+# @package _global_
+defaults:
+  - paths
+  - extras
+  - hydra: default
+  - trainer
+  - module: resnet50
+  - module/loss: focal_loss
+  - module/scheduler: sequential
+  - module/metric: fbeta_score
+  - module/optimizer: adamw
+  - datamodule: default
+  - strategy: auto
+  - loggers: null
+  - callbacks: default
+  - debug: null
+  - profiler: null
+  - _self_
+
+stage: train
+ckpt_path: null
+seed: 42
+tags: null
+train: true
+test: true
+optimized_metric: best_val_score

--- a/radiologist-core/src/radiologist/core/configs/trainer.yaml
+++ b/radiologist-core/src/radiologist/core/configs/trainer.yaml
@@ -1,0 +1,14 @@
+# @package _global_
+trainer:
+  _target_: lightning.pytorch.trainer.Trainer
+  accelerator: auto
+  devices: auto
+  num_nodes: 1
+  precision: 32-true
+  max_epochs: -1
+  min_epochs: 1
+  gradient_clip_val: 2
+  gradient_clip_algorithm: norm
+  deterministic: true
+  use_distributed_sampler: false
+  default_root_dir: ${paths.output_dir}

--- a/radiologist-core/src/radiologist/core/registry/__init__.py
+++ b/radiologist-core/src/radiologist/core/registry/__init__.py
@@ -20,23 +20,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from .callbacks import (
-    AttributionCallback,
-    BestMetricCallback,
-    WandbDefineSummaryCallback,
-)
-from .data import WebDatasetDataModule
-from .losses import FocalLoss
-from .module import LModule
-from .registry import promote_to_registry, pull_checkpoint
+from .promote import promote_to_registry
+from .pull import pull_checkpoint
 
-__all__ = [
-    "AttributionCallback",
-    "BestMetricCallback",
-    "FocalLoss",
-    "LModule",
-    "WandbDefineSummaryCallback",
-    "WebDatasetDataModule",
-    "pull_checkpoint",
-    "promote_to_registry",
-]
+__all__ = ["pull_checkpoint", "promote_to_registry"]

--- a/radiologist-core/src/radiologist/core/registry/promote.py
+++ b/radiologist-core/src/radiologist/core/registry/promote.py
@@ -1,0 +1,250 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import json
+import os
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn as nn
+
+try:
+    import wandb  # type: ignore[import-untyped]
+except ImportError:
+    wandb = None  # type: ignore[assignment]
+
+try:
+    import onnx  # type: ignore[import-untyped]
+    import onnx.helper as onnx_helper  # type: ignore[import-untyped]
+except ImportError:
+    onnx = None  # type: ignore[assignment]
+    onnx_helper = None  # type: ignore[assignment]
+
+from radiologist.core.module import LModule
+from radiologist.core.registry.pull import pull_checkpoint
+
+
+def _resolve_layer(net: nn.Module, dot_path: str) -> nn.Module:
+    """Resolve a dot-separated attribute path against ``net``.
+
+    Raises:
+        AttributeError: if any segment of the path does not exist.
+    """
+    obj = net
+    for part in dot_path.split("."):
+        try:
+            obj = getattr(obj, part)
+        except AttributeError:
+            raise AttributeError(
+                f"Layer {dot_path!r} not found in net: "
+                f"segment {part!r} missing on {type(obj).__name__}"
+            )
+    return obj  # type: ignore[return-value]
+
+
+class _CamWrapper(nn.Module):
+    """Thin wrapper that returns ``(logits, activation)`` from a forward pass.
+
+    The activation is captured from ``target_layer`` via a forward hook.
+    """
+
+    def __init__(self, net: nn.Module, target_layer: nn.Module) -> None:
+        super().__init__()
+        self.net = net
+        self._activation: Optional[torch.Tensor] = None
+        target_layer.register_forward_hook(self._hook)
+
+    def _hook(
+        self,
+        module: nn.Module,
+        input: Tuple[torch.Tensor, ...],
+        output: torch.Tensor,
+    ) -> None:
+        self._activation = output
+
+    def forward(self, x: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+        logits = self.net(x)
+        if self._activation is None:
+            raise RuntimeError("Forward hook did not capture activation.")
+        return logits, self._activation
+
+
+def _set_metadata_props(model: "onnx.ModelProto", props: dict) -> "onnx.ModelProto":
+    """Write ``props`` dict as ``metadata_props`` on an ONNX model."""
+    del model.metadata_props[:]
+    for k, v in props.items():
+        entry = model.metadata_props.add()
+        entry.key = k
+        entry.value = v
+    return model
+
+
+def promote_to_registry(
+    artifact: str,
+    collection: str,
+    registry_alias: str,
+    input_shape: Tuple[int, ...],
+    classes: List[str],
+    cam_target_layer: str,
+    local_dir: str,
+    opset: int = 17,
+) -> str:
+    """Pull a checkpoint, export two ONNX models, and link them to the W&B registry.
+
+    Args:
+        artifact: W&B artifact reference ``"entity/project/name:alias"``.
+        collection: W&B Model Registry collection name.
+        registry_alias: alias to attach when linking (e.g. ``"latest"``).
+        input_shape: ONNX input shape, e.g. ``(1, 3, 224, 224)``.
+        classes: ordered class names embedded in ONNX metadata.
+        cam_target_layer: dot-path into ``LModule.net`` for CAM activation hook.
+        local_dir: directory for downloaded checkpoint and exported ONNX files.
+        opset: ONNX opset version (default 17, must be ≥ 12 for MCD).
+
+    Returns:
+        Qualified name of the linked artifact in the W&B Model Registry.
+
+    Raises:
+        RuntimeError: if ``wandb`` or ``onnx`` is not installed.
+        AttributeError: if ``cam_target_layer`` cannot be resolved against ``LModule.net``.
+    """
+    if wandb is None:
+        raise RuntimeError(
+            "wandb is required for promote_to_registry. "
+            "Install it with: pip install wandb"
+        )
+    if onnx is None:
+        raise RuntimeError(
+            "onnx is required for promote_to_registry. "
+            "Install it with: pip install onnx"
+        )
+
+    os.makedirs(local_dir, exist_ok=True)
+
+    # --- Pull checkpoint and read run metadata ---------------------------
+    ckpt_path = pull_checkpoint(artifact, local_dir)
+
+    api = wandb.Api()
+    art = api.artifact(artifact)
+    source_run = art.logged_by()
+    run_id: str = source_run.id
+    precision: str = source_run.config["trainer"]["precision"]
+
+    # --- Load LModule from checkpoint ------------------------------------
+    # Lightning checkpoints embed Python objects (e.g. functools.partial) so we
+    # must opt out of the weights_only=True default introduced in PyTorch 2.6.
+    # This is safe because the checkpoint originates from our own W&B artifact.
+    lmodule = LModule.load_from_checkpoint(
+        ckpt_path, map_location="cpu", weights_only=False
+    )
+    net = lmodule.net
+
+    # --- Resolve cam_target_layer (raises AttributeError if missing) -----
+    target_layer = _resolve_layer(net, cam_target_layer)
+
+    # --- Common metadata -------------------------------------------------
+    base_meta = {
+        "precision": precision,
+        "run_id": run_id,
+        "input_shape": json.dumps(list(input_shape)),
+        "classes": json.dumps(classes),
+        "framework": "pytorch-lightning",
+    }
+
+    dummy_input = torch.zeros(*input_shape)
+
+    # =====================================================================
+    # Export 1 — deterministic (dropout folded, cam hook active)
+    # =====================================================================
+    det_path = os.path.join(local_dir, f"model-{run_id}.onnx")
+
+    net.train(mode=False)
+    wrapper = _CamWrapper(net, target_layer)
+    wrapper.train(mode=False)
+
+    torch.onnx.export(
+        wrapper,
+        (dummy_input,),
+        det_path,
+        opset_version=opset,
+        input_names=["input"],
+        output_names=["logits", "feature_maps"],
+        do_constant_folding=True,
+    )
+
+    det_model = onnx.load(det_path)
+    det_meta = dict(base_meta)
+    det_meta["cam_target_layer"] = cam_target_layer
+    det_meta["output_names"] = json.dumps(["logits", "feature_maps"])
+    _set_metadata_props(det_model, det_meta)
+    onnx.save(det_model, det_path)
+
+    # =====================================================================
+    # Export 2 — MC-dropout (Dropout preserved in training mode)
+    # =====================================================================
+    mcd_path = os.path.join(local_dir, f"model-{run_id}-mcd.onnx")
+
+    net.train(mode=False)
+    for m in net.modules():
+        if isinstance(m, nn.Dropout):
+            m.train()
+
+    torch.onnx.export(
+        net,
+        (dummy_input,),
+        mcd_path,
+        opset_version=opset,
+        input_names=["input"],
+        output_names=["logits"],
+        training=torch.onnx.TrainingMode.PRESERVE,
+        do_constant_folding=False,
+    )
+
+    mcd_model = onnx.load(mcd_path)
+    mcd_meta = dict(base_meta)
+    mcd_meta["mc_dropout"] = "true"
+    _set_metadata_props(mcd_model, mcd_meta)
+    onnx.save(mcd_model, mcd_path)
+
+    # =====================================================================
+    # Link both files to W&B Model Registry
+    # =====================================================================
+    with wandb.init(job_type="registry-promote") as run:
+        det_art = wandb.Artifact(
+            name=f"model-{run_id}",
+            type="model",
+        )
+        det_art.link(collection, aliases=[registry_alias])
+        run.log_artifact(det_art)
+
+        mcd_art = wandb.Artifact(
+            name=f"model-{run_id}-mcd",
+            type="model",
+        )
+        mcd_art.link(collection, aliases=[registry_alias])
+        linked = run.log_artifact(mcd_art)
+        linked.wait()
+        qualified_name: str = linked.qualified_name
+
+    return qualified_name

--- a/radiologist-core/src/radiologist/core/registry/promote.py
+++ b/radiologist-core/src/radiologist/core/registry/promote.py
@@ -108,7 +108,7 @@ def promote_to_registry(
     classes: List[str],
     cam_target_layer: str,
     local_dir: str,
-    opset: int = 17,
+    opset: int = 18,
 ) -> str:
     """Pull a checkpoint, export two ONNX models, and link them to the W&B registry.
 
@@ -120,7 +120,7 @@ def promote_to_registry(
         classes: ordered class names embedded in ONNX metadata.
         cam_target_layer: dot-path into ``LModule.net`` for CAM activation hook.
         local_dir: directory for downloaded checkpoint and exported ONNX files.
-        opset: ONNX opset version (default 17, must be ≥ 12 for MCD).
+        opset: ONNX opset version (default 18, must be ≥ 12 for MCD).
 
     Returns:
         Qualified name of the linked artifact in the W&B Model Registry.

--- a/radiologist-core/src/radiologist/core/registry/pull.py
+++ b/radiologist-core/src/radiologist/core/registry/pull.py
@@ -1,0 +1,70 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import glob
+import os
+from typing import Optional
+
+try:
+    import wandb  # type: ignore[import-untyped]
+except ImportError:
+    wandb = None  # type: ignore[assignment]
+
+
+def pull_checkpoint(
+    artifact: str,
+    local_dir: str,
+    storage_options: Optional[dict] = None,
+) -> str:
+    """Download a W&B artifact and return the local .ckpt path.
+
+    Args:
+        artifact: W&B artifact reference ``"entity/project/name:alias"``.
+        local_dir: directory into which the artifact is downloaded.
+        storage_options: unused; reserved for future fsspec pass-through.
+
+    Returns:
+        Absolute path to the downloaded ``.ckpt`` file.
+
+    Raises:
+        RuntimeError: if ``wandb`` is not installed.
+        FileNotFoundError: if the downloaded artifact contains no ``.ckpt`` file.
+    """
+    if wandb is None:
+        raise RuntimeError(
+            "wandb is required to pull checkpoints. "
+            "Install it with: pip install wandb"
+        )
+
+    api = wandb.Api()
+    art = api.artifact(artifact)
+    download_dir = art.download(root=local_dir)
+
+    ckpt_files = glob.glob(os.path.join(download_dir, "**", "*.ckpt"), recursive=True)
+    if not ckpt_files:
+        raise FileNotFoundError(
+            f"No .ckpt file found in artifact downloaded to {download_dir!r}"
+        )
+
+    return ckpt_files[0]

--- a/radiologist-core/src/radiologist/core/train.py
+++ b/radiologist-core/src/radiologist/core/train.py
@@ -1,0 +1,107 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional, Tuple
+
+import hydra
+from omegaconf import DictConfig
+
+from radiologist.utils.ml import (
+    extras,
+    get_metric_value,
+    instantiate_callbacks,
+    instantiate_loggers,
+    log_hyperparameters,
+    set_seed,
+    task_wrapper,
+)
+
+try:
+    from hydra.utils import instantiate
+    from lightning.pytorch import Trainer
+except ImportError:
+    Trainer = object  # type: ignore[assignment,misc]
+    instantiate = None  # type: ignore[assignment]
+
+
+@task_wrapper
+def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
+    """Instantiate all components from cfg and run fit + optional test.
+
+    Args:
+        cfg: Hydra DictConfig with keys train, test, seed, ckpt_path, callbacks,
+            loggers, trainer, module, datamodule.
+
+    Returns:
+        Tuple of (metric_dict, object_dict).
+    """
+    if cfg.get("seed"):
+        set_seed(cfg.seed)
+
+    callbacks = instantiate_callbacks(cfg.get("callbacks"))
+    loggers = instantiate_loggers(cfg.get("loggers"))
+
+    object_dict: Dict[str, Any] = {}
+    metric_dict: Dict[str, Any] = {}
+
+    if cfg.get("train") or cfg.get("test"):
+        datamodule = instantiate(cfg.datamodule)
+        module = instantiate(cfg.module)
+        trainer: Trainer = instantiate(
+            cfg.trainer,
+            callbacks=callbacks,
+            logger=loggers,
+        )
+        object_dict = {
+            "cfg": cfg,
+            "datamodule": datamodule,
+            "module": module,
+            "trainer": trainer,
+        }
+
+        if cfg.get("train"):
+            trainer.fit(
+                model=module, datamodule=datamodule, ckpt_path=cfg.get("ckpt_path")
+            )
+
+        if cfg.get("test"):
+            ckpt_path = (
+                trainer.checkpoint_callback.best_model_path  # type: ignore[union-attr]
+                if cfg.get("train")
+                else cfg.get("ckpt_path")
+            )
+            trainer.test(model=module, datamodule=datamodule, ckpt_path=ckpt_path)
+
+        log_hyperparameters(object_dict)
+        metric_dict = {**trainer.callback_metrics}
+
+    return metric_dict, object_dict
+
+
+@hydra.main(version_base="1.3", config_path="configs", config_name="train")
+def main(cfg: DictConfig) -> Optional[float]:
+    """Hydra entry point: apply extras, run train, return optimized metric."""
+    extras(cfg)
+    metrics, _ = train(cfg)
+    return get_metric_value(metrics, cfg.get("optimized_metric"))

--- a/radiologist-core/tests/test_registry.py
+++ b/radiologist-core/tests/test_registry.py
@@ -1,0 +1,487 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import json
+from functools import partial
+from pathlib import Path
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock, patch
+
+if TYPE_CHECKING:
+    from radiologist.core import LModule
+
+import pytest
+import torch
+import torch.nn as nn
+from torchmetrics.classification import MulticlassFBetaScore
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal net and LModule
+# ---------------------------------------------------------------------------
+
+
+def _make_tiny_net() -> nn.Sequential:
+    """Tiny net with a Dropout so MCD export can find it."""
+    return nn.Sequential(
+        nn.Conv2d(3, 4, 3, padding=1),
+        nn.ReLU(),
+        nn.Dropout(p=0.5),
+        nn.AdaptiveAvgPool2d((1, 1)),
+        nn.Flatten(),
+        nn.Linear(4, 2),
+    )
+
+
+def _make_lmodule(net: nn.Module) -> "LModule":
+    from radiologist.core import FocalLoss, LModule
+
+    return LModule(
+        net=net,
+        loss=FocalLoss(),
+        metric=partial(MulticlassFBetaScore, beta=1.0, num_classes=2),
+        optimizer=partial(torch.optim.Adam, lr=1e-3),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Wandb stub factory
+# ---------------------------------------------------------------------------
+
+
+def _make_fake_wandb_api(tmp_path: Path, run_id: str, precision: str) -> MagicMock:
+    """Return a wandb.Api() mock that serves a fake artifact backed by tmp_path."""
+    artifact_mock = MagicMock()
+    artifact_mock.download.return_value = str(tmp_path)
+
+    source_run = MagicMock()
+    source_run.id = run_id
+    source_run.config = {"trainer": {"precision": precision}}
+    artifact_mock.logged_by.return_value = source_run
+
+    api_mock = MagicMock()
+    api_mock.artifact.return_value = artifact_mock
+    return api_mock
+
+
+def _make_fake_wandb_module(tmp_path: Path, run_id: str, precision: str) -> MagicMock:
+    """Return a wandb module stub usable in patch.dict(sys.modules, ...)."""
+    fake = MagicMock()
+    fake.Api.return_value = _make_fake_wandb_api(tmp_path, run_id, precision)
+
+    linked_artifact = MagicMock()
+    linked_artifact.qualified_name = f"wandb-registry-model/{run_id}:latest"
+
+    artifact_log_mock = MagicMock()
+    artifact_log_mock.qualified_name = f"wandb-registry-model/{run_id}:latest"
+    artifact_log_mock.wait.return_value = None
+
+    run_mock = MagicMock()
+    run_mock.__enter__ = MagicMock(return_value=run_mock)
+    run_mock.__exit__ = MagicMock(return_value=False)
+    run_mock.log_artifact.return_value = artifact_log_mock
+    fake.init.return_value = run_mock
+    fake.Artifact.return_value = artifact_log_mock
+
+    return fake
+
+
+# ---------------------------------------------------------------------------
+# AC: pull_checkpoint — RuntimeError when wandb not installed
+# ---------------------------------------------------------------------------
+
+
+def test_pull_checkpoint_raises_runtime_error_when_wandb_absent():
+    import radiologist.core.registry.pull as pull_mod
+
+    with patch.object(pull_mod, "wandb", None):
+        with pytest.raises(RuntimeError, match="wandb"):
+            pull_mod.pull_checkpoint("entity/project/model:best", "/tmp/ckpt")
+
+
+# ---------------------------------------------------------------------------
+# AC: pull_checkpoint — FileNotFoundError when no .ckpt in artifact dir
+# ---------------------------------------------------------------------------
+
+
+def test_pull_checkpoint_raises_file_not_found_when_no_ckpt(tmp_path):
+    import radiologist.core.registry.pull as pull_mod
+
+    fake_api = MagicMock()
+    artifact_mock = MagicMock()
+    artifact_mock.download.return_value = str(tmp_path)  # empty — no .ckpt
+    fake_api.artifact.return_value = artifact_mock
+    fake_wandb = MagicMock()
+    fake_wandb.Api.return_value = fake_api
+
+    with patch.object(pull_mod, "wandb", fake_wandb):
+        with pytest.raises(FileNotFoundError):
+            pull_mod.pull_checkpoint("entity/project/model:best", str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# AC: pull_checkpoint — returns path when .ckpt exists
+# ---------------------------------------------------------------------------
+
+
+def test_pull_checkpoint_returns_ckpt_path_when_ckpt_exists(tmp_path):
+    import radiologist.core.registry.pull as pull_mod
+
+    ckpt_file = tmp_path / "model.ckpt"
+    ckpt_file.write_text("dummy")
+
+    fake_api = MagicMock()
+    artifact_mock = MagicMock()
+    artifact_mock.download.return_value = str(tmp_path)
+    fake_api.artifact.return_value = artifact_mock
+    fake_wandb = MagicMock()
+    fake_wandb.Api.return_value = fake_api
+
+    with patch.object(pull_mod, "wandb", fake_wandb):
+        result = pull_mod.pull_checkpoint("entity/project/model:best", str(tmp_path))
+
+    assert result == str(ckpt_file)
+
+
+# ---------------------------------------------------------------------------
+# AC: promote_to_registry — RuntimeError when wandb absent
+# ---------------------------------------------------------------------------
+
+
+def test_promote_to_registry_raises_runtime_error_when_wandb_absent():
+    import radiologist.core.registry.promote as promo_mod
+
+    with patch.object(promo_mod, "wandb", None):
+        with pytest.raises(RuntimeError, match="wandb"):
+            promo_mod.promote_to_registry(
+                artifact="entity/project/model:best",
+                collection="my-collection",
+                registry_alias="latest",
+                input_shape=(1, 3, 8, 8),
+                classes=["healthy", "sick"],
+                cam_target_layer="0",
+                local_dir="/tmp",
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC: promote_to_registry — RuntimeError when onnx absent
+# ---------------------------------------------------------------------------
+
+
+def test_promote_to_registry_raises_runtime_error_when_onnx_absent(tmp_path):
+    import radiologist.core.registry.promote as promo_mod
+
+    net = _make_tiny_net()
+    lm = _make_lmodule(net)
+    fake_wandb = _make_fake_wandb_module(tmp_path, "abc123", "16-mixed")
+    ckpt_path = tmp_path / "model.ckpt"
+    ckpt_path.write_text("placeholder")
+
+    with (
+        patch.object(promo_mod, "wandb", fake_wandb),
+        patch.object(promo_mod, "onnx", None),
+        patch.object(promo_mod, "pull_checkpoint", return_value=str(ckpt_path)),
+        patch.object(promo_mod.LModule, "load_from_checkpoint", return_value=lm),
+    ):
+        with pytest.raises(RuntimeError, match="onnx"):
+            promo_mod.promote_to_registry(
+                artifact="entity/project/model:best",
+                collection="my-collection",
+                registry_alias="latest",
+                input_shape=(1, 3, 8, 8),
+                classes=["healthy", "sick"],
+                cam_target_layer="0",
+                local_dir=str(tmp_path),
+            )
+
+
+# ---------------------------------------------------------------------------
+# AC: promote_to_registry — AttributeError for bad cam_target_layer
+# ---------------------------------------------------------------------------
+
+
+def test_promote_to_registry_raises_attribute_error_for_bad_cam_layer(tmp_path):
+    import radiologist.core.registry.promote as promo_mod
+
+    net = _make_tiny_net()
+    lm = _make_lmodule(net)
+    fake_wandb = _make_fake_wandb_module(tmp_path, "abc123", "16-mixed")
+    ckpt_path = tmp_path / "model.ckpt"
+    ckpt_path.write_text("placeholder")
+
+    with (
+        patch.object(promo_mod, "wandb", fake_wandb),
+        patch.object(promo_mod, "pull_checkpoint", return_value=str(ckpt_path)),
+        patch.object(promo_mod.LModule, "load_from_checkpoint", return_value=lm),
+    ):
+        with pytest.raises(AttributeError):
+            promo_mod.promote_to_registry(
+                artifact="entity/project/model:best",
+                collection="my-collection",
+                registry_alias="latest",
+                input_shape=(1, 3, 8, 8),
+                classes=["healthy", "sick"],
+                cam_target_layer="nonexistent.deep.layer",
+                local_dir=str(tmp_path),
+            )
+
+    assert list(tmp_path.glob("*.onnx")) == []
+
+
+# ---------------------------------------------------------------------------
+# Fixture: promote_result — both ONNX files on disk
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def promote_result(tmp_path):
+    """Run promote_to_registry with full stubs; return (local_dir, run_id, result)."""
+    import radiologist.core.registry.promote as promo_mod
+
+    net = _make_tiny_net()
+    lm = _make_lmodule(net)
+    run_id = "abc123"
+    precision = "16-mixed"
+    fake_wandb = _make_fake_wandb_module(tmp_path, run_id, precision)
+    ckpt_path = tmp_path / "model.ckpt"
+    ckpt_path.write_text("placeholder")
+
+    with (
+        patch.object(promo_mod, "wandb", fake_wandb),
+        patch.object(promo_mod, "pull_checkpoint", return_value=str(ckpt_path)),
+        patch.object(promo_mod.LModule, "load_from_checkpoint", return_value=lm),
+    ):
+        result = promo_mod.promote_to_registry(
+            artifact="entity/project/model:best",
+            collection="my-collection",
+            registry_alias="latest",
+            input_shape=(1, 3, 8, 8),
+            classes=["healthy", "sick"],
+            cam_target_layer="2",  # Sequential index — Dropout layer
+            local_dir=str(tmp_path),
+        )
+
+    return tmp_path, run_id, result
+
+
+# ---------------------------------------------------------------------------
+# AC: both ONNX files created
+# ---------------------------------------------------------------------------
+
+
+def test_promote_creates_deterministic_and_mcd_onnx_files(promote_result):
+    local_dir, run_id, _ = promote_result
+    assert (local_dir / f"model-{run_id}.onnx").exists()
+    assert (local_dir / f"model-{run_id}-mcd.onnx").exists()
+
+
+# ---------------------------------------------------------------------------
+# AC: deterministic ONNX metadata_props
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_onnx_has_required_metadata_keys(promote_result):
+    import onnx
+
+    local_dir, run_id, _ = promote_result
+    model = onnx.load(str(local_dir / f"model-{run_id}.onnx"))
+    props = {p.key: p.value for p in model.metadata_props}
+
+    for key in ("precision", "run_id", "input_shape", "classes", "framework"):
+        assert key in props, f"Missing metadata key: {key}"
+
+    assert "cam_target_layer" in props
+    output_names = json.loads(props["output_names"])
+    assert "logits" in output_names
+    assert "feature_maps" in output_names
+
+
+# ---------------------------------------------------------------------------
+# AC: MCD ONNX metadata_props
+# ---------------------------------------------------------------------------
+
+
+def test_mcd_onnx_has_required_metadata_keys_and_mc_dropout_true(promote_result):
+    import onnx
+
+    local_dir, run_id, _ = promote_result
+    model = onnx.load(str(local_dir / f"model-{run_id}-mcd.onnx"))
+    props = {p.key: p.value for p in model.metadata_props}
+
+    for key in ("precision", "run_id", "input_shape", "classes", "framework"):
+        assert key in props, f"Missing metadata key: {key}"
+
+    assert props.get("mc_dropout") == "true"
+
+
+# ---------------------------------------------------------------------------
+# AC: precision comes from W&B run config
+# ---------------------------------------------------------------------------
+
+
+def test_precision_metadata_comes_from_wandb_run_config(tmp_path):
+    import onnx
+
+    import radiologist.core.registry.promote as promo_mod
+
+    net = _make_tiny_net()
+    lm = _make_lmodule(net)
+    custom_precision = "bf16-mixed"
+    run_id = "xyz789"
+    fake_wandb = _make_fake_wandb_module(tmp_path, run_id, custom_precision)
+    ckpt_path = tmp_path / "model.ckpt"
+    ckpt_path.write_text("placeholder")
+
+    with (
+        patch.object(promo_mod, "wandb", fake_wandb),
+        patch.object(promo_mod, "pull_checkpoint", return_value=str(ckpt_path)),
+        patch.object(promo_mod.LModule, "load_from_checkpoint", return_value=lm),
+    ):
+        promo_mod.promote_to_registry(
+            artifact="entity/project/model:best",
+            collection="my-collection",
+            registry_alias="latest",
+            input_shape=(1, 3, 8, 8),
+            classes=["healthy", "sick"],
+            cam_target_layer="2",
+            local_dir=str(tmp_path),
+        )
+
+    model = onnx.load(str(tmp_path / f"model-{run_id}.onnx"))
+    props = {p.key: p.value for p in model.metadata_props}
+    assert props["precision"] == custom_precision
+
+
+# ---------------------------------------------------------------------------
+# AC: deterministic ONNX is deterministic
+# ---------------------------------------------------------------------------
+
+
+def test_deterministic_onnx_gives_identical_outputs_on_two_runs(promote_result):
+    import numpy as np
+    import onnxruntime as ort
+
+    local_dir, run_id, _ = promote_result
+    sess = ort.InferenceSession(str(local_dir / f"model-{run_id}.onnx"))
+    inp = np.random.randn(1, 3, 8, 8).astype(np.float32)
+    out1 = sess.run(None, {sess.get_inputs()[0].name: inp})
+    out2 = sess.run(None, {sess.get_inputs()[0].name: inp})
+    np.testing.assert_array_equal(out1[0], out2[0])
+
+
+# ---------------------------------------------------------------------------
+# AC: MCD ONNX retains Dropout nodes
+# ---------------------------------------------------------------------------
+
+
+def test_mcd_onnx_retains_dropout_nodes(promote_result):
+    import onnx
+
+    local_dir, run_id, _ = promote_result
+    model = onnx.load(str(local_dir / f"model-{run_id}-mcd.onnx"))
+    dropout_nodes = [n for n in model.graph.node if n.op_type == "Dropout"]
+    assert len(dropout_nodes) > 0, "Expected at least one Dropout node in MCD ONNX"
+
+
+# ---------------------------------------------------------------------------
+# AC: MCD ONNX is stochastic
+# ---------------------------------------------------------------------------
+
+
+def test_mcd_onnx_gives_different_outputs_on_two_runs(promote_result):
+    import numpy as np
+    import onnxruntime as ort
+
+    local_dir, run_id, _ = promote_result
+    so = ort.SessionOptions()
+    so.graph_optimization_level = ort.GraphOptimizationLevel.ORT_DISABLE_ALL
+    sess = ort.InferenceSession(
+        str(local_dir / f"model-{run_id}-mcd.onnx"),
+        sess_options=so,
+    )
+    inp = np.random.randn(1, 3, 8, 8).astype(np.float32)
+
+    outputs = [sess.run(None, {sess.get_inputs()[0].name: inp})[0] for _ in range(10)]
+    all_same = all(np.array_equal(outputs[0], o) for o in outputs[1:])
+    assert not all_same, "MCD ONNX should be stochastic but all outputs were identical"
+
+
+# ---------------------------------------------------------------------------
+# AC: idempotent — re-running overwrites files
+# ---------------------------------------------------------------------------
+
+
+def test_promote_is_idempotent_overwrites_existing_files(tmp_path):
+    import radiologist.core.registry.promote as promo_mod
+
+    net = _make_tiny_net()
+    lm = _make_lmodule(net)
+    run_id = "abc123"
+    ckpt_path = tmp_path / "model.ckpt"
+    ckpt_path.write_text("placeholder")
+
+    kwargs = dict(
+        artifact="entity/project/model:best",
+        collection="my-collection",
+        registry_alias="latest",
+        input_shape=(1, 3, 8, 8),
+        classes=["healthy", "sick"],
+        cam_target_layer="2",
+        local_dir=str(tmp_path),
+    )
+
+    for _ in range(2):
+        fake_wandb = _make_fake_wandb_module(tmp_path, run_id, "16-mixed")
+        with (
+            patch.object(promo_mod, "wandb", fake_wandb),
+            patch.object(promo_mod, "pull_checkpoint", return_value=str(ckpt_path)),
+            patch.object(promo_mod.LModule, "load_from_checkpoint", return_value=lm),
+        ):
+            promo_mod.promote_to_registry(**kwargs)
+
+    assert (tmp_path / f"model-{run_id}.onnx").exists()
+    assert (tmp_path / f"model-{run_id}-mcd.onnx").exists()
+
+
+# ---------------------------------------------------------------------------
+# AC: promote returns linked qualified name
+# ---------------------------------------------------------------------------
+
+
+def test_promote_returns_qualified_name(promote_result):
+    _, run_id, result = promote_result
+    assert isinstance(result, str)
+    assert len(result) > 0
+
+
+# ---------------------------------------------------------------------------
+# AC: public API importable from radiologist.core
+# ---------------------------------------------------------------------------
+
+
+def test_pull_checkpoint_and_promote_importable_from_core():
+    from radiologist.core import promote_to_registry, pull_checkpoint
+
+    assert callable(pull_checkpoint)
+    assert callable(promote_to_registry)

--- a/radiologist-core/tests/test_train.py
+++ b/radiologist-core/tests/test_train.py
@@ -1,0 +1,183 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel, @TaxelleT, @Yeyecodes
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import sys
+from pathlib import Path
+
+import pytest
+from omegaconf import DictConfig, OmegaConf
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+
+
+@pytest.fixture()
+def minimal_cfg() -> DictConfig:
+    """Minimal DictConfig that disables all heavy operations."""
+    return OmegaConf.create(
+        {
+            "train": False,
+            "test": False,
+            "seed": 42,
+            "ckpt_path": None,
+            "optimized_metric": None,
+            "extras": {
+                "ignore_warnings": False,
+                "enforce_tags": False,
+                "print_config": False,
+            },
+        }
+    )
+
+
+def test_train_returns_tuple_of_two_dicts_when_train_and_test_disabled(
+    minimal_cfg: DictConfig,
+) -> None:
+    from radiologist.core.train import train
+
+    result = train(minimal_cfg)
+
+    assert isinstance(result, tuple), "train() must return a tuple"
+    assert len(result) == 2, "train() must return a tuple of length 2"
+    metrics, obj_dict = result
+    assert isinstance(metrics, dict), "first element must be a dict of metrics"
+    assert isinstance(obj_dict, dict), "second element must be a dict of objects"
+
+
+def test_train_reraises_exception_via_task_wrapper(minimal_cfg: DictConfig) -> None:
+    """Exceptions raised inside train() propagate after task_wrapper finalises wandb."""
+    from radiologist.core.train import train
+
+    bad_cfg = OmegaConf.create(
+        {
+            "train": True,
+            "test": False,
+            "seed": 42,
+            "ckpt_path": None,
+            "optimized_metric": None,
+            "extras": {
+                "ignore_warnings": False,
+                "enforce_tags": False,
+                "print_config": False,
+            },
+            "callbacks": None,
+            "loggers": None,
+            "trainer": {"_target_": "this.does.not.Exist"},
+            "module": {"_target_": "this.does.not.Exist"},
+            "datamodule": {"_target_": "this.does.not.Exist"},
+        }
+    )
+
+    with pytest.raises(Exception):
+        train(bad_cfg)
+
+
+def test_train_public_api_symbols_importable() -> None:
+    """All Phase 1-3 public symbols resolve from radiologist.core."""
+    from radiologist.core import (  # noqa: F401
+        AttributionCallback,
+        BestMetricCallback,
+        FocalLoss,
+        LModule,
+        WandbDefineSummaryCallback,
+        WebDatasetDataModule,
+    )
+
+
+def test_train_module_importable() -> None:
+    """train and main are importable from radiologist.core.train."""
+    from radiologist.core.train import main, train  # noqa: F401
+
+    assert callable(train)
+    assert callable(main)
+
+
+def test_configs_train_yaml_exists() -> None:
+    """configs/train.yaml exists under radiologist.core package."""
+    configs_dir = (
+        Path(__file__).parent.parent / "src" / "radiologist" / "core" / "configs"
+    )
+    assert (configs_dir / "train.yaml").exists(), "configs/train.yaml must exist"
+
+
+def test_configs_eval_yaml_exists() -> None:
+    """configs/eval.yaml exists under radiologist.core package."""
+    configs_dir = (
+        Path(__file__).parent.parent / "src" / "radiologist" / "core" / "configs"
+    )
+    assert (configs_dir / "eval.yaml").exists(), "configs/eval.yaml must exist"
+
+
+def test_configs_trainer_yaml_has_use_distributed_sampler_false() -> None:
+    """configs/trainer.yaml sets use_distributed_sampler: false (required for WebDataset DDP)."""
+    configs_dir = (
+        Path(__file__).parent.parent / "src" / "radiologist" / "core" / "configs"
+    )
+    cfg = OmegaConf.load(configs_dir / "trainer.yaml")
+    assert cfg.trainer.use_distributed_sampler == False  # noqa: E712
+
+
+def test_configs_callbacks_default_yaml_wires_all_five_callbacks() -> None:
+    """callbacks/default.yaml lists all five required callbacks."""
+    configs_dir = (
+        Path(__file__).parent.parent / "src" / "radiologist" / "core" / "configs"
+    )
+    with open(configs_dir / "callbacks" / "default.yaml") as f:
+        content = f.read()
+
+    required = [
+        "best_metric",
+        "wandb_summary",
+        "attribution",
+        "model_checkpoint",
+        "lr_monitor",
+    ]
+    for name in required:
+        assert name in content, f"callbacks/default.yaml must reference '{name}'"
+
+
+def test_configs_datamodule_num_classes_interpolation_resolves() -> None:
+    """${datamodule.num_classes} is a valid interpolation reference in module configs."""
+    configs_dir = (
+        Path(__file__).parent.parent / "src" / "radiologist" / "core" / "configs"
+    )
+    with open(configs_dir / "module" / "resnet50.yaml") as f:
+        content = f.read()
+    assert "${datamodule.num_classes}" in content
+
+
+def test_configs_train_yaml_has_correct_optimized_metric() -> None:
+    """train.yaml root config has optimized_metric: best_val_score."""
+    configs_dir = (
+        Path(__file__).parent.parent / "src" / "radiologist" / "core" / "configs"
+    )
+    cfg = OmegaConf.load(configs_dir / "train.yaml")
+    assert cfg.optimized_metric == "best_val_score"
+
+
+def test_configs_eval_yaml_has_train_false_test_true() -> None:
+    """eval.yaml sets train: false and test: true (eval-only mode)."""
+    configs_dir = (
+        Path(__file__).parent.parent / "src" / "radiologist" / "core" / "configs"
+    )
+    cfg = OmegaConf.load(configs_dir / "eval.yaml")
+    assert cfg.train == False  # noqa: E712
+    assert cfg.test == True  # noqa: E712

--- a/uv.lock
+++ b/uv.lock
@@ -2,22 +2,38 @@ version = 1
 revision = 3
 requires-python = ">=3.10"
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.11'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.11' and platform_machine != 's390x'",
+    "python_full_version < '3.11' and platform_machine == 's390x'",
 ]
 
 [manifest]
@@ -711,6 +727,18 @@ wheels = [
 ]
 
 [[package]]
+name = "coloredlogs"
+version = "15.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "humanfriendly" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/c7/eed8f27100517e8c0e6b923d5f0845d0cb99763da6fdee00478f91db7325/coloredlogs-15.0.1.tar.gz", hash = "sha256:7c991aa71a4577af2f82600d8f8f3a89f936baeaf9b50a9c197da014e5bf16b0", size = 278520, upload-time = "2021-06-11T10:22:45.202Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/06/3d6badcf13db419e25b07041d9c7b4a2c331d3f4e7134445ec5df57714cd/coloredlogs-15.0.1-py2.py3-none-any.whl", hash = "sha256:612ee75c546f53e92e70049c9dbfcc18c935a2b9a53b66085ce9ef6a6e5c0934", size = 46018, upload-time = "2021-06-11T10:22:42.561Z" },
+]
+
+[[package]]
 name = "coolname"
 version = "5.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1100,6 +1128,14 @@ wheels = [
 ]
 
 [[package]]
+name = "flatbuffers"
+version = "25.12.19"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e8/2d/d2a548598be01649e2d46231d151a6c56d10b964d94043a335ae56ea2d92/flatbuffers-25.12.19-py2.py3-none-any.whl", hash = "sha256:7634f50c427838bb021c2d66a3d1168e9d199b0607e6329399f04846d42e20b4", size = 26661, upload-time = "2025-12-19T23:16:13.622Z" },
+]
+
+[[package]]
 name = "frozenlist"
 version = "1.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1251,6 +1287,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/0bd3f6796422cfed6be1949c44668b386400f231d63ab30aefa6165baf0f/gcsfs-2026.4.0.tar.gz", hash = "sha256:f3d80dd1c98737798bc84472e6ff9c59873bd17a26e170d46ce90b3118db4390", size = 1139035, upload-time = "2026-04-29T21:04:11.64Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/37/3922951a55a3d0f0340e884929087ce08e333cbb16a86002535c095960fc/gcsfs-2026.4.0-py3-none-any.whl", hash = "sha256:d9e838834d8cce6cb623c6a6a5fad66a4d122dc5c609d4b1c1977b55f759dcc5", size = 72190, upload-time = "2026-04-29T21:04:09.997Z" },
+]
+
+[[package]]
+name = "gitdb"
+version = "4.0.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "smmap" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/63b0fc47eb32792c7ba1fe1b694daec9a63620db1e313033d18140c2320a/gitdb-4.0.12.tar.gz", hash = "sha256:5ef71f855d191a3326fcfbc0d5da835f26b13fbcba60c32c21091c349ffdb571", size = 394684, upload-time = "2025-01-02T07:20:46.413Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/61/5c78b91c3143ed5c14207f463aecfc8f9dbb5092fb2869baf37c273b2705/gitdb-4.0.12-py3-none-any.whl", hash = "sha256:67073e15955400952c6565cc3e707c554a4eea2e428946f7a4c162fab9bd9bcf", size = 62794, upload-time = "2025-01-02T07:20:43.624Z" },
+]
+
+[[package]]
+name = "gitpython"
+version = "3.1.50"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "gitdb" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/33/f6/354ae6491228b5eb40e10d89c4d13c651fe1cf7556e35ebdded50cff57ce/gitpython-3.1.50.tar.gz", hash = "sha256:80da2d12504d52e1f998772dc5baf6e553f8d2fcfe1fcc226c9d9a2ee3372dcc", size = 219798, upload-time = "2026-05-06T04:01:26.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/20/7a/1c6e3562dfd8950adbb11ffbc65d21e7c89d01a6e4f137fa981056de25c5/gitpython-3.1.50-py3-none-any.whl", hash = "sha256:d352abe2908d07355014abdd21ddf798c2a961469239afec4962e9da884858f9", size = 212507, upload-time = "2026-05-06T04:01:23.799Z" },
 ]
 
 [[package]]
@@ -1696,6 +1756,18 @@ http2 = [
 ]
 
 [[package]]
+name = "humanfriendly"
+version = "10.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pyreadline3", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/3f/2c29224acb2e2df4d2046e4c73ee2662023c58ff5b113c4c1adac0886c43/humanfriendly-10.0.tar.gz", hash = "sha256:6b0b831ce8f15f7300721aa49829fc4e83921a9a301cc7f606be6686a2288ddc", size = 360702, upload-time = "2021-09-17T21:40:43.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f0/0f/310fb31e39e2d734ccaa2c0fb981ee41f7bd5056ce9bc29b2248bd569169/humanfriendly-10.0-py2.py3-none-any.whl", hash = "sha256:1697e1a8a8f550fd43c2865cd84542fc175a61dcb779b6fee18cf6b6ccba1477", size = 86794, upload-time = "2021-09-17T21:40:39.897Z" },
+]
+
+[[package]]
 name = "humanize"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2118,6 +2190,52 @@ wheels = [
 ]
 
 [[package]]
+name = "ml-dtypes"
+version = "0.5.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/4a/c27b42ed9b1c7d13d9ba8b6905dece787d6259152f2309338aed29b2447b/ml_dtypes-0.5.4.tar.gz", hash = "sha256:8ab06a50fb9bf9666dd0fe5dfb4676fa2b0ac0f31ecff72a6c3af8e22c063453", size = 692314, upload-time = "2025-11-17T22:32:31.031Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fe/3a/c5b855752a70267ff729c349e650263adb3c206c29d28cc8ea7ace30a1d5/ml_dtypes-0.5.4-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:b95e97e470fe60ed493fd9ae3911d8da4ebac16bd21f87ffa2b7c588bf22ea2c", size = 679735, upload-time = "2025-11-17T22:31:31.367Z" },
+    { url = "https://files.pythonhosted.org/packages/41/79/7433f30ee04bd4faa303844048f55e1eb939131c8e5195a00a96a0939b64/ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b4b801ebe0b477be666696bda493a9be8356f1f0057a57f1e35cd26928823e5a", size = 5051883, upload-time = "2025-11-17T22:31:33.658Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b1/8938e8830b0ee2e167fc75a094dea766a1152bde46752cd9bfc57ee78a82/ml_dtypes-0.5.4-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:388d399a2152dd79a3f0456a952284a99ee5c93d3e2f8dfe25977511e0515270", size = 5030369, upload-time = "2025-11-17T22:31:35.595Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/a3/51886727bd16e2f47587997b802dd56398692ce8c6c03c2e5bb32ecafe26/ml_dtypes-0.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:4ff7f3e7ca2972e7de850e7b8fcbb355304271e2933dd90814c1cb847414d6e2", size = 210738, upload-time = "2025-11-17T22:31:37.43Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/5e/712092cfe7e5eb667b8ad9ca7c54442f21ed7ca8979745f1000e24cf8737/ml_dtypes-0.5.4-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:6c7ecb74c4bd71db68a6bea1edf8da8c34f3d9fe218f038814fd1d310ac76c90", size = 679734, upload-time = "2025-11-17T22:31:39.223Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/cf/912146dfd4b5c0eea956836c01dcd2fce6c9c844b2691f5152aca196ce4f/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bc11d7e8c44a65115d05e2ab9989d1e045125d7be8e05a071a48bc76eb6d6040", size = 5056165, upload-time = "2025-11-17T22:31:41.071Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/80/19189ea605017473660e43762dc853d2797984b3c7bf30ce656099add30c/ml_dtypes-0.5.4-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b9a53598f21e453ea2fbda8aa783c20faff8e1eeb0d7ab899309a0053f1483", size = 5034975, upload-time = "2025-11-17T22:31:42.758Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/24/70bd59276883fdd91600ca20040b41efd4902a923283c4d6edcb1de128d2/ml_dtypes-0.5.4-cp311-cp311-win_amd64.whl", hash = "sha256:7c23c54a00ae43edf48d44066a7ec31e05fdc2eee0be2b8b50dd1903a1db94bb", size = 210742, upload-time = "2025-11-17T22:31:44.068Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/c9/64230ef14e40aa3f1cb254ef623bf812735e6bec7772848d19131111ac0d/ml_dtypes-0.5.4-cp311-cp311-win_arm64.whl", hash = "sha256:557a31a390b7e9439056644cb80ed0735a6e3e3bb09d67fd5687e4b04238d1de", size = 160709, upload-time = "2025-11-17T22:31:46.557Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/b8/3c70881695e056f8a32f8b941126cf78775d9a4d7feba8abcb52cb7b04f2/ml_dtypes-0.5.4-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:a174837a64f5b16cab6f368171a1a03a27936b31699d167684073ff1c4237dac", size = 676927, upload-time = "2025-11-17T22:31:48.182Z" },
+    { url = "https://files.pythonhosted.org/packages/54/0f/428ef6881782e5ebb7eca459689448c0394fa0a80bea3aa9262cba5445ea/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a7f7c643e8b1320fd958bf098aa7ecf70623a42ec5154e3be3be673f4c34d900", size = 5028464, upload-time = "2025-11-17T22:31:50.135Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/cb/28ce52eb94390dda42599c98ea0204d74799e4d8047a0eb559b6fd648056/ml_dtypes-0.5.4-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9ad459e99793fa6e13bd5b7e6792c8f9190b4e5a1b45c63aba14a4d0a7f1d5ff", size = 5009002, upload-time = "2025-11-17T22:31:52.001Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/f0/0cfadd537c5470378b1b32bd859cf2824972174b51b873c9d95cfd7475a5/ml_dtypes-0.5.4-cp312-cp312-win_amd64.whl", hash = "sha256:c1a953995cccb9e25a4ae19e34316671e4e2edaebe4cf538229b1fc7109087b7", size = 212222, upload-time = "2025-11-17T22:31:53.742Z" },
+    { url = "https://files.pythonhosted.org/packages/16/2e/9acc86985bfad8f2c2d30291b27cd2bb4c74cea08695bd540906ed744249/ml_dtypes-0.5.4-cp312-cp312-win_arm64.whl", hash = "sha256:9bad06436568442575beb2d03389aa7456c690a5b05892c471215bfd8cf39460", size = 160793, upload-time = "2025-11-17T22:31:55.358Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/a1/4008f14bbc616cfb1ac5b39ea485f9c63031c4634ab3f4cf72e7541f816a/ml_dtypes-0.5.4-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:8c760d85a2f82e2bed75867079188c9d18dae2ee77c25a54d60e9cc79be1bc48", size = 676888, upload-time = "2025-11-17T22:31:56.907Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/b7/dff378afc2b0d5a7d6cd9d3209b60474d9819d1189d347521e1688a60a53/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ce756d3a10d0c4067172804c9cc276ba9cc0ff47af9078ad439b075d1abdc29b", size = 5036993, upload-time = "2025-11-17T22:31:58.497Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/33/40cd74219417e78b97c47802037cf2d87b91973e18bb968a7da48a96ea44/ml_dtypes-0.5.4-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:533ce891ba774eabf607172254f2e7260ba5f57bdd64030c9a4fcfbd99815d0d", size = 5010956, upload-time = "2025-11-17T22:31:59.931Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/8b/200088c6859d8221454825959df35b5244fa9bdf263fd0249ac5fb75e281/ml_dtypes-0.5.4-cp313-cp313-win_amd64.whl", hash = "sha256:f21c9219ef48ca5ee78402d5cc831bd58ea27ce89beda894428bc67a52da5328", size = 212224, upload-time = "2025-11-17T22:32:01.349Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/dfc3775cb36367816e678f69a7843f6f03bd4e2bcd79941e01ea960a068e/ml_dtypes-0.5.4-cp313-cp313-win_arm64.whl", hash = "sha256:35f29491a3e478407f7047b8a4834e4640a77d2737e0b294d049746507af5175", size = 160798, upload-time = "2025-11-17T22:32:02.864Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/74/e9ddb35fd1dd43b1106c20ced3f53c2e8e7fc7598c15638e9f80677f81d4/ml_dtypes-0.5.4-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:304ad47faa395415b9ccbcc06a0350800bc50eda70f0e45326796e27c62f18b6", size = 702083, upload-time = "2025-11-17T22:32:04.08Z" },
+    { url = "https://files.pythonhosted.org/packages/74/f5/667060b0aed1aa63166b22897fdf16dca9eb704e6b4bbf86848d5a181aa7/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6a0df4223b514d799b8a1629c65ddc351b3efa833ccf7f8ea0cf654a61d1e35d", size = 5354111, upload-time = "2025-11-17T22:32:05.546Z" },
+    { url = "https://files.pythonhosted.org/packages/40/49/0f8c498a28c0efa5f5c95a9e374c83ec1385ca41d0e85e7cf40e5d519a21/ml_dtypes-0.5.4-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:531eff30e4d368cb6255bc2328d070e35836aa4f282a0fb5f3a0cd7260257298", size = 5366453, upload-time = "2025-11-17T22:32:07.115Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/27/12607423d0a9c6bbbcc780ad19f1f6baa2b68b18ce4bddcdc122c4c68dc9/ml_dtypes-0.5.4-cp313-cp313t-win_amd64.whl", hash = "sha256:cb73dccfc991691c444acc8c0012bee8f2470da826a92e3a20bb333b1a7894e6", size = 225612, upload-time = "2025-11-17T22:32:08.615Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/80/5a5929e92c72936d5b19872c5fb8fc09327c1da67b3b68c6a13139e77e20/ml_dtypes-0.5.4-cp313-cp313t-win_arm64.whl", hash = "sha256:3bbbe120b915090d9dd1375e4684dd17a20a2491ef25d640a908281da85e73f1", size = 164145, upload-time = "2025-11-17T22:32:09.782Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/1339dc6e2557a344f5ba5590872e80346f76f6cb2ac3dd16e4666e88818c/ml_dtypes-0.5.4-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:2b857d3af6ac0d39db1de7c706e69c7f9791627209c3d6dedbfca8c7e5faec22", size = 673781, upload-time = "2025-11-17T22:32:11.364Z" },
+    { url = "https://files.pythonhosted.org/packages/04/f9/067b84365c7e83bda15bba2b06c6ca250ce27b20630b1128c435fb7a09aa/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:805cef3a38f4eafae3a5bf9ebdcdb741d0bcfd9e1bd90eb54abd24f928cd2465", size = 5036145, upload-time = "2025-11-17T22:32:12.783Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/bb/82c7dcf38070b46172a517e2334e665c5bf374a262f99a283ea454bece7c/ml_dtypes-0.5.4-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:14a4fd3228af936461db66faccef6e4f41c1d82fcc30e9f8d58a08916b1d811f", size = 5010230, upload-time = "2025-11-17T22:32:14.38Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/93/2bfed22d2498c468f6bcd0d9f56b033eaa19f33320389314c19ef6766413/ml_dtypes-0.5.4-cp314-cp314-win_amd64.whl", hash = "sha256:8c6a2dcebd6f3903e05d51960a8058d6e131fe69f952a5397e5dbabc841b6d56", size = 221032, upload-time = "2025-11-17T22:32:15.763Z" },
+    { url = "https://files.pythonhosted.org/packages/76/a3/9c912fe6ea747bb10fe2f8f54d027eb265db05dfb0c6335e3e063e74e6e8/ml_dtypes-0.5.4-cp314-cp314-win_arm64.whl", hash = "sha256:5a0f68ca8fd8d16583dfa7793973feb86f2fbb56ce3966daf9c9f748f52a2049", size = 163353, upload-time = "2025-11-17T22:32:16.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/02/48aa7d84cc30ab4ee37624a2fd98c56c02326785750cd212bc0826c2f15b/ml_dtypes-0.5.4-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:bfc534409c5d4b0bf945af29e5d0ab075eae9eecbb549ff8a29280db822f34f9", size = 702085, upload-time = "2025-11-17T22:32:18.175Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/e7/85cb99fe80a7a5513253ec7faa88a65306be071163485e9a626fce1b6e84/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2314892cdc3fcf05e373d76d72aaa15fda9fb98625effa73c1d646f331fcecb7", size = 5355358, upload-time = "2025-11-17T22:32:19.7Z" },
+    { url = "https://files.pythonhosted.org/packages/79/2b/a826ba18d2179a56e144aef69e57fb2ab7c464ef0b2111940ee8a3a223a2/ml_dtypes-0.5.4-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0d2ffd05a2575b1519dc928c0b93c06339eb67173ff53acb00724502cda231cf", size = 5366332, upload-time = "2025-11-17T22:32:21.193Z" },
+    { url = "https://files.pythonhosted.org/packages/84/44/f4d18446eacb20ea11e82f133ea8f86e2bf2891785b67d9da8d0ab0ef525/ml_dtypes-0.5.4-cp314-cp314t-win_amd64.whl", hash = "sha256:4381fe2f2452a2d7589689693d3162e876b3ddb0a832cde7a414f8e1adf7eab1", size = 236612, upload-time = "2025-11-17T22:32:22.579Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/3f/3d42e9a78fe5edf792a83c074b13b9b770092a4fbf3462872f4303135f09/ml_dtypes-0.5.4-cp314-cp314t-win_arm64.whl", hash = "sha256:11942cbf2cf92157db91e5022633c0d9474d4dfd813a909383bd23ce828a4b7d", size = 168825, upload-time = "2025-11-17T22:32:23.766Z" },
+]
+
+[[package]]
 name = "mpmath"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2337,7 +2455,8 @@ name = "networkx"
 version = "3.4.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and platform_machine != 's390x'",
+    "python_full_version < '3.11' and platform_machine == 's390x'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/fd/1d/06475e1cd5264c0b870ea2cc6fdb3e37177c1e565c43f56ff17a10e3937f/networkx-3.4.2.tar.gz", hash = "sha256:307c3669428c5362aab27c8a1260aa8f47c4e91d3891f48be0141738d8d053e1", size = 2151368, upload-time = "2024-10-21T12:39:38.695Z" }
 wheels = [
@@ -2349,21 +2468,36 @@ name = "networkx"
 version = "3.6.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/6a/51/63fe664f3908c97be9d2e4f1158eb633317598cfa6e1fc14af5383f17512/networkx-3.6.1.tar.gz", hash = "sha256:26b7c357accc0c8cde558ad486283728b65b6a95d85ee1cd66bafab4c8168509", size = 2517025, upload-time = "2025-12-08T17:02:39.908Z" }
 wheels = [
@@ -2384,7 +2518,8 @@ name = "numpy"
 version = "2.2.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and platform_machine != 's390x'",
+    "python_full_version < '3.11' and platform_machine == 's390x'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d043ee156a356c0a8f0c6309dff6b21b4d71a073b8a8/numpy-2.2.6.tar.gz", hash = "sha256:e29554e2bef54a90aa5cc07da6ce955accb83f21ab5de01a62c8478897b264fd", size = 20276440, upload-time = "2025-05-17T22:38:04.611Z" }
 wheels = [
@@ -2449,21 +2584,36 @@ name = "numpy"
 version = "2.4.6"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
 wheels = [
@@ -2715,6 +2865,121 @@ wheels = [
 ]
 
 [[package]]
+name = "onnx"
+version = "1.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c5/93/942d2a0f6a70538eea042ce0445c8aefd46559ad153469986f29a743c01c/onnx-1.21.0.tar.gz", hash = "sha256:4d8b67d0aaec5864c87633188b91cc520877477ec0254eda122bef8be43cd764", size = 12074608, upload-time = "2026-03-27T21:33:36.118Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a8/28/a14b1845bf9302c3a787221e8f37cde4e7f930e10d95a8e22dd910aeb41d/onnx-1.21.0-cp310-cp310-macosx_12_0_universal2.whl", hash = "sha256:e0c21cc5c7a41d1a509828e2b14fe9c30e807c6df611ec0fd64a47b8d4b16abd", size = 17966899, upload-time = "2026-03-27T21:32:15.53Z" },
+    { url = "https://files.pythonhosted.org/packages/41/7b/788881bf022a4cfb7b0843782f88415ea51c805cee4a909dcf2e49bb8129/onnx-1.21.0-cp310-cp310-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e1931bfcc222a4c9da6475f2ffffb84b97ab3876041ec639171c11ce802bee6a", size = 17534297, upload-time = "2026-03-27T21:32:18.343Z" },
+    { url = "https://files.pythonhosted.org/packages/16/51/eb64d4f2ec6caa98909aab5fbcfa24be9c059081e804bbb0012cc549ef89/onnx-1.21.0-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c9b56ad04039fac6b028c07e54afa1ec7f75dd340f65311f2c292e41ed7aa4d9", size = 17616697, upload-time = "2026-03-27T21:32:21Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/4e/6b1f7800dae3407dc850e7e59d591ed8c83e9b3401e4cd57a1f612e400c6/onnx-1.21.0-cp310-cp310-win32.whl", hash = "sha256:3abd09872523c7e0362d767e4e63bd7c6bac52a5e2c3edbf061061fe540e2027", size = 16288893, upload-time = "2026-03-27T21:32:23.864Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/a8/89273e581d3943e20314af19b1596ab4d763f9c2eb07d4eaf4fb0593219b/onnx-1.21.0-cp310-cp310-win_amd64.whl", hash = "sha256:f2c7c234c568402e10db74e33d787e4144e394ae2bcbbf11000fbfe2e017ad68", size = 16443416, upload-time = "2026-03-27T21:32:26.655Z" },
+    { url = "https://files.pythonhosted.org/packages/45/48/32e383aa6bc40b72a9fd419937aaa647078190c9bfccdc97b316d2dee687/onnx-1.21.0-cp311-cp311-macosx_12_0_universal2.whl", hash = "sha256:2aca19949260875c14866fc77ea0bc37e4e809b24976108762843d328c92d3ce", size = 17968053, upload-time = "2026-03-27T21:32:29.558Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/26/5726e8df7d36e96bb3c679912d1a86af42f393d77aa17d6b98a97d4289ce/onnx-1.21.0-cp311-cp311-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:82aa6ab51144df07c58c4850cb78d4f1ae969d8c0bf657b28041796d49ba6974", size = 17534821, upload-time = "2026-03-27T21:32:32.351Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/2b/021dcd2dd50c3c71b7959d7368526da384a295c162fb4863f36057973f78/onnx-1.21.0-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10c3185a232089335581fabb98fba4e86d3e8246b8140f2e406082438100ebda", size = 17616664, upload-time = "2026-03-27T21:32:34.921Z" },
+    { url = "https://files.pythonhosted.org/packages/12/00/afa32a46fa122a7ed42df1cfe8796922156a3725ba8fc581c4779c96e2fc/onnx-1.21.0-cp311-cp311-win32.whl", hash = "sha256:f53b3c15a3b539c16b99655c43c365622046d68c49b680c48eba4da2a4fb6f27", size = 16289035, upload-time = "2026-03-27T21:32:37.783Z" },
+    { url = "https://files.pythonhosted.org/packages/73/8d/483cc980a24d4c0131d0af06d0ff6a37fb08ae90a7848ece8cef645194f1/onnx-1.21.0-cp311-cp311-win_amd64.whl", hash = "sha256:5f78c411743db317a76e5d009f84f7e3d5380411a1567a868e82461a1e5c775d", size = 16443748, upload-time = "2026-03-27T21:32:40.337Z" },
+    { url = "https://files.pythonhosted.org/packages/38/78/9d06fd5aaaed1ec9cb8a3b70fbbf00c1bdc18db610771e96379f0ed58112/onnx-1.21.0-cp311-cp311-win_arm64.whl", hash = "sha256:ab6a488dabbb172eebc9f3b3e7ac68763f32b0c571626d4a5004608f866cc83d", size = 16406123, upload-time = "2026-03-27T21:32:45.159Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ae/cb644ec84c25e63575d9d8790fdcc5d1a11d67d3f62f872edb35fa38d158/onnx-1.21.0-cp312-abi3-macosx_12_0_universal2.whl", hash = "sha256:fc2635400fe39ff37ebc4e75342cc54450eadadf39c540ff132c319bf4960095", size = 17965930, upload-time = "2026-03-27T21:32:48.089Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/b6/eeb5903586645ef8a49b4b7892580438741acc3df91d7a5bd0f3a59ea9cb/onnx-1.21.0-cp312-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9003d5206c01fa2ff4b46311566865d8e493e1a6998d4009ec6de39843f1b59b", size = 17531344, upload-time = "2026-03-27T21:32:50.837Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/00/4823f06357892d1e60d6f34e7299d2ba4ed2108c487cc394f7ce85a3ff14/onnx-1.21.0-cp312-abi3-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9261bd580fb8548c9c37b3c6750387eb8f21ea43c63880d37b2c622e1684285", size = 17613697, upload-time = "2026-03-27T21:32:54.222Z" },
+    { url = "https://files.pythonhosted.org/packages/23/1d/391f3c567ae068c8ac4f1d1316bae97c9eb45e702f05975fe0e17ad441f0/onnx-1.21.0-cp312-abi3-win32.whl", hash = "sha256:9ea4e824964082811938a9250451d89c4ec474fe42dd36c038bfa5df31993d1e", size = 16287200, upload-time = "2026-03-27T21:32:57.277Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/a6/5eefbe5b40ea96de95a766bd2e0e751f35bdea2d4b951991ec9afaa69531/onnx-1.21.0-cp312-abi3-win_amd64.whl", hash = "sha256:458d91948ad9a7729a347550553b49ab6939f9af2cddf334e2116e45467dc61f", size = 16441045, upload-time = "2026-03-27T21:33:00.081Z" },
+    { url = "https://files.pythonhosted.org/packages/63/c4/0ed8dc037a39113d2a4d66e0005e07751c299c46b993f1ad5c2c35664c20/onnx-1.21.0-cp312-abi3-win_arm64.whl", hash = "sha256:ca14bc4842fccc3187eb538f07eabeb25a779b39388b006db4356c07403a7bbb", size = 16403134, upload-time = "2026-03-27T21:33:03.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/89/0e1a9beb536401e2f45ac88735e123f2735e12fc7b56ff6c11727e097526/onnx-1.21.0-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:257d1d1deb6a652913698f1e3f33ef1ca0aa69174892fe38946d4572d89dd94f", size = 17975430, upload-time = "2026-03-27T21:33:07.005Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/46/e6dc71a7b3b317265591b20a5f71d0ff5c0d26c24e52283139dc90c66038/onnx-1.21.0-cp313-cp313t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:7cd7cb8f6459311bdb557cbf6c0ccc6d8ace11c304d1bba0a30b4a4688e245f8", size = 17537435, upload-time = "2026-03-27T21:33:09.765Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2e/27affcac63eaf2ef183a44fd1a1354b11da64a6c72fe6f3fdcf5571bcee5/onnx-1.21.0-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b58a4cfec8d9311b73dc083e4c1fa362069267881144c05139b3eba5dc3a840", size = 17617687, upload-time = "2026-03-27T21:33:12.619Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5c/ac8ed15e941593a3672ce424280b764979026317811f2e8508432bfc3429/onnx-1.21.0-cp313-cp313t-win_amd64.whl", hash = "sha256:1a9baf882562c4cebf79589bebb7cd71a20e30b51158cac3e3bbaf27da6163bd", size = 16449402, upload-time = "2026-03-27T21:33:15.555Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/aa/d2231e0dcaad838217afc64c306c8152a080134d2034e247cc973d577674/onnx-1.21.0-cp313-cp313t-win_arm64.whl", hash = "sha256:bba12181566acf49b35875838eba49536a327b2944664b17125577d230c637ad", size = 16408273, upload-time = "2026-03-27T21:33:18.599Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/0a/8905b14694def6ad23edf1011fdd581500384062f8c4c567e114be7aa272/onnx-1.21.0-cp314-cp314t-macosx_12_0_universal2.whl", hash = "sha256:7ee9d8fd6a4874a5fa8b44bbcabea104ce752b20469b88bc50c7dcf9030779ad", size = 17975331, upload-time = "2026-03-27T21:33:21.69Z" },
+    { url = "https://files.pythonhosted.org/packages/61/28/f4e401e5199d1b9c8b76c7e7ae1169e050515258e877b58fa8bb49d3bdcc/onnx-1.21.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5489f25fe461e7f32128218251a466cabbeeaf1eaa791c79daebf1a80d5a2cc9", size = 17537430, upload-time = "2026-03-27T21:33:24.547Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/cf/5d13320eb3660d5af360ea3b43aa9c63a70c92a9b4d1ea0d34501a32fcb8/onnx-1.21.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:db17fc0fec46180b6acbd1d5d8650a04e5527c02b09381da0b5b888d02a204c8", size = 17617662, upload-time = "2026-03-27T21:33:27.418Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/50/3eaa1878338247be021e6423696813d61e77e534dccbd15a703a144e703d/onnx-1.21.0-cp314-cp314t-win_amd64.whl", hash = "sha256:19d9971a3e52a12968ae6c70fd0f86c349536de0b0c33922ecdbe52d1972fe60", size = 16463688, upload-time = "2026-03-27T21:33:30.229Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/48/38d46b43bbb525e0b6a4c2c4204cc6795d67e45687a2f7403e06d8e7053d/onnx-1.21.0-cp314-cp314t-win_arm64.whl", hash = "sha256:efba467efb316baf2a9452d892c2f982b9b758c778d23e38c7f44fa211b30bb9", size = 16423387, upload-time = "2026-03-27T21:33:33.446Z" },
+]
+
+[[package]]
+name = "onnx-ir"
+version = "0.2.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "onnx" },
+    { name = "sympy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/35/e6/672fefb2f108d077f58181a7babf4c0f8d1182a30353ffc9c79c63afc5ee/onnx_ir-0.2.1.tar.gz", hash = "sha256:8b8b10a93f43e65962104de6070c43c5dacb0e3cdfefc7c8059dd83c9db64f35", size = 144279, upload-time = "2026-04-20T20:21:47.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8c/aa/f7a53321c60b9ad9ee184b6018292ed6b5389947592a2c8c09c736bb7f9e/onnx_ir-0.2.1-py3-none-any.whl", hash = "sha256:c7285da889312f91882de2092e298a9eeeefbfc1d1951c49d983992967eb09a7", size = 166792, upload-time = "2026-04-20T20:21:46.357Z" },
+]
+
+[[package]]
+name = "onnxruntime"
+version = "1.23.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coloredlogs" },
+    { name = "flatbuffers" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "packaging" },
+    { name = "protobuf" },
+    { name = "sympy" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/35/d6/311b1afea060015b56c742f3531168c1644650767f27ef40062569960587/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_arm64.whl", hash = "sha256:a7730122afe186a784660f6ec5807138bf9d792fa1df76556b27307ea9ebcbe3", size = 17195934, upload-time = "2025-10-27T23:06:14.143Z" },
+    { url = "https://files.pythonhosted.org/packages/db/db/81bf3d7cecfbfed9092b6b4052e857a769d62ed90561b410014e0aae18db/onnxruntime-1.23.2-cp310-cp310-macosx_13_0_x86_64.whl", hash = "sha256:b28740f4ecef1738ea8f807461dd541b8287d5650b5be33bca7b474e3cbd1f36", size = 19153079, upload-time = "2025-10-27T23:05:57.686Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4d/a382452b17cf70a2313153c520ea4c96ab670c996cb3a95cc5d5ac7bfdac/onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f7d1fe034090a1e371b7f3ca9d3ccae2fabae8c1d8844fb7371d1ea38e8e8d2", size = 15219883, upload-time = "2025-10-22T03:46:21.66Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/56/179bf90679984c85b417664c26aae4f427cba7514bd2d65c43b181b7b08b/onnxruntime-1.23.2-cp310-cp310-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4ca88747e708e5c67337b0f65eed4b7d0dd70d22ac332038c9fc4635760018f7", size = 17370357, upload-time = "2025-10-22T03:46:57.968Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6d/738e50c47c2fd285b1e6c8083f15dac1a5f6199213378a5f14092497296d/onnxruntime-1.23.2-cp310-cp310-win_amd64.whl", hash = "sha256:0be6a37a45e6719db5120e9986fcd30ea205ac8103fd1fb74b6c33348327a0cc", size = 13467651, upload-time = "2025-10-27T23:06:11.904Z" },
+    { url = "https://files.pythonhosted.org/packages/44/be/467b00f09061572f022ffd17e49e49e5a7a789056bad95b54dfd3bee73ff/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_arm64.whl", hash = "sha256:6f91d2c9b0965e86827a5ba01531d5b669770b01775b23199565d6c1f136616c", size = 17196113, upload-time = "2025-10-22T03:47:33.526Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/a8/3c23a8f75f93122d2b3410bfb74d06d0f8da4ac663185f91866b03f7da1b/onnxruntime-1.23.2-cp311-cp311-macosx_13_0_x86_64.whl", hash = "sha256:87d8b6eaf0fbeb6835a60a4265fde7a3b60157cf1b2764773ac47237b4d48612", size = 19153857, upload-time = "2025-10-22T03:46:37.578Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/d8/506eed9af03d86f8db4880a4c47cd0dffee973ef7e4f4cff9f1d4bcf7d22/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bbfd2fca76c855317568c1b36a885ddea2272c13cb0e395002c402f2360429a6", size = 15220095, upload-time = "2025-10-22T03:46:24.769Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/80/113381ba832d5e777accedc6cb41d10f9eca82321ae31ebb6bcede530cea/onnxruntime-1.23.2-cp311-cp311-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:da44b99206e77734c5819aa2142c69e64f3b46edc3bd314f6a45a932defc0b3e", size = 17372080, upload-time = "2025-10-22T03:47:00.265Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/db/1b4a62e23183a0c3fe441782462c0ede9a2a65c6bbffb9582fab7c7a0d38/onnxruntime-1.23.2-cp311-cp311-win_amd64.whl", hash = "sha256:902c756d8b633ce0dedd889b7c08459433fbcf35e9c38d1c03ddc020f0648c6e", size = 13468349, upload-time = "2025-10-22T03:47:25.783Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9e/f748cd64161213adeef83d0cb16cb8ace1e62fa501033acdd9f9341fff57/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_arm64.whl", hash = "sha256:b8f029a6b98d3cf5be564d52802bb50a8489ab73409fa9db0bf583eabb7c2321", size = 17195929, upload-time = "2025-10-22T03:47:36.24Z" },
+    { url = "https://files.pythonhosted.org/packages/91/9d/a81aafd899b900101988ead7fb14974c8a58695338ab6a0f3d6b0100f30b/onnxruntime-1.23.2-cp312-cp312-macosx_13_0_x86_64.whl", hash = "sha256:218295a8acae83905f6f1aed8cacb8e3eb3bd7513a13fe4ba3b2664a19fc4a6b", size = 19157705, upload-time = "2025-10-22T03:46:40.415Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/4e40f2fba272a6698d62be2cd21ddc3675edfc1a4b9ddefcc4648f115315/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:76ff670550dc23e58ea9bc53b5149b99a44e63b34b524f7b8547469aaa0dcb8c", size = 15226915, upload-time = "2025-10-22T03:46:27.773Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/88/9cc25d2bafe6bc0d4d3c1db3ade98196d5b355c0b273e6a5dc09c5d5d0d5/onnxruntime-1.23.2-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f9b4ae77f8e3c9bee50c27bc1beede83f786fe1d52e99ac85aa8d65a01e9b77", size = 17382649, upload-time = "2025-10-22T03:47:02.782Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/b4/569d298f9fc4d286c11c45e85d9ffa9e877af12ace98af8cab52396e8f46/onnxruntime-1.23.2-cp312-cp312-win_amd64.whl", hash = "sha256:25de5214923ce941a3523739d34a520aac30f21e631de53bba9174dc9c004435", size = 13470528, upload-time = "2025-10-22T03:47:28.106Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/41/fba0cabccecefe4a1b5fc8020c44febb334637f133acefc7ec492029dd2c/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_arm64.whl", hash = "sha256:2ff531ad8496281b4297f32b83b01cdd719617e2351ffe0dba5684fb283afa1f", size = 17196337, upload-time = "2025-10-22T03:46:35.168Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/f9/2d49ca491c6a986acce9f1d1d5fc2099108958cc1710c28e89a032c9cfe9/onnxruntime-1.23.2-cp313-cp313-macosx_13_0_x86_64.whl", hash = "sha256:162f4ca894ec3de1a6fd53589e511e06ecdc3ff646849b62a9da7489dee9ce95", size = 19157691, upload-time = "2025-10-22T03:46:43.518Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/a1/428ee29c6eaf09a6f6be56f836213f104618fb35ac6cc586ff0f477263eb/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45d127d6e1e9b99d1ebeae9bcd8f98617a812f53f46699eafeb976275744826b", size = 15226898, upload-time = "2025-10-22T03:46:30.039Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/2b/b57c8a2466a3126dbe0a792f56ad7290949b02f47b86216cd47d857e4b77/onnxruntime-1.23.2-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8bace4e0d46480fbeeb7bbe1ffe1f080e6663a42d1086ff95c1551f2d39e7872", size = 17382518, upload-time = "2025-10-22T03:47:05.407Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/93/aba75358133b3a941d736816dd392f687e7eab77215a6e429879080b76b6/onnxruntime-1.23.2-cp313-cp313-win_amd64.whl", hash = "sha256:1f9cc0a55349c584f083c1c076e611a7c35d5b867d5d6e6d6c823bf821978088", size = 13470276, upload-time = "2025-10-22T03:47:31.193Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/3d/6830fa61c69ca8e905f237001dbfc01689a4e4ab06147020a4518318881f/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9d2385e774f46ac38f02b3a91a91e30263d41b2f1f4f26ae34805b2a9ddef466", size = 15229610, upload-time = "2025-10-22T03:46:32.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/ca/862b1e7a639460f0ca25fd5b6135fb42cf9deea86d398a92e44dfda2279d/onnxruntime-1.23.2-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2b9233c4947907fd1818d0e581c049c41ccc39b2856cc942ff6d26317cee145", size = 17394184, upload-time = "2025-10-22T03:47:08.127Z" },
+]
+
+[[package]]
+name = "onnxscript"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
+    { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
+    { name = "onnx" },
+    { name = "onnx-ir" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/99/fd948eba63ba65b52265a4cd09a14f96bb9f5b730fcef58876c4358bf406/onnxscript-0.7.0.tar.gz", hash = "sha256:c95ed7b339b02cface56ee27689565c46612e1fc542c562298dddfdad5268dc5", size = 612032, upload-time = "2026-04-20T17:09:19.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/ce/2ed92575cc3be4ea1db5f38f16f20765f9b20b69b14d6c1d9972658a8ee9/onnxscript-0.7.0-py3-none-any.whl", hash = "sha256:5b356907d4501e9919f8599c91d8da967406a37b1fac2b40caa55a49acf242ea", size = 714842, upload-time = "2026-04-20T17:09:22.089Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.42.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2821,7 +3086,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and platform_machine != 's390x'",
+    "python_full_version < '3.11' and platform_machine == 's390x'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -2885,21 +3151,36 @@ name = "pandas"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -3718,6 +3999,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pyreadline3"
+version = "3.5.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b6/6d/f94028646d7bbe6d9d873c47ee7c246f2d29129d253f0d96cb6fcab70733/pyreadline3-3.5.6.tar.gz", hash = "sha256:61e53218b99656091ddb077df9e71f25850e72e030b6183b39c9b7e6e4f4a9bf", size = 100368, upload-time = "2026-05-14T17:55:04.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/5e/35c856e186b74678c24927847ad9895a51f1bc02a0c6126477a6c6040064/pyreadline3-3.5.6-py3-none-any.whl", hash = "sha256:8449b734232e42a5dcd74048e39b60db2839a4c38cf3ae2bf7707d58b5389c0d", size = 85243, upload-time = "2026-05-14T17:55:03.262Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -4024,6 +4314,7 @@ dependencies = [
     { name = "hydra-core" },
     { name = "lightning" },
     { name = "omegaconf" },
+    { name = "onnxscript" },
     { name = "radiologist-utils" },
     { name = "torch" },
     { name = "torchmetrics" },
@@ -4031,17 +4322,29 @@ dependencies = [
     { name = "webdataset" },
 ]
 
+[package.optional-dependencies]
+registry = [
+    { name = "onnx" },
+    { name = "onnxruntime" },
+    { name = "wandb" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "hydra-core", specifier = ">=1.3.0" },
     { name = "lightning", specifier = ">=2.0.0" },
     { name = "omegaconf", specifier = ">=2.3.0" },
+    { name = "onnx", marker = "extra == 'registry'", specifier = ">=1.14.0" },
+    { name = "onnxruntime", marker = "extra == 'registry'", specifier = ">=1.18.0,<1.24.0" },
+    { name = "onnxscript", specifier = ">=0.1.0" },
     { name = "radiologist-utils", editable = "radiologist-utils" },
     { name = "torch", specifier = ">=2.0.0" },
     { name = "torchmetrics", specifier = ">=1.0.0" },
     { name = "torchvision", specifier = ">=0.15.0" },
+    { name = "wandb", marker = "extra == 'registry'", specifier = ">=0.18.0" },
     { name = "webdataset", specifier = ">=0.2.86" },
 ]
+provides-extras = ["registry"]
 
 [[package]]
 name = "radiologist-etl"
@@ -4331,7 +4634,8 @@ name = "rpds-py"
 version = "0.30.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and platform_machine != 's390x'",
+    "python_full_version < '3.11' and platform_machine == 's390x'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
 wheels = [
@@ -4456,21 +4760,36 @@ name = "rpds-py"
 version = "2026.5.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/2e/43/25a8dcd3feedd735039a8f0b5b7e3b118232b5eae288c4fd9ab200d41094/rpds_py-2026.5.1.tar.gz", hash = "sha256:07b24fea40541e28570e5b795a4a38fbdcd12550c06bd0748005ecc8116ca256", size = 64459, upload-time = "2026-05-28T12:02:13.232Z" }
 wheels = [
@@ -4677,7 +4996,8 @@ name = "scikit-image"
 version = "0.25.2"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and platform_machine != 's390x'",
+    "python_full_version < '3.11' and platform_machine == 's390x'",
 ]
 dependencies = [
     { name = "imageio", marker = "python_full_version < '3.11'" },
@@ -4719,21 +5039,36 @@ name = "scikit-image"
 version = "0.26.0"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "imageio", marker = "python_full_version >= '3.11'" },
@@ -4803,7 +5138,8 @@ name = "scipy"
 version = "1.15.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and platform_machine != 's390x'",
+    "python_full_version < '3.11' and platform_machine == 's390x'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -4862,21 +5198,36 @@ name = "scipy"
 version = "1.17.1"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.11'" },
@@ -4955,6 +5306,19 @@ wheels = [
 ]
 
 [[package]]
+name = "sentry-sdk"
+version = "2.61.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/63/3b/4bc6b348bbd331daa14d4babe9f2b99bc854f4da41560eefb9488d78481d/sentry_sdk-2.61.1.tar.gz", hash = "sha256:9c6adccb3feefa9ba032c8d295ca477575c2f11896046a2b0ad686c47c4af555", size = 459429, upload-time = "2026-06-01T07:24:18.875Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/54/c9218db183846e08efaf68534889ef42e499dde432778881104a42f7071b/sentry_sdk-2.61.1-py3-none-any.whl", hash = "sha256:fa36eaf4b8ad708f718500d4bdcc1532637526a22beb874d88cbc0a46458b5ae", size = 483735, upload-time = "2026-06-01T07:24:17.027Z" },
+]
+
+[[package]]
 name = "setuptools"
 version = "81.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4979,6 +5343,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "smmap"
+version = "5.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
 ]
 
 [[package]]
@@ -5102,7 +5475,8 @@ name = "tifffile"
 version = "2025.5.10"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version < '3.11'",
+    "python_full_version < '3.11' and platform_machine != 's390x'",
+    "python_full_version < '3.11' and platform_machine == 's390x'",
 ]
 dependencies = [
     { name = "numpy", version = "2.2.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.11'" },
@@ -5117,9 +5491,12 @@ name = "tifffile"
 version = "2026.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version == '3.11.*' and sys_platform == 'win32'",
-    "python_full_version == '3.11.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.11.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.11.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.11.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version == '3.11.*'" },
@@ -5134,18 +5511,30 @@ name = "tifffile"
 version = "2026.5.15"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.15' and sys_platform == 'win32'",
-    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
-    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'win32'",
-    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'win32'",
-    "python_full_version == '3.13.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.13.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'win32'",
-    "python_full_version == '3.12.*' and sys_platform == 'emscripten'",
-    "python_full_version == '3.12.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.15' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.13.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.13.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'win32'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform == 'emscripten'",
+    "python_full_version == '3.12.*' and platform_machine != 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.12.*' and platform_machine == 's390x' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 dependencies = [
     { name = "numpy", version = "2.4.6", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
@@ -5464,6 +5853,35 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/15/ba/1f6e8c957e4932be060dcdc482d339c12e0216351478add3645cdaa53c05/virtualenv-21.3.3.tar.gz", hash = "sha256:f5bda277e553b1c2b3c1a8debfc30496e1288cc93ce6b7b71b3280047e317328", size = 7613784, upload-time = "2026-05-13T18:01:30.19Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/34/a9dbe051de88a63eb7408ea66630bac38e72f7f6077d4be58737106860d9/virtualenv-21.3.3-py3-none-any.whl", hash = "sha256:7d5987d8369e098e41406efb780a3d4ca79280097293899e351a6407ee153ab3", size = 7594554, upload-time = "2026-05-13T18:01:27.815Z" },
+]
+
+[[package]]
+name = "wandb"
+version = "0.27.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "packaging" },
+    { name = "platformdirs" },
+    { name = "protobuf" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "sentry-sdk" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/31/fe53d06b75ef0a7f2f0ee5931a89f7aedc27d233840b1839616860fed256/wandb-0.27.0.tar.gz", hash = "sha256:579e75300173059f9334e1f513a79ef15f6d9ea5c74e20d695633648cdd02031", size = 41090732, upload-time = "2026-05-14T03:44:08.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ea/5e/2c199e70e636ecfd217cde0bc7469f4511e1d03d0685eb92bfdfce391430/wandb-0.27.0-py3-none-macosx_12_0_arm64.whl", hash = "sha256:c156be4851485f3c4160cb6eb2e8991b4cdeffbccefc5636d33cf5e254847365", size = 24886476, upload-time = "2026-05-14T03:43:27.569Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/cd/a617c871cd304a9804e56a7ec2ec2c65685bf0091a2b9f91910175a149e2/wandb-0.27.0-py3-none-macosx_12_0_x86_64.whl", hash = "sha256:20179f38afb0158859a4141d29ac650d3fdbd0cf801a74ce25565c934f03776c", size = 26045779, upload-time = "2026-05-14T03:43:31.999Z" },
+    { url = "https://files.pythonhosted.org/packages/10/0a/d3f159a201530b84b72ca5f98c68d1f351c2d9a1864558ed76c811407fae/wandb-0.27.0-py3-none-manylinux_2_28_aarch64.whl", hash = "sha256:626497d7975fa898d0a4a239da7a510483495ca3514510dbe75004a25963af4d", size = 25480764, upload-time = "2026-05-14T03:43:35.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6a/8721fcdf71d42639191040a77a585d2982402b1754700cb2ecfc2ca1470a/wandb-0.27.0-py3-none-manylinux_2_28_x86_64.whl", hash = "sha256:f772da7005cc26a2a32b729a16982a583dc68b3d493df6a09d0aa5c5ca5a2060", size = 27256204, upload-time = "2026-05-14T03:43:39.765Z" },
+    { url = "https://files.pythonhosted.org/packages/00/5e/279d167ba79fb7a8a43401c9f25efd0f6663ee9bd1eaf5a8578530198888/wandb-0.27.0-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:63acfc5b994e4a90e4a2fbdee6d45e664da3dd865bb1419942c8995c06c41cf1", size = 25647469, upload-time = "2026-05-14T03:43:44.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/51/a69ac59300e3c813939d0764348959ed2a21e14c668cb1cebcb04010da6a/wandb-0.27.0-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:17aae6e4a88cd05c00ea8f546220918e3ebb6f8c1c36b70ef04a5ac75f0d7160", size = 27599005, upload-time = "2026-05-14T03:43:50.926Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/40/bf510c8758727df020f83b717ebc1fcc1739ed7f6ae1796ebef60bf6f592/wandb-0.27.0-py3-none-win32.whl", hash = "sha256:0bd5659417e386bf6538b5e2ffe6885774c6197f0e4853bfed517d5b0db457f1", size = 25036164, upload-time = "2026-05-14T03:43:54.839Z" },
+    { url = "https://files.pythonhosted.org/packages/54/ff/69f88e7d90c22b79bcb911143c13e59742ee192080b21015ff83a5a1f60a/wandb-0.27.0-py3-none-win_amd64.whl", hash = "sha256:89d584b73166eecee96fb446f18d0e45b1aa45aba6a3696296f3f06d7454516b", size = 25036170, upload-time = "2026-05-14T03:43:59.227Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/38/f7efd7a87297a55c7e9a331a1dbb5b19e54aeacc11fe6f43f8636a73987c/wandb-0.27.0-py3-none-win_arm64.whl", hash = "sha256:a6c129c311edf210a2b4f2f4acc557eff522628125f5f28ed27df19c16c07079", size = 22972710, upload-time = "2026-05-14T03:44:03.275Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `radiologist-core/src/radiologist/core/registry/` with `pull.py`, `promote.py`, and `__init__.py`
- `pull_checkpoint` downloads a W&B artifact and returns the local `.ckpt` path; raises `RuntimeError` when wandb is absent and `FileNotFoundError` when no `.ckpt` is found
- `promote_to_registry` exports two ONNX models (`model-{run_id}.onnx` deterministic + `model-{run_id}-mcd.onnx` MC-dropout) with `metadata_props`, links both to the W&B Model Registry, and returns the qualified name
- Both symbols re-exported from `radiologist.core`
- `wandb`, `onnx`, and `onnxscript` added as `[registry]` optional extras to `radiologist-core`

## Test plan

- [x] `pull_checkpoint` raises `RuntimeError` (wandb absent) — patched at module level
- [x] `pull_checkpoint` raises `FileNotFoundError` (no `.ckpt` in artifact dir)
- [x] `pull_checkpoint` returns correct path when `.ckpt` exists
- [x] `promote_to_registry` raises `RuntimeError` (wandb/onnx absent)
- [x] `promote_to_registry` raises `AttributeError` for bad `cam_target_layer`; no ONNX written
- [x] Both `model-{run_id}.onnx` and `model-{run_id}-mcd.onnx` created
- [x] Deterministic ONNX `metadata_props` correct (all required keys + `cam_target_layer` + `output_names`)
- [x] MCD ONNX `metadata_props` correct (`mc_dropout: "true"`)
- [x] `precision` read from W&B run config, not hardcoded
- [x] Deterministic ONNX produces identical outputs on two inference runs
- [x] MCD ONNX retains `Dropout` nodes in graph
- [x] MCD ONNX produces different outputs across 10 runs (stochastic)
- [x] Idempotent: re-running overwrites both files
- [x] `promote_to_registry` returns a non-empty qualified name string
- [x] Public API importable from `radiologist.core`
- All 77 core tests pass; `mypy` clean

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)
