### PR TITLE
docs(chore): add agent memory from milestone-1 session and update CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -89,7 +89,7 @@ Three active members: `radiologist-utils`, `radiologist-core`, `radiologist-etl`
 
 Each package uses `namespace = true` (no `__init__.py` at the `radiologist/` level). Add new members to `[tool.uv.workspace] members` and `[tool.uv.sources]` in the root `pyproject.toml`.
 
-Each package sets `module-name = "radiocovid.*"` in its `pyproject.toml` (intentional — do not change). Sources live under `src/radiologist/`; tests import via a `sys.path.insert(0, src/)` shim in each package's `tests/conftest.py`. Mirror this pattern when adding new packages.
+Each package sets `module-name = "radiologist.*"` in its `pyproject.toml` (intentional — do not change). Sources live under `src/radiologist/`; tests import via a `sys.path.insert(0, src/)` shim in each package's `tests/conftest.py`. Mirror this pattern when adding new packages.
 
 ### Requirements
 
@@ -124,7 +124,7 @@ Run `pyenv [command] --help` to display `pyenv`'s help.
 
 ### Worktrees
 
-Always create worktrees in `PROJECT-ROOT`/.claude/worktrees to maintain clean repo - No exceptions.
+Always create worktrees in `PROJECT-ROOT`/.claude/worktrees to maintain clean repo. Never nest worktrees - No exceptions.
 
 [Environment setup](#environment-setup) still apply in worktrees - No exceptions.
 
@@ -165,6 +165,7 @@ Fixtures defined in a `conftest.py` can be used by any test in that package with
 - Commitizen convention enforced via commitizen's pre-commit hook. Valid prefix types: `feat`, `fix`, `refactor`, `test`, `docs`, `chore`, `revert`, `style`.
 - Stacked PRs: branches that depend on other feature branches must target the dependency branch, not `main`. Adjust `gh pr create --base` accordingly.
 - After a `pre-commit.ci` remote auto-fix commit, run `git fetch origin <branch> && git rebase origin/<branch>` before the next push to avoid diverged-branch rejection.
+- Keep git tree linear.
 
 ## Gotchas
 
@@ -173,3 +174,4 @@ Fixtures defined in a `conftest.py` can be used by any test in that package with
 - **[LICENSE]** You MUST NOT add the license header in your code yourself. `pre-commit` we do that.
 - **[MEMORY]** Generalise before saving: a gotcha observed on one instance (a class, function, OS, or library) should be written at the level of the broader behavior it exemplifies — not pinned to the specific case that triggered it. When writing a memory or gotcha, ask: is this specific to X, or is X just one case of a wider rule? Write the wider rule; mention X only as an example if it aids clarity.
 - **[Extra]** For optional extra deps, write their imports (e.g. `from prefect import ...`) wrapped in `try/except ImportError` with stub no-ops so modules import cleanly without the extra installed.
+- **[Context]** Large output floods the context window and wastes tokens. Keep Bash output small: pipe through `grep`/`head`/`tail` to extract only what matters, or redirect to `$TMPDIR/out.txt` and read it selectively with the Read tool (`offset`/`limit`). Never `cat` a file via Bash — use the Read tool directly. Never dump raw `find`, `tree`, or long test output into context without filtering.

--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -3,6 +3,11 @@
 - [Numpy bool assertions](feedback_numpy_bool_assertions.md) — use `== True/False` not `is True/False` for pandas/numpy cells from Parquet/DataFrame
 - [Output dir creation](feedback_pipeline_dir_creation.md) — functions that write to caller-supplied paths must mkdir before writing; fsspec local does not auto-create parents
 - [WebDataset TarWriter](feedback_webdataset_tarwriter.md) — use `wds.TarWriter` not `wds.ShardWriter` for predetermined shard paths
+- [WebDataset .cls extension](feedback_webdataset_cls_extension.md) — `.cls` files with string labels must skip `.decode()`; handle raw bytes in `.map()` manually
+- [DataLoader worker pickling](feedback_dataloader_worker_pickling.md) — Dataset classes for `num_workers > 0` must be module-level, not defined inside test functions
+- [importlib.reload side effects](feedback_importlib_reload_side_effects.md) — use `patch.object(mod, "dep", None)` not reload+patch.dict to test absent optional deps
+- [Lightning checkpoint weights_only](feedback_lightning_ckpt_weights_only.md) — `load_from_checkpoint` requires `weights_only=False` in PyTorch 2.6+ due to `functools.partial` in hparams
+- [ONNX export patterns](feedback_onnx_export_patterns.md) — pass dummy input as tuple `(x,)`; MCD export: freeze net then re-enable Dropout layers only
 - [Write files via Python](feedback_write_files_via_python.md) — use `python3 -c` or Write tool for files containing `!=` or shell-special chars
 - [ETL implementation patterns](project_etl_implementation.md) — scikit-image import scope, functools.partial pickling, fsspec normalization, Prefect import guard, ParquetWriter guard, workers sentinel
 - [Pipeline architecture](project_pipeline_architecture.md) — ops.py/prefect.py split pattern, compute_run_id hashing contract, Prefect 3 API facts

--- a/.claude/agent-memory/tdd-developer/feedback_dataloader_worker_pickling.md
+++ b/.claude/agent-memory/tdd-developer/feedback_dataloader_worker_pickling.md
@@ -1,0 +1,12 @@
+---
+name: dataloader-worker-pickling
+description: DataLoader workers require picklable objects; classes defined inside test functions will fail with spawn multiprocessing
+metadata:
+  type: feedback
+---
+
+DataLoader `num_workers > 0` spawns separate processes via `multiprocessing.spawn`. Any object passed to a worker (Dataset, collate_fn, worker_init_fn) must be picklable.
+
+**Why:** `spawn` pickles the Dataset object to send it to the child process. A class defined inside a function body (`class Foo` inside `def test_foo`) is a closure-scoped name — pickle cannot resolve it by module path and raises `AttributeError: Can't pickle local object`.
+
+**How to apply:** When writing tests that use DataLoader with `num_workers > 0`, define all Dataset classes at module level, not inside test functions. Alternatively, avoid `num_workers > 0` in tests — call the `worker_init_fn` directly to verify seeding behavior without spawning workers, which also avoids cross-test `sys.path` pollution in multi-package pytest runs.

--- a/.claude/agent-memory/tdd-developer/feedback_importlib_reload_side_effects.md
+++ b/.claude/agent-memory/tdd-developer/feedback_importlib_reload_side_effects.md
@@ -1,0 +1,14 @@
+---
+name: importlib-reload-side-effects
+description: importlib.reload changes module globals permanently; prefer patch.object over reload+patch.dict
+metadata:
+  type: feedback
+---
+
+`importlib.reload(mod)` re-executes the module with the current `sys.modules` state, permanently changing module-level globals (e.g. `wandb = None`). The `patch.dict(sys.modules, ...)` context manager restores `sys.modules` on exit, but does NOT undo the reload's changes to the module's own namespace.
+
+**Consequence:** Tests that reload a module to test "absent optional" behavior will corrupt subsequent tests that expect the real module to be present.
+
+**Fix:** Use `patch.object(module, "wandb", None)` to patch the module-level name directly. This is always reversible and doesn't cause onnx or other extension C-library re-init issues.
+
+**How to apply:** Any time you want to test `try/except ImportError` stubs, prefer `patch.object(mod, "dep_name", None)` over `importlib.reload` + `sys.modules` patching.

--- a/.claude/agent-memory/tdd-developer/feedback_lightning_ckpt_weights_only.md
+++ b/.claude/agent-memory/tdd-developer/feedback_lightning_ckpt_weights_only.md
@@ -1,0 +1,12 @@
+---
+name: lightning-ckpt-weights-only
+description: LModule.load_from_checkpoint requires weights_only=False in PyTorch 2.6+ because checkpoints contain functools.partial
+metadata:
+  type: feedback
+---
+
+PyTorch 2.6 changed `torch.load` default to `weights_only=True`. Lightning checkpoints embed Python objects (e.g. `functools.partial` factories from `save_hyperparameters`) that are not safe globals, so `load_from_checkpoint` raises `UnpicklingError` unless `weights_only=False` is passed explicitly.
+
+**Why:** `LModule` stores optimizer/metric/scheduler as `functools.partial` in hparams. These can't be deserialized with `weights_only=True`.
+
+**How to apply:** Always call `LModule.load_from_checkpoint(path, map_location="cpu", weights_only=False)` in production code. In tests, mock `LModule.load_from_checkpoint` with `patch.object` to return a pre-built instance — this avoids the serialization issue entirely and is the cleaner test approach.

--- a/.claude/agent-memory/tdd-developer/feedback_onnx_export_patterns.md
+++ b/.claude/agent-memory/tdd-developer/feedback_onnx_export_patterns.md
@@ -1,0 +1,14 @@
+---
+name: onnx-export-patterns
+description: Patterns for safe torch.onnx.export calls and ONNX metadata_props in this project
+metadata:
+  type: feedback
+---
+
+Pass input args as a tuple to `torch.onnx.export`: use `(dummy_input,)` not `dummy_input` to satisfy mypy's `tuple[Any, ...]` type constraint.
+
+For MC-dropout export: call `model.train(mode=False)` on the full net first, then re-enable only `nn.Dropout` layers with `for m in net.modules(): if isinstance(m, nn.Dropout): m.train()`. Export with `training=torch.onnx.TrainingMode.PRESERVE, do_constant_folding=False`. Requires `onnxscript` installed alongside `onnx`.
+
+**Why:** The deterministic/stochastic distinction requires BatchNorm frozen (running stats) and Dropout active only for MCD.
+
+**How to apply:** Same pattern for any future ONNX export that needs MC-dropout inference.

--- a/.claude/agent-memory/tdd-developer/feedback_webdataset_cls_extension.md
+++ b/.claude/agent-memory/tdd-developer/feedback_webdataset_cls_extension.md
@@ -1,0 +1,23 @@
+---
+name: webdataset-cls-extension
+description: WebDataset's built-in decoder treats .cls files as integer class indices, not string labels — skip decode() and handle raw bytes in .map()
+metadata:
+  type: feedback
+---
+
+WebDataset's `decode("pil")` or `decode("rgb8")` has a built-in handler for `.cls` files that expects them to contain integer bytes (e.g., `b"3"`). If your `.cls` files contain string labels (e.g., `b"ABNORMAL"`), you'll get `ValueError: invalid literal for int() with base 10`.
+
+**Why:** The ETL produces `.cls` files with UTF-8 string labels, but WebDataset assumes `.cls` = integer class index.
+
+**How to apply:** Skip `.decode()` entirely. Access raw `sample["png"]` bytes and `sample["cls"]` bytes in `.map()`, decode them manually (PIL for images, `.decode("utf-8")` for labels). Example pattern in `datamodule.py`:
+
+```python
+def decode_sample(sample: dict) -> dict:
+    img = Image.open(io.BytesIO(sample["png"])).convert("RGB")
+    tensor = transform(img)
+    label_str = sample["cls"].decode("utf-8").strip()
+    target = torch.tensor(resolve(label_str), dtype=torch.int64)
+    return {"input": tensor, "target": target, "key": sample["__key__"]}
+
+ds = wds.WebDataset(shards).compose(wds.split_by_node, wds.split_by_worker).map(decode_sample)
+```


### PR DESCRIPTION
## Summary

- Add TDD agent memory files capturing feedback from the milestone-1 session (dataloader pickling, importlib reload, Lightning checkpoint, ONNX export, WebDataset cls extension)
- Update `CLAUDE.md` with linear git tree requirement and revised worktree path note

## Test plan

- [ ] No code changes — docs/config only; no tests required
