### PR TITLE
docs(repo): add per-package READMEs and relocate CLAUDE.md

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -10,6 +10,15 @@ This project provides a fully reproducible machine-learning pipeline that takes 
 
 Stack: PyTorch · Lightning · Hydra · W&B · DVC · Prefect · FastAPI · Streamlit · UV · PyEnv.
 
+### Module READMEs
+
+Each active package has a README that is the primary reference for its responsibilities, public API, configuration, and design decisions. Read the relevant README before exploring source files.
+
+- `README.md` — end-to-end pipeline overview and quick-start
+- `radiologist-utils/README.md` — filesystem helpers, logging, ML utilities
+- `radiologist-etl/README.md` — ETL pipeline stages, Haralick GLCM, sharding
+- `radiologist-core/README.md` — training loop, datamodule, callbacks, ONNX registry
+
 ### Repository layout
 
 This project adopts a mono-repo layout managed by `UV`.
@@ -76,7 +85,7 @@ This project adopts a mono-repo layout managed by `UV`.
 
 ### uv workspace
 
-Five members: `radiologist-utils`, `radiologist-core`, `radiologist-etl`, `radiologist-inference`, `radiologist-app`.
+Three active members: `radiologist-utils`, `radiologist-core`, `radiologist-etl`. `radiologist-app` and `radiologist-inference` are **planned but not yet implemented** — their directories do not exist.
 
 Each package uses `namespace = true` (no `__init__.py` at the `radiologist/` level). Add new members to `[tool.uv.workspace] members` and `[tool.uv.sources]` in the root `pyproject.toml`.
 
@@ -126,8 +135,8 @@ When an subagent ends his work in a worktree:
 ### Running tests
 
 ```bash
-uv run --active pytest -q -p no:warnings                          # all packages
-uv run --active pytest radiologist-core/tests -q -p no:warnings  # single package
+uv run --active pytest -q                          # all packages
+uv run --active pytest radiologist-core/tests -q   # single package
 ```
 
 ### Code style — PEP 8
@@ -159,6 +168,7 @@ Fixtures defined in a `conftest.py` can be used by any test in that package with
 
 ## Gotchas
 
+- **[Packages]** `radiologist-app/` and `radiologist-inference/` do not exist on disk — they are planned packages. Do not attempt to read or import from them.
 - **[PyTorch]** The sandbox security hook false-positives on the `.eval()` method name. Use `model.train(mode=False)` instead of `model.eval()` in any PyTorch code.
 - **[LICENSE]** You MUST NOT add the license header in your code yourself. `pre-commit` we do that.
 - **[MEMORY]** Generalise before saving: a gotcha observed on one instance (a class, function, OS, or library) should be written at the level of the broader behavior it exemplifies — not pinned to the specific case that triggered it. When writing a memory or gotcha, ask: is this specific to X, or is X just one case of a wider rule? Write the wider rule; mention X only as an example if it aids clarity.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,145 @@
-# radiologist
+# Radiologist
+
+A fully reproducible machine-learning pipeline for chest X-ray classification. Takes a raw archive of labelled radiographs and produces a production-ready classifier distinguishing healthy lungs from viral pneumonia / COVID-19 and other opacities — complete with visual explanations and uncertainty estimates.
+
+## Business value
+
+| Capability | What it enables |
+|---|---|
+| Automated quality gating | Flags images where lungs fall outside the frame or whose texture statistics are outliers before any model trains on them |
+| Deterministic, reproducible splits | Every image is assigned to train / val / test by a hash of its filename; reruns always produce the same cohort without storing split state |
+| Class-balanced streaming training | Clinical datasets are heavily imbalanced; the pipeline compensates automatically so the model does not specialise on the majority class |
+| GradCAM visual explanations | Every prediction can be accompanied by a heatmap highlighting the lung region that drove the decision — enabling radiologist review |
+| Uncertainty estimation | MC-Dropout at inference time surfaces cases where the model is uncertain, flagging them for human review |
+| W&B Model Registry integration | Versioned, auditable model promotion to a central registry; downstream services pull a specific alias (`production`, `staging`) |
+
+## Architecture overview
+
+```
+Raw X-rays (GCS or local)
+        │
+        ▼
+┌───────────────────┐
+│  radiologist-etl  │  Feature extraction → quality filtering → deterministic split
+│                   │  → JSONL manifest → WebDataset tar shards
+└────────┬──────────┘
+         │  shards + manifest (GCS)
+         ▼
+┌───────────────────┐
+│  radiologist-core │  Lightning training loop (ResNet-50 + Focal Loss + AdamW)
+│                   │  → W&B checkpoint → ONNX export → Model Registry
+└────────┬──────────┘
+         │  ONNX artefacts (W&B Registry)
+         ▼
+┌───────────────────┐
+│  radiologist-app  │  FastAPI / Streamlit serving  (planned)
+└───────────────────┘
+```
+
+The shared foundation (`radiologist-utils`) sits below all layers.
+
+## Repository layout
+
+This is a UV workspace mono-repo. Each package is independently installable and testable.
+
+| Package | Purpose |
+|---|---|
+| [`radiologist-utils`](radiologist-utils/README.md) | Filesystem-agnostic I/O, logging, ML training utilities |
+| [`radiologist-etl`](radiologist-etl/README.md) | Data preparation — Haralick GLCM, IQR filtering, sharding |
+| [`radiologist-core`](radiologist-core/README.md) | Model training, evaluation, attribution, registry promotion |
+| `radiologist-app` | Streamlit / FastAPI serving UI *(planned)* |
+| `radiologist-inference` | DVC-tracked raw and processed images *(planned)* |
+
+## Tech stack
+
+**Training:** PyTorch · Lightning · torchvision (ResNet-50) · TorchMetrics
+
+**Data:** WebDataset · fsspec · GCS · DVC
+
+**Experiment tracking:** Weights & Biases · Hydra
+
+**ETL:** Prefect · scikit-image (Haralick GLCM) · Parquet · pyarrow
+
+**Serving (planned):** FastAPI · Streamlit · ONNX Runtime
+
+**Tooling:** UV · PyEnv · pre-commit · tox · mypy · black · isort
+
+## Quick start
+
+### 1 — Set up the environment
+
+```bash
+pyenv activate radiologist
+uv sync --active --extra all --all-groups
+pre-commit install
+pre-commit install --hook-stage commit-msg
+```
+
+### 2 — Prepare the data
+
+```bash
+cd radiologist-etl
+uv run --active python -m radiologist.etl.prefect_pipelines \
+    source=gs://my-bucket/raw_chest_xray/ \
+    destination=gs://my-bucket/manifests/ \
+    shard_root=gs://my-bucket/shards/
+```
+
+See [`radiologist-etl/README.md`](radiologist-etl/README.md) for the full configuration reference and resume flags.
+
+### 3 — Train
+
+```bash
+cd radiologist-core
+uv run --active python -m radiologist.core.train \
+    datamodule.shard_root=gs://my-bucket/shards/ \
+    datamodule.split_manifest_uri=gs://my-bucket/manifests/manifest-abc123.jsonl
+```
+
+### 4 — Promote to the model registry
+
+```python
+from radiologist.core.registry import promote_to_registry
+
+promote_to_registry(
+    artifact="entity/project/model-artifact:v3",
+    collection="chest-xray-classifier",
+    registry_alias="production",
+    input_shape=(1, 1, 224, 224),
+    classes=["healthy", "viral", "opacity"],
+    cam_target_layer="layer4.1.conv2",
+)
+```
+
+This exports two ONNX models — deterministic (with GradCAM activation output) and MC-Dropout (for uncertainty estimation) — and links them to the W&B registry.
+
+### 5 — Run the test suite
+
+```bash
+uv run --active pytest -q -p no:warnings                          # all packages
+uv run --active pytest radiologist-core/tests -q -p no:warnings   # single package
+```
+
+## Key design decisions
+
+**Remote-first filesystem.** All I/O goes through fsspec. Switching from local to GCS (or S3) requires only a URI change — no code changes anywhere.
+
+**Deterministic ETL run IDs.** The ETL run ID is a SHA-256 digest of the config dict plus a dataset fingerprint (file count + total bytes + run label). Rerunning with the same config and same data always produces the same ID, making runs idempotent and traceable.
+
+**Two ONNX exports from one checkpoint.** The registry step exports two artefacts: a deterministic model that returns `(logits, activation)` for GradCAM visualisation, and an MC-Dropout model with stochastic passes preserved for uncertainty estimation. Both are linked to the same registry entry so consumers choose the variant they need.
+
+**Optional extras everywhere.** Heavy optional dependencies (`prefect`, `captum`, `onnx`, `wandb`) are wrapped in `try/except ImportError` stubs. The package imports cleanly without them; the feature gracefully no-ops or raises a clear install message when invoked without its extra.
+
+**Prior-calibrated logit initialisation.** The final classification layer's bias is initialised to `−log(prior)` where `prior` comes from the training set class frequencies. This prevents the model spending the first epochs learning the class imbalance; it starts with calibrated logits instead.
+
+## Reproducibility
+
+- Python version pinned to 3.10 via `.python-version`
+- `uv.lock` pins every transitive dependency
+- `set_seed` seeds Python, NumPy, PyTorch, CUDA and sets `CUBLAS_WORKSPACE_CONFIG` and `PYTHONHASHSEED`
+- `trainer.yaml` sets `deterministic: true`
+- ETL split assignment is MD5-hash-based — independent of insertion order or random state
+
+## License
+
+See [LICENSE](LICENSE).

--- a/radiologist-core/README.md
+++ b/radiologist-core/README.md
@@ -1,0 +1,226 @@
+# radiologist-core
+
+The ML engine. Provides the Lightning training loop, streaming data module, focal loss, GradCAM attribution, and W&B model registry integration for chest X-ray classification.
+
+## Business context
+
+Once clean, labelled WebDataset shards exist (produced by `radiologist-etl`), this package trains a classifier capable of distinguishing:
+
+- **Healthy** lung (no finding)
+- **Viral** pneumonia / COVID (infectious infiltrates)
+- **Opacity** (other lung opacities)
+
+The trained model is exported as two ONNX artefacts — one for deterministic inference with visual explanations (GradCAM), one for uncertainty-aware inference (MC-Dropout) — and linked to a W&B Model Registry collection for downstream consumption by an inference or serving layer.
+
+## Key capabilities
+
+| Capability | What it enables |
+|---|---|
+| Class-balanced streaming | Trains on imbalanced clinical data without manual oversampling scripts |
+| Prior-calibrated bias init | Logit outputs are calibrated to class prevalence from the first step |
+| Focal Loss | Focuses learning on hard, misclassified examples rather than easy majority samples |
+| GradCAM attribution | Produces heatmaps showing which lung region drove the prediction |
+| MC-Dropout ONNX export | Enables uncertainty estimation at inference time (multiple stochastic passes) |
+| HPO-friendly best-metric tracking | Optuna / W&B Sweeps receive the best epoch score, not the last |
+
+## Package layout
+
+```
+radiologist-core/src/radiologist/core/
+├── train.py            # Hydra entry point and train() function
+├── module.py           # LModule (LightningModule)
+├── losses.py           # FocalLoss
+├── data/
+│   ├── datamodule.py   # WebDatasetDataModule
+│   └── shards.py       # shard discovery helpers
+├── callbacks/
+│   ├── attribution.py  # GradCAM + Integrated Gradients
+│   ├── best_metric.py  # best-epoch metric tracking
+│   └── wandb_summary.py
+├── registry/
+│   ├── promote.py      # promote_to_registry (ONNX export + W&B upload)
+│   └── pull.py         # pull_checkpoint
+└── configs/            # Hydra config tree
+```
+
+## Training a model
+
+### Prerequisites
+
+- Shards on GCS (or local) produced by `radiologist-etl`
+- W&B API key in the environment (`WANDB_API_KEY`)
+
+### Quick start
+
+```bash
+cd radiologist-core
+uv run --active python -m radiologist.core.train
+```
+
+The defaults load from `src/radiologist/core/configs/train.yaml`. Override on the command line:
+
+```bash
+uv run --active python -m radiologist.core.train \
+    trainer.max_epochs=30 \
+    datamodule.shard_root=gs://my-bucket/shards/ \
+    datamodule.split_manifest_uri=gs://my-bucket/manifests/manifest-abc123.jsonl \
+    seed=42
+```
+
+### Evaluation only
+
+```bash
+uv run --active python -m radiologist.core.train \
+    --config-name eval \
+    ckpt_path=/path/to/checkpoint.ckpt
+```
+
+## Core components
+
+### `LModule`
+
+A backbone-agnostic `LightningModule`. Pass any `nn.Module` as `net`.
+
+```python
+from radiologist.core import LModule
+from torchvision.models import resnet50
+
+module = LModule(
+    net=resnet50(num_classes=3),
+    loss=FocalLoss(gamma=2, alpha=1),
+    metric=MulticlassFBetaScore(num_classes=3, beta=1.0, average="macro"),
+    optimizer=partial(AdamW, lr=1e-3, weight_decay=1e-2),
+    scheduler=partial(sequential_scheduler, ...),
+    trainable_layers=None,   # None = full re-init; list of dot-paths = fine-tune
+    priors=None,             # overridden from datamodule at setup time
+)
+```
+
+On `setup('fit')`, `LModule` does one of two things depending on `trainable_layers`:
+
+- **`None`** — reinitialise all weights (Kaiming normal on Conv, Xavier on Linear). Use when training from scratch.
+- **`["layer4", "fc"]`** — freeze all parameters, then selectively unfreeze by dot-path. Use when fine-tuning a pretrained backbone.
+
+In both cases, if class priors are available (from the datamodule), the final `nn.Linear` bias is initialised to `−log(priors)`, giving calibrated starting logits.
+
+### `WebDatasetDataModule`
+
+Streams images from WebDataset tar shards. Handles class-balanced sampling automatically.
+
+```python
+from radiologist.core import WebDatasetDataModule
+
+dm = WebDatasetDataModule(
+    shard_root="gs://bucket/shards/",
+    split_manifest_uri="gs://bucket/manifests/manifest-abc123.jsonl",
+    label_map={"normal": "healthy", "pneumonia": "viral", "COVID": "viral"},
+    batch_size=32,
+)
+```
+
+The `label_map` collapses raw ETL folder names (e.g. `normal`, `COVID`) into model class names (e.g. `healthy`, `viral`). This decouples the dataset's folder structure from the model's output space.
+
+Training dataloader: one `wds.WebDataset` pipeline per class with `resampled=True` (infinite streaming), combined via `wds.RandomMix` weighted by inverse class frequency, then unbatch → shuffle → rebatch for global shuffling within an epoch. Validation and test dataloaders are flat sequential pipelines with no resampling.
+
+### `FocalLoss`
+
+```python
+from radiologist.core import FocalLoss
+
+loss = FocalLoss(gamma=2.0, alpha=1.0, use_softmax=True, reduction="mean")
+```
+
+Applies softmax to logits, computes `alpha * (1 − pt)^gamma * −log(pt)`. Supports optional one-hot conversion and `mean | sum | none` reductions.
+
+### Callbacks
+
+#### `AttributionCallback`
+
+Computes Layer GradCAM and Integrated Gradients every `every_n_val_epochs` validation epochs and on all test batches. Saves normalised PNGs to `{log_dir}/attributions/` and logs them to W&B. Skipped gracefully when `captum` is not installed.
+
+```yaml
+# configs/callbacks/default.yaml
+attribution:
+  _target_: radiologist.core.callbacks.AttributionCallback
+  target_layer: layer4.1.conv2
+  every_n_val_epochs: 5
+  n_test_batches: 4
+  n_samples_per_batch: 4
+```
+
+#### `BestMetricCallback`
+
+Writes `best_{monitor}` to `trainer.callback_metrics` after every validation epoch. When training finishes, HPO frameworks (Optuna, W&B Sweeps) read the best epoch score rather than the last.
+
+#### `WandbDefineSummaryCallback`
+
+Calls `wandb.run.define_metric` at fit start so the W&B run summary panel highlights the best validation score automatically.
+
+## Promoting a trained model to the registry
+
+```python
+from radiologist.core.registry import promote_to_registry
+
+promote_to_registry(
+    artifact="entity/project/model-artifact:v3",
+    collection="chest-xray-classifier",
+    registry_alias="production",
+    input_shape=(1, 1, 224, 224),
+    classes=["healthy", "viral", "opacity"],
+    cam_target_layer="layer4.1.conv2",
+)
+```
+
+This exports two ONNX models from the checkpoint:
+
+1. **Deterministic** — `_CamWrapper` forward hook returns `(logits, activation)`. Useful for inference with visual explanation.
+2. **MC-Dropout** — `nn.Dropout` layers left in training mode (`TrainingMode.PRESERVE`, no constant folding). Run multiple forward passes and aggregate for uncertainty estimation.
+
+Both are uploaded as W&B artifacts and linked to the registry collection under `registry_alias`.
+
+### Pulling a checkpoint
+
+```python
+from radiologist.core.registry import pull_checkpoint
+
+ckpt_path = pull_checkpoint(
+    run_id="wandb-run-id",           # resolve by run ID
+    metric="best_val_score",
+    # or: tags=["production"], groups=["experiment-v2"]  to filter runs
+)
+```
+
+## Configuration reference
+
+The Hydra config tree lives at `src/radiologist/core/configs/`. Key files:
+
+| File | Purpose |
+|---|---|
+| `train.yaml` | Root config; wires all sub-configs |
+| `eval.yaml` | Evaluation-only mode (`train: false`, `ckpt_path: ???`) |
+| `trainer.yaml` | Lightning Trainer (precision, gradient clipping, deterministic) |
+| `datamodule/default.yaml` | Shard URIs, label map, transforms, normalisation |
+| `module/resnet50.yaml` | ResNet-50 backbone, `num_classes` interpolated from datamodule |
+| `module/loss/focal_loss.yaml` | γ=2, α=1, softmax, mean |
+| `module/optimizer/adamw.yaml` | AdamW, lr=1e-3, weight_decay=1e-2 |
+| `module/scheduler/sequential.yaml` | Linear warmup 500 steps → cosine annealing 10 000 steps |
+| `module/metric/fbeta_score.yaml` | Macro F1 (`MulticlassFBetaScore`, β=1) |
+| `callbacks/default.yaml` | BestMetric, WandbSummary, Attribution, ModelCheckpoint, LRMonitor |
+
+## Optional extras
+
+Install the `registry` extra for ONNX export and W&B registry features:
+
+```bash
+uv add --active "radiologist-core[registry]"
+```
+
+Adds: `onnx`, `onnxruntime`, `onnxscript`.
+
+## Dependencies
+
+Core: `radiologist-utils`, `torch`, `torchvision`, `lightning`, `webdataset`, `torchmetrics`, `wandb`, `hydra-core`.
+
+Optional (`registry`): `onnx`, `onnxruntime`, `onnxscript`.
+
+Optional (`attribution`): `captum`.

--- a/radiologist-etl/README.md
+++ b/radiologist-etl/README.md
@@ -1,0 +1,161 @@
+# radiologist-etl
+
+Data preparation pipeline. Transforms a raw folder of labelled chest X-ray images (local or GCS) into streaming-ready WebDataset tar shards, producing a deterministic manifest and quality-filtered dataset.
+
+## Business context
+
+Raw clinical X-ray archives are large, heterogeneous, and noisy. Images may be cropped so severely that the lungs fall outside the frame, or they may contain GLCM texture patterns that are statistical outliers relative to the rest of the cohort. Training on such images degrades model accuracy and reproducibility.
+
+`radiologist-etl` solves this before any model ever sees the data:
+
+- **Quality gate** — Haralick GLCM features and lung-boundary checks flag images that should not enter training.
+- **Deterministic splits** — every image is deterministically assigned to `train`, `val`, or `test` based on a hash of its filename, so reruns always produce the same split without storing split state.
+- **Streaming format** — output shards (`WebDataset` tars) stream efficiently from GCS during training without downloading the full dataset.
+- **Reproducibility** — a content-addressed run ID (SHA-256 over config + dataset fingerprint) makes each ETL run traceable.
+
+## Pipeline stages
+
+```
+Raw images (GCS or local)
+  └─ 1. StatsProcessor      → stats-{run_id}.parquet        (Haralick GLCM + lung asymmetry)
+  └─ 2. filter_iqr           → stats-{run_id}-filtered.parquet  (IQR outlier removal)
+       filter_lung_out_of_frame
+  └─ 3. assign_split         → stats-{run_id}-split.parquet  (MD5-deterministic split)
+  └─ 4. write_jsonl          → manifest-{run_id}.jsonl        (canonical manifest)
+  └─ 5. build_shards         → {shard_root}/{split}/{label}/{split}-{label}-{idx:06d}.tar
+```
+
+Each stage is independently resumable via Prefect task caching and the `resume_from_*` config flags.
+
+## Key classes and functions
+
+### Manifest (`radiologist.etl.manifest`)
+
+`ManifestRecord` is the canonical data row throughout the pipeline. Each image becomes one record.
+
+```python
+@dataclass
+class ManifestRecord:
+    manifest_id: str         # unique per run
+    path: str                # original fsspec URI
+    filename: str            # basename used for split assignment
+    label: str               # raw class label from folder name
+    split: str               # "train" | "val" | "test"
+    stats: dict              # flat float dict of extracted features
+    lung_out_of_frame: bool
+    excluded: bool
+    exclusion_reason: str    # pipe-joined list of reasons
+    shard: str               # path to the tar shard (set by build_shards)
+```
+
+`ParquetWriter` and `JsonlWriter` serialise records to Parquet and JSONL respectively. `records_reader` deserialises a JSONL manifest back to a list of `ManifestRecord`.
+
+### Feature extraction (`radiologist.etl.stats`)
+
+```python
+from radiologist.etl import make_haralick, lung_asymmetry
+
+extractor = make_haralick(
+    features=["mean", "std", "entropy", "contrast", "homogeneity"],
+    distances=[1],
+    angles=[0, 0.785, 1.571, 2.356],
+)
+# extractor(image, metadata, mask) -> dict[str, float]
+```
+
+`make_haralick` returns a `StatExtractor` (a `Protocol`-typed callable). Any function with signature `(image, metadata, mask?) -> dict[str, float]` can be plugged into `StatsProcessor` in its place.
+
+`lung_asymmetry(image, metadata, mask)` — returns `asymmetry_ratio` and `asymmetry_diff` from a lung segmentation mask.
+
+### Quality filtering (`radiologist.etl.filters`)
+
+```python
+from radiologist.etl import filter_iqr, filter_lung_out_of_frame
+
+df = filter_iqr(df, columns=["haralick_mean"], factor=1.5)
+df = filter_lung_out_of_frame(df)
+```
+
+Both functions modify `excluded` and `exclusion_reason` in place on the loaded DataFrame and return it. They do not drop rows; exclusion is a flag so the manifest remains complete.
+
+### Deterministic splitting (`radiologist.etl.split`)
+
+```python
+from radiologist.etl import assign_split
+
+split = assign_split("patient_001_ap.png", ratios={"train": 0.70, "val": 0.15, "test": 0.15})
+# → "train"  (deterministic: same filename always yields same split)
+```
+
+The MD5 hex digest of the filename is converted to a fraction in `[0, 1)` and mapped to a cumulative-ratio bracket. No split state is stored.
+
+### Shard construction (`radiologist.etl.shards`)
+
+```python
+from radiologist.etl import build_shards
+
+updated_manifest_path = build_shards(
+    manifest_path="gs://bucket/manifest-abc123.jsonl",
+    shard_root="gs://bucket/shards/",
+    ratios={"train": 0.70, "val": 0.15, "test": 0.15},
+    shard_size=1000,
+)
+```
+
+Writes `{shard_root}/{split}/{label}/{split}-{label}-{idx:06d}.tar` files. The manifest is rewritten in place with the `shard` field set on every included record.
+
+## Running the pipeline
+
+### Via Hydra (recommended)
+
+```bash
+cd radiologist-etl
+uv run --active python -m radiologist.etl.prefect_pipelines \
+    source=gs://radiologist-liora-gcs/raw_chest_x_ray_data/images \
+    destination=gs://radiologist-liora-gcs/manifests/ \
+    shard_root=gs://radiologist-liora-gcs/shards/
+```
+
+Override any config key on the command line. Common overrides:
+
+| Key | Default | Description |
+|---|---|---|
+| `source` | GCS URI | Raw image directory |
+| `masks_root` | GCS URI | Segmentation mask directory |
+| `destination` | GCS URI | Manifest output directory |
+| `iqr_factor` | `1.5` | IQR multiplier for outlier threshold |
+| `split_ratios.train` | `0.70` | Train fraction |
+| `workers` | `null` (all CPUs) | Parallel worker count |
+| `build_shards` | `true` | Whether to produce tar shards |
+| `shard_size` | `1000` | Max images per tar shard |
+| `resume_from_manifest` | `false` | Skip stats/filter/split, go straight to sharding |
+
+### Resume from a previous stage
+
+```bash
+uv run --active python -m radiologist.etl.prefect_pipelines \
+    resume_from_manifest=true \
+    destination=gs://bucket/manifests/ \
+    build_shards=true
+```
+
+### Programmatic use
+
+```python
+from radiologist.etl import (
+    StatsProcessor, make_haralick,
+    filter_iqr, filter_lung_out_of_frame,
+    assign_split, build_shards,
+    JsonlWriter,
+)
+```
+
+## Configuration reference
+
+Full config lives at `src/radiologist/etl/conf/etl.yaml`. The entry point is `radiologist.etl.prefect_pipelines:main` decorated with `@hydra.main`.
+
+## Dependencies
+
+Core: `radiologist-utils`, `fsspec`, `gcsfs`, `numpy`, `Pillow`, `scikit-image`, `pandas`, `pyarrow`, `webdataset`.
+
+Optional: `prefect` (orchestration, install via `--extra prefect`). When not installed, `@flow` and `@task` are identity decorators and the pipeline runs as plain Python.

--- a/radiologist-utils/README.md
+++ b/radiologist-utils/README.md
@@ -1,0 +1,73 @@
+# radiologist-utils
+
+Shared foundation library for the Radiologist mono-repo. Every other package depends on it; it has no internal workspace dependencies.
+
+## What it solves
+
+Provides three capabilities needed across the entire pipeline:
+
+1. **Filesystem-agnostic I/O** — reading images and joining paths works identically whether data lives on a local disk, Google Cloud Storage, or any other fsspec-compatible remote.
+2. **Structured logging** — thin `logging.LoggerAdapter` wrappers for plain CLI scripts and for distributed Lightning training (rank-aware, rank-zero-only gating).
+3. **ML training utilities** — reproducible seeding, Kaiming / Xavier weight initialisation, Hydra config helpers, and Lightning callback/logger instantiation from config.
+
+## Public API
+
+All symbols below are importable from `radiologist.utils` or `radiologist.utils.ml`.
+
+### Filesystem helpers (`radiologist.utils`)
+
+| Symbol | Purpose |
+|---|---|
+| `pathjoin(a, *paths) -> str` | Join path segments, preserving fsspec protocols (`gs://`, `s3://`, …) |
+| `pathname(path) -> str` | Protocol-aware `Path.name` |
+| `pathparent(path) -> str` | Protocol-aware `Path.parent` |
+| `pathstem(path) -> str` | Protocol-aware `Path.stem` |
+| `ImageReader(source, storage_options)` | Factory returning `LocalImageReader` or `RemoteImageReader` based on URI scheme |
+| `read_image(source, storage_options)` | Read a single PNG/JPEG from any fsspec URI → `(np.ndarray, metadata)` |
+
+`BaseImageReader` is an abstract lazy iterator over `(np.ndarray, dict)` tuples. Iterate it to stream images without loading the entire dataset into memory.
+
+```python
+from radiologist.utils import ImageReader
+
+reader = ImageReader("gs://my-bucket/images/", storage_options={"token": "anon"})
+for image, meta in reader:
+    process(image, meta)
+```
+
+### Logging (`radiologist.utils`)
+
+| Symbol | Purpose |
+|---|---|
+| `Logger(name, extra)` | Plain `LoggerAdapter` for CLI scripts |
+| `RankedLogger(name, rank_zero_only, extra)` | Distributed-safe adapter; suppresses non-rank-0 output when `rank_zero_only=True` |
+
+### ML utilities (`radiologist.utils.ml`)
+
+| Symbol | Purpose |
+|---|---|
+| `set_seed(seed, ...)` | Seeds Python, NumPy, PyTorch, CUDA; sets `PYTHONHASHSEED` and `CUBLAS_WORKSPACE_CONFIG` |
+| `seed_worker(worker_id)` | DataLoader `worker_init_fn` for reproducible multi-process loading |
+| `get_seeded_generator(seed)` | Returns a seeded `torch.Generator` for DataLoader `generator=` |
+| `initialize_weights(module, ...)` | Kaiming-init Conv layers, Xavier-init Linear layers |
+| `instantiate_callbacks(callbacks_cfg)` | Build a list of Lightning callbacks from a Hydra DictConfig |
+| `instantiate_loggers(logger_cfg)` | Build a list of Lightning loggers from a Hydra DictConfig |
+| `sequential_scheduler(optimizer, schedulers, milestones)` | Compose multiple LR schedulers into a `SequentialLR` |
+| `extras(cfg)` | Apply optional Hydra run-time extras (warning suppression, tag enforcement, config printing) |
+| `task_wrapper(task_func)` | Decorator ensuring `wandb.finish()` is always called on exit |
+| `get_metric_value(metric_dict, metric_name)` | Safely retrieve a scalar metric from `trainer.callback_metrics` |
+| `log_hyperparameters(object_dict)` | Rank-zero: resolve full Hydra config and pass to every trainer logger |
+| `print_config_tree(cfg, ...)` | Pretty-print a DictConfig as a Rich tree |
+| `enforce_tags(cfg, ...)` | Prompt for W&B tags when absent; raise during multirun if tags are empty |
+
+## Design notes
+
+- `ImageReader` is a factory function (not a class) that returns a concrete subclass. All path helpers accept arbitrary fsspec URIs, making the whole stack remote-filesystem-compatible without any caller-side branching.
+- Optional heavy dependencies (`torch`, `lightning`, `wandb`, `omegaconf`) are guarded with `try/except ImportError` stubs so the module imports cleanly without them.
+- `RankedLogger` never imports Lightning at module level — it wraps the standard `logging` module only.
+
+## Dependencies
+
+Core: `fsspec`, `gcsfs`, `numpy`, `Pillow`, `rich`.
+
+Optional (installed via extras): `omegaconf`, `hydra-core`, `torch`, `lightning`, `wandb`, `lightning_utilities`.


### PR DESCRIPTION
The root README was a one-line stub and CLAUDE.md lived at the repository root rather than under .claude/. Agents had no single reference for each package's responsibilities, public API, or design decisions, so every session started by re-exploring source files.

- Expand README.md into a full project overview (business value, architecture diagram, quick-start, repo layout).
- Add radiologist-core/README.md, radiologist-etl/README.md, and radiologist-utils/README.md as the primary references for each package.
- Move CLAUDE.md → .claude/CLAUDE.md and update it to reflect the three active packages (radiologist-app and radiologist-inference are planned, not yet on disk), add a Module READMEs index, and correct the test command (drop the -p no:warnings flag).
- Add a gotcha noting that radiologist-app/ and radiologist-inference/ do not exist on disk to prevent agents from attempting imports.