### PR TITLE
feat: train-time ONNX export, W&B-ref resume, smart staging/production promotion

### DIFF
--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -12,5 +12,6 @@
 - [ETL implementation patterns](project_etl_implementation.md) — scikit-image import scope, functools.partial pickling, fsspec normalization, Prefect import guard, ParquetWriter guard, workers sentinel
 - [Pipeline architecture](project_pipeline_architecture.md) — ops.py/prefect.py split pattern, compute_run_id hashing contract, Prefect 3 API facts
 - [Manual ckpt fixture missing hook fields](feedback_manual_ckpt_fixture_missing_hook_fields.md) — hand-built checkpoint fixtures lack fields Lightning hooks add; check before relying on them
+- [W&B sandbox env vars](feedback_wandb_sandbox_env_vars.md) — set WANDB_DIR/WANDB_DATA_DIR/WANDB_CACHE_DIR/WANDB_CONFIG_DIR to a writable tmp before running tests that build real `wandb.Artifact` objects
 
 See also: [[shared/MEMORY.md]] for cross-agent rules (TDD, gh CLI, uv venv).

--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -11,5 +11,6 @@
 - [Write files via Python](feedback_write_files_via_python.md) — use `python3 -c` or Write tool for files containing `!=` or shell-special chars
 - [ETL implementation patterns](project_etl_implementation.md) — scikit-image import scope, functools.partial pickling, fsspec normalization, Prefect import guard, ParquetWriter guard, workers sentinel
 - [Pipeline architecture](project_pipeline_architecture.md) — ops.py/prefect.py split pattern, compute_run_id hashing contract, Prefect 3 API facts
+- [Manual ckpt fixture missing hook fields](feedback_manual_ckpt_fixture_missing_hook_fields.md) — hand-built checkpoint fixtures lack fields Lightning hooks add; check before relying on them
 
 See also: [[shared/MEMORY.md]] for cross-agent rules (TDD, gh CLI, uv venv).

--- a/.claude/agent-memory/tdd-developer/feedback_manual_ckpt_fixture_missing_hook_fields.md
+++ b/.claude/agent-memory/tdd-developer/feedback_manual_ckpt_fixture_missing_hook_fields.md
@@ -1,0 +1,24 @@
+---
+name: manual-ckpt-fixture-missing-hook-fields
+description: shared test checkpoint fixtures built by hand (not via a real trainer save) can lack fields that Lightning hooks add — check before relying on them
+metadata:
+  type: feedback
+---
+
+The `ckpt_path` fixture in `radiologist-core/tests/conftest.py` builds its checkpoint
+dict by hand (`{"epoch":..., "state_dict":..., "hyper_parameters":...}`) rather than
+running a real `trainer.fit()` + save. Any field a `LightningModule` hook adds at save
+time (e.g. `LModule.on_save_checkpoint` setting `checkpoint["precision"]`) will be
+absent from this hand-built dict unless added explicitly.
+
+**Why:** discovered while implementing issue #110 (`restore_precision`) — the fixture
+didn't carry a `"precision"` key even though the module's `on_save_checkpoint` always
+sets one, because the fixture never exercises that hook.
+
+**How to apply:** before writing a test that reads a checkpoint field added by a
+Lightning hook, check the shared fixture's checkpoint dict for that field. If missing,
+extend the fixture directly (add the key with a representative value, e.g.
+`"precision": "32-true"`) rather than duplicating checkpoint construction in the new
+test file — keeps the "real, shared, Lightning-loadable checkpoint" fixture invariant
+intact for all consumers. See [[shared/MEMORY.md]] for the broader "never mock owned
+code" testing rule this fixture pattern serves.

--- a/.claude/agent-memory/tdd-developer/feedback_pytest_worktree_isolation.md
+++ b/.claude/agent-memory/tdd-developer/feedback_pytest_worktree_isolation.md
@@ -1,0 +1,50 @@
+---
+name: feedback-pytest-worktree-isolation
+description: How to run pytest correctly inside a radiologist worktree when the shared pyenv venv's editable installs point at a sibling worktree
+metadata:
+  type: feedback
+---
+
+In this monorepo, editable installs (`*.pth` files in the shared `radiologist`
+pyenv virtualenv's site-packages) are plain sys.path-appending `.pth` files
+pointing at whichever worktree last ran `make dev-install` / `uv sync`. When
+multiple agents work in parallel worktrees sharing that one venv (sandbox
+denies creating a new global `pyenv virtualenv`), each package's `.pth` file
+may point at a *different* (possibly since-deleted) worktree, not the one
+currently being edited.
+
+The root `conftest.py` sys.path shim is supposed to make each worktree
+self-consistent regardless of stale `.pth` entries, but it only takes effect
+when pytest resolves conftest collection from the actual rootdir. Passing an
+explicit package-scoped path (e.g. `pytest radiologist-core/tests`, exactly
+what `make test-core` does under the hood) can silently skip loading the
+top-level `conftest.py`, so imports fall through to site-packages and quietly
+resolve to a different worktree's source — tests can pass or fail against
+code you never touched, with no visible error.
+
+**Why:** discovered while implementing issue #109 — `test_resume_onnx_skeleton_contract.py`
+tests failed with "DID NOT RAISE NotImplementedError" even though the stub in
+this worktree still raised, because Python was importing `radiologist.core.resume`
+from a sibling agent's worktree via a stale `.pth` file, and the sibling had already
+implemented that function.
+
+**How to apply:** in a worktree, always invoke pytest with `--confcutdir=.`
+pinned to the repo root alongside the explicit package path, e.g.:
+`python -m pytest radiologist-core/tests --confcutdir=. -q`. This forces
+pytest to load the root `conftest.py` (which inserts this worktree's own
+`src/` dirs at the front of `sys.path`), so imports resolve to the current
+worktree regardless of what the shared venv's `.pth` files point to. Do NOT
+run bare `python -m pytest` with no path args across all 5 testpaths at once —
+each package's `tests/conftest.py` registers under the same plugin name
+`tests.conftest` (no `__init__.py` in test dirs), causing a
+`ValueError: Plugin already registered under a different name` when more than
+one package's tests collect in the same session. Run one package's tests dir
+at a time with `--confcutdir=.`.
+
+Also: `uv run --active pytest ...` (what `make test-core` invokes) can fail
+outright in the sandbox with `Failed to initialize cache at .../.cache/uv`
+or a Rust panic in `system-configuration`/tokio — unrelated to the code under
+test. Fall back to invoking `python -m pytest` directly (the activated pyenv
+venv's `python` already has all deps installed) when `uv run` fails this way.
+
+See also [[shared/feedback_uv_venv]].

--- a/.claude/agent-memory/tdd-developer/feedback_wandb_sandbox_env_vars.md
+++ b/.claude/agent-memory/tdd-developer/feedback_wandb_sandbox_env_vars.md
@@ -1,0 +1,36 @@
+---
+name: feedback-wandb-sandbox-env-vars
+description: wandb SDK writes to ~/Library/Application Support/wandb (or ~/.cache/wandb) by default, which the sandbox denies — set WANDB_DIR/WANDB_DATA_DIR/WANDB_CACHE_DIR/WANDB_CONFIG_DIR to a writable tmp dir before running radiologist-registry or radiologist-core tests that exercise real `wandb.Artifact` objects
+metadata:
+  type: feedback
+---
+
+Tests that instantiate a real `wandb.Artifact(...)` (not a mock) — e.g.
+`_WandbUploader.log_model_artifacts` tests that call `.add_file()` — make the
+wandb SDK stage the file via `tempfile.NamedTemporaryFile` under
+`~/Library/Application Support/wandb/artifacts/staging` (or the platform
+equivalent). The sandbox denies writes there, so these tests fail with
+`PermissionError: Operation not permitted`, even though nothing about the
+test or the code under test is wrong — the code being mocked is just the
+`_wandb` sentinel's `Api`/network calls, not `wandb.Artifact` itself, which is
+real local-only object construction.
+
+**Why:** discovered while implementing issue #111 — pre-existing tests in
+`test_artifact_promotion.py::TestUploaderLogModelArtifacts` (from #109) failed
+with this `PermissionError` on a fresh run in this worktree, unrelated to the
+new promotion code being added.
+
+**How to apply:** before running `radiologist-registry` (or any package)
+tests that touch real `wandb.Artifact`/`wandb.init` objects, export these to
+a sandbox-writable tmp dir:
+
+```bash
+export WANDB_DIR=$TMPDIR/wandb WANDB_DATA_DIR=$TMPDIR/wandb_data \
+       WANDB_CACHE_DIR=$TMPDIR/wandb_cache WANDB_CONFIG_DIR=$TMPDIR/wandb_config
+mkdir -p "$WANDB_DIR" "$WANDB_DATA_DIR" "$WANDB_CACHE_DIR" "$WANDB_CONFIG_DIR"
+```
+
+Then run pytest as usual (see [[feedback_pytest_worktree_isolation]] for the
+`--confcutdir=.` requirement in worktrees). Do this proactively at the start
+of any registry/core test session rather than waiting for the `PermissionError`
+to appear.

--- a/radiologist-core/src/radiologist/core/callbacks/__init__.py
+++ b/radiologist-core/src/radiologist/core/callbacks/__init__.py
@@ -22,10 +22,12 @@
 
 from radiologist.core.callbacks.attribution import AttributionCallback
 from radiologist.core.callbacks.best_metric import BestMetricCallback
+from radiologist.core.callbacks.onnx_export import OnnxExportCallback
 from radiologist.core.callbacks.wandb_summary import WandbDefineSummaryCallback
 
 __all__ = [
     "AttributionCallback",
     "BestMetricCallback",
+    "OnnxExportCallback",
     "WandbDefineSummaryCallback",
 ]

--- a/radiologist-core/src/radiologist/core/callbacks/onnx_export.py
+++ b/radiologist-core/src/radiologist/core/callbacks/onnx_export.py
@@ -23,6 +23,10 @@
 from typing import Any, List, Tuple
 
 import lightning as L
+import wandb
+
+from radiologist.core.registry import export_onnx
+from radiologist.registry import WandbRegistry
 
 
 class OnnxExportCallback(L.Callback):
@@ -38,7 +42,32 @@ class OnnxExportCallback(L.Callback):
         cam_target_layer: str,
         opset: int = 18,
     ) -> None:
-        raise NotImplementedError
+        super().__init__()
+        self.input_shape = input_shape
+        self.classes = classes
+        self.cam_target_layer = cam_target_layer
+        self.opset = opset
+        self._registry = WandbRegistry()
 
     def on_fit_end(self, trainer: Any, pl_module: Any) -> None:
-        raise NotImplementedError
+        run = getattr(wandb, "run", None)
+        if run is None:
+            return
+
+        checkpoint_callback = getattr(trainer, "checkpoint_callback", None)
+        best_ckpt = getattr(checkpoint_callback, "best_model_path", "")
+        if not best_ckpt:
+            return
+        last_ckpt = getattr(checkpoint_callback, "last_model_path", "") or None
+
+        out_dir = trainer.log_dir or trainer.default_root_dir
+        result = export_onnx(
+            ckpt_path=best_ckpt,
+            run_id=run.id,
+            input_shape=self.input_shape,
+            classes=self.classes,
+            cam_target_layer=self.cam_target_layer,
+            out_dir=out_dir,
+            opset=self.opset,
+        )
+        self._registry.log_model_artifacts(result, run, best_ckpt, last_ckpt)

--- a/radiologist-core/src/radiologist/core/callbacks/onnx_export.py
+++ b/radiologist-core/src/radiologist/core/callbacks/onnx_export.py
@@ -20,22 +20,25 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from radiologist.core.callbacks import (
-    AttributionCallback,
-    BestMetricCallback,
-    OnnxExportCallback,
-    WandbDefineSummaryCallback,
-)
-from radiologist.core.data import WebDatasetDataModule
-from radiologist.core.losses import FocalLoss
-from radiologist.core.module import LModule
+from typing import Any, List, Tuple
 
-__all__ = [
-    "AttributionCallback",
-    "BestMetricCallback",
-    "FocalLoss",
-    "LModule",
-    "OnnxExportCallback",
-    "WandbDefineSummaryCallback",
-    "WebDatasetDataModule",
-]
+import lightning as L
+
+
+class OnnxExportCallback(L.Callback):
+    """Opt-in end-of-fit ONNX export that logs the model to the active W&B run.
+
+    Silent no-op when wandb has no active run or no best checkpoint exists.
+    """
+
+    def __init__(
+        self,
+        input_shape: Tuple[int, ...],
+        classes: List[str],
+        cam_target_layer: str,
+        opset: int = 18,
+    ) -> None:
+        raise NotImplementedError
+
+    def on_fit_end(self, trainer: Any, pl_module: Any) -> None:
+        raise NotImplementedError

--- a/radiologist-core/src/radiologist/core/configs/callbacks/onnx_export.yaml
+++ b/radiologist-core/src/radiologist/core/configs/callbacks/onnx_export.yaml
@@ -1,0 +1,7 @@
+# @package callbacks
+onnx_export:
+  _target_: radiologist.core.OnnxExportCallback
+  input_shape: [1, 3, 224, 224]
+  classes: ["normal", "abnormal"]
+  cam_target_layer: layer4
+  opset: 18

--- a/radiologist-core/src/radiologist/core/configs/train.yaml
+++ b/radiologist-core/src/radiologist/core/configs/train.yaml
@@ -19,6 +19,8 @@ defaults:
 
 stage: train
 ckpt_path: null
+resume_ref: null
+resume_path: null
 seed: 42
 tags: null
 train: true

--- a/radiologist-core/src/radiologist/core/resume.py
+++ b/radiologist-core/src/radiologist/core/resume.py
@@ -1,0 +1,52 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Optional
+
+from omegaconf import DictConfig
+
+
+def resolve_resume_ckpt(cfg: DictConfig) -> Optional[str]:
+    """Resolve the checkpoint path to resume training from, if any.
+
+    Precedence: ``resume_ref`` (W&B, needs ``resume_path``, exclusive with
+    ``ckpt_path``) > ``ckpt_path`` (local path, unchanged) > ``None``
+    (train from scratch).
+
+    Raises:
+        ValueError: if ``resume_ref`` is set without ``resume_path``, if both
+            ``resume_ref`` and ``ckpt_path`` are set, or if ``resume_ref``
+            does not parse as ``'<run_id>:<tag>'``.
+    """
+    raise NotImplementedError
+
+
+def restore_precision(cfg: DictConfig, ckpt_path: str) -> None:
+    """Restore ``cfg.trainer.precision`` from a checkpoint's stored value, if present.
+
+    Security: loads with weights_only=False — Lightning checkpoints unpickle
+    non-tensor objects (consistent with module.py / train.py). The trust
+    boundary matches fit's own ckpt load: checkpoints originate from the
+    user's own local path or their authenticated W&B project, never an
+    untrusted source. Do not switch to weights_only=True.
+    """
+    raise NotImplementedError

--- a/radiologist-core/src/radiologist/core/resume.py
+++ b/radiologist-core/src/radiologist/core/resume.py
@@ -20,9 +20,23 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import Optional
+from typing import Optional, Tuple
 
+import torch
 from omegaconf import DictConfig
+
+from radiologist.registry import WandbRegistry
+
+
+def _parse_resume_ref(resume_ref: str) -> Tuple[str, str]:
+    parts = resume_ref.split(":")
+    if len(parts) != 2 or not parts[0] or not parts[1]:
+        raise ValueError(
+            f"resume_ref must be '<run_id>:<tag>' with non-empty parts, "
+            f"got {resume_ref!r}."
+        )
+    run_id, tag = parts
+    return run_id, tag
 
 
 def resolve_resume_ckpt(cfg: DictConfig) -> Optional[str]:
@@ -37,7 +51,27 @@ def resolve_resume_ckpt(cfg: DictConfig) -> Optional[str]:
             ``resume_ref`` and ``ckpt_path`` are set, or if ``resume_ref``
             does not parse as ``'<run_id>:<tag>'``.
     """
-    raise NotImplementedError
+    resume_ref = cfg.get("resume_ref")
+    resume_path = cfg.get("resume_path")
+    ckpt_path = cfg.get("ckpt_path")
+
+    if resume_ref:
+        if not resume_path:
+            raise ValueError(
+                "resume_path must be set when resume_ref is set "
+                "(resume_ref, resume_path)."
+            )
+        if ckpt_path:
+            raise ValueError(
+                "resume_ref and ckpt_path are mutually exclusive resume "
+                "sources; set only one (ckpt_path, resume_ref)."
+            )
+        run_id, tag = _parse_resume_ref(resume_ref)
+        registry = WandbRegistry()
+        ref = registry.resolve(path=resume_path, run_id=run_id, version=tag)
+        return registry.download(ref, cfg.paths.output_dir)
+
+    return ckpt_path
 
 
 def restore_precision(cfg: DictConfig, ckpt_path: str) -> None:
@@ -49,4 +83,7 @@ def restore_precision(cfg: DictConfig, ckpt_path: str) -> None:
     user's own local path or their authenticated W&B project, never an
     untrusted source. Do not switch to weights_only=True.
     """
-    raise NotImplementedError
+    checkpoint = torch.load(ckpt_path, weights_only=False)
+    precision = checkpoint.get("precision")
+    if precision is not None:
+        cfg.trainer.precision = precision

--- a/radiologist-core/src/radiologist/core/train.py
+++ b/radiologist-core/src/radiologist/core/train.py
@@ -46,6 +46,7 @@ except ImportError:
     instantiate = None  # type: ignore[assignment]
 
 from radiologist.core.module import LModule
+from radiologist.core.resume import resolve_resume_ckpt, restore_precision
 
 log = RankedLogger(__name__, rank_zero_only=True)
 
@@ -78,9 +79,10 @@ def train(cfg: DictConfig) -> Tuple[Dict[str, Any], Dict[str, Any]]:
             raise KeyError("Missing key module in config.")
 
         module = LModule(cfg=cfg.get("module"))
-
-        if cfg.get("ckpt_path") and module.precision:
-            cfg.trainer.precision = module.precision
+        resolved_ckpt = resolve_resume_ckpt(cfg)
+        if resolved_ckpt is not None:
+            restore_precision(cfg, resolved_ckpt)
+            cfg.ckpt_path = resolved_ckpt
 
         trainer: Trainer = instantiate(
             cfg.trainer,

--- a/radiologist-core/tests/conftest.py
+++ b/radiologist-core/tests/conftest.py
@@ -245,6 +245,7 @@ def ckpt_path(tmp_path, lmodule):
 
     Stores the cfg DictConfig in hyper_parameters so Lightning reconstructs
     the module via LModule(cfg=...) using the same architecture as lmodule.
+    Includes "precision", mirroring LModule.on_save_checkpoint.
     """
     import lightning as L
     import torch
@@ -256,6 +257,7 @@ def ckpt_path(tmp_path, lmodule):
         "pytorch-lightning_version": L.__version__,
         "state_dict": lmodule.state_dict(),
         "hyper_parameters": {"cfg": _LMODULE_CFG},
+        "precision": "32-true",
     }
     torch.save(ckpt, path)
     return path

--- a/radiologist-core/tests/test_onnx_export_callback.py
+++ b/radiologist-core/tests/test_onnx_export_callback.py
@@ -1,0 +1,211 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import lightning as L
+import wandb
+from lightning.pytorch.callbacks import ModelCheckpoint
+
+from radiologist.core import OnnxExportCallback
+
+INPUT_SHAPE = (1, 3, 8, 8)
+CLASSES = ["healthy", "sick"]
+CAM_TARGET_LAYER = "2"  # Dropout layer index in the lmodule fixture net
+
+
+def _real_fit_trainer(tmp_path: Path, callback: OnnxExportCallback):
+    checkpoint_callback = ModelCheckpoint(
+        dirpath=str(tmp_path / "checkpoints"),
+        monitor="val_score",
+        mode="max",
+        save_top_k=1,
+        save_last=True,
+    )
+    trainer = L.Trainer(
+        max_epochs=1,
+        limit_train_batches=2,
+        limit_val_batches=2,
+        accelerator="cpu",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        default_root_dir=str(tmp_path),
+        callbacks=[checkpoint_callback, callback],
+        logger=False,
+    )
+    return trainer
+
+
+# ---------------------------------------------------------------------------
+# AC1/AC3: active run + best checkpoint -> det+mcd logged with alias 'best'
+# and onnx files exist on disk.
+# ---------------------------------------------------------------------------
+
+
+def test_on_fit_end_logs_best_alias_artifacts_and_writes_onnx_files(
+    lmodule, dm, tmp_path
+):
+    callback = OnnxExportCallback(
+        input_shape=INPUT_SHAPE,
+        classes=CLASSES,
+        cam_target_layer=CAM_TARGET_LAYER,
+    )
+    trainer = _real_fit_trainer(tmp_path, callback)
+    fake_run = MagicMock()
+    fake_run.id = "run123"
+
+    with patch.object(wandb, "run", fake_run):
+        trainer.fit(lmodule, datamodule=dm)
+
+    assert fake_run.log_artifact.called
+    aliases_seen = [
+        call.kwargs.get("aliases") for call in fake_run.log_artifact.call_args_list
+    ]
+    assert ["best"] in aliases_seen
+
+    names_logged = [call.args[0].name for call in fake_run.log_artifact.call_args_list]
+    assert any(name.startswith(f"model-{fake_run.id}") for name in names_logged)
+    assert any(name.endswith("-mcd") for name in names_logged)
+
+
+def test_on_fit_end_writes_det_and_mcd_onnx_to_run_output_dir(lmodule, dm, tmp_path):
+    callback = OnnxExportCallback(
+        input_shape=INPUT_SHAPE,
+        classes=CLASSES,
+        cam_target_layer=CAM_TARGET_LAYER,
+    )
+    trainer = _real_fit_trainer(tmp_path, callback)
+    fake_run = MagicMock()
+    fake_run.id = "run456"
+
+    with patch.object(wandb, "run", fake_run):
+        trainer.fit(lmodule, datamodule=dm)
+
+    out_dir = Path(trainer.log_dir or trainer.default_root_dir)
+    onnx_files = list(out_dir.rglob("*.onnx"))
+    det_files = [f for f in onnx_files if not f.name.endswith("-mcd.onnx")]
+    mcd_files = [f for f in onnx_files if f.name.endswith("-mcd.onnx")]
+    assert det_files, "deterministic .onnx must exist on disk"
+    assert mcd_files, "mc-dropout .onnx must exist on disk"
+
+
+# ---------------------------------------------------------------------------
+# AC2: last checkpoint also present -> model-{run_id} logged with alias 'last'
+# ---------------------------------------------------------------------------
+
+
+def test_on_fit_end_logs_last_alias_when_last_checkpoint_exists(lmodule, dm, tmp_path):
+    callback = OnnxExportCallback(
+        input_shape=INPUT_SHAPE,
+        classes=CLASSES,
+        cam_target_layer=CAM_TARGET_LAYER,
+    )
+    trainer = _real_fit_trainer(tmp_path, callback)
+    fake_run = MagicMock()
+    fake_run.id = "run789"
+
+    with patch.object(wandb, "run", fake_run):
+        trainer.fit(lmodule, datamodule=dm)
+
+    assert trainer.checkpoint_callback.last_model_path
+    aliases_seen = [
+        call.kwargs.get("aliases") for call in fake_run.log_artifact.call_args_list
+    ]
+    assert ["last"] in aliases_seen
+
+
+# ---------------------------------------------------------------------------
+# Silent no-op: no active W&B run
+# ---------------------------------------------------------------------------
+
+
+def test_on_fit_end_noop_when_no_active_wandb_run(lmodule, dm, tmp_path):
+    callback = OnnxExportCallback(
+        input_shape=INPUT_SHAPE,
+        classes=CLASSES,
+        cam_target_layer=CAM_TARGET_LAYER,
+    )
+    trainer = L.Trainer(
+        fast_dev_run=True,
+        accelerator="cpu",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        callbacks=[callback],
+        logger=False,
+    )
+
+    with patch.object(wandb, "run", None):
+        trainer.fit(lmodule, datamodule=dm)
+
+    out_dir = Path(trainer.log_dir or trainer.default_root_dir)
+    assert list(out_dir.rglob("*.onnx")) == []
+
+
+# ---------------------------------------------------------------------------
+# Silent no-op: no best checkpoint available (no ModelCheckpoint configured)
+# ---------------------------------------------------------------------------
+
+
+def test_on_fit_end_noop_when_no_best_checkpoint_available(lmodule, dm, tmp_path):
+    callback = OnnxExportCallback(
+        input_shape=INPUT_SHAPE,
+        classes=CLASSES,
+        cam_target_layer=CAM_TARGET_LAYER,
+    )
+    trainer = L.Trainer(
+        fast_dev_run=True,
+        accelerator="cpu",
+        enable_progress_bar=False,
+        enable_model_summary=False,
+        enable_checkpointing=False,
+        callbacks=[callback],
+        logger=False,
+    )
+    fake_run = MagicMock()
+
+    with patch.object(wandb, "run", fake_run):
+        trainer.fit(lmodule, datamodule=dm)
+
+    assert not fake_run.log_artifact.called
+
+
+# ---------------------------------------------------------------------------
+# This slice never links to a collection / applies production|staging alias
+# ---------------------------------------------------------------------------
+
+
+def test_on_fit_end_never_links_artifacts_to_a_collection(lmodule, dm, tmp_path):
+    callback = OnnxExportCallback(
+        input_shape=INPUT_SHAPE,
+        classes=CLASSES,
+        cam_target_layer=CAM_TARGET_LAYER,
+    )
+    trainer = _real_fit_trainer(tmp_path, callback)
+    fake_run = MagicMock()
+    fake_run.id = "runlink"
+
+    with patch.object(wandb, "run", fake_run):
+        trainer.fit(lmodule, datamodule=dm)
+
+    assert fake_run.log_artifact.called
+    assert not fake_run.link_artifact.called

--- a/radiologist-core/tests/test_resume.py
+++ b/radiologist-core/tests/test_resume.py
@@ -1,0 +1,174 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+import torch
+from omegaconf import OmegaConf
+
+
+def _make_artifact(qualified_name: str, version: str, run_id: str) -> MagicMock:
+    art = MagicMock()
+    art.qualified_name = qualified_name
+    art.version = version
+    source_run = MagicMock()
+    source_run.id = run_id
+    art.logged_by.return_value = source_run
+    return art
+
+
+class TestResolveResumeCkptFromScratch:
+    def test_returns_none_when_all_keys_null(self) -> None:
+        from radiologist.core.resume import resolve_resume_ckpt
+
+        cfg = OmegaConf.create(
+            {"ckpt_path": None, "resume_ref": None, "resume_path": None}
+        )
+
+        assert resolve_resume_ckpt(cfg) is None
+
+
+class TestResolveResumeCkptFromLocalPath:
+    def test_returns_ckpt_path_unchanged_when_no_resume_ref(
+        self, ckpt_path: str
+    ) -> None:
+        from radiologist.core.resume import resolve_resume_ckpt
+
+        cfg = OmegaConf.create(
+            {"ckpt_path": ckpt_path, "resume_ref": None, "resume_path": None}
+        )
+
+        assert resolve_resume_ckpt(cfg) == ckpt_path
+
+
+class TestResolveResumeCkptFromWandbRef:
+    def test_resolves_and_downloads_via_wandb_registry(
+        self, tmp_path: Any, ckpt_path: str
+    ) -> None:
+        from radiologist.core.resume import resolve_resume_ckpt
+
+        art = _make_artifact("entity/project/model-run123:best", "v3", "run123")
+
+        cfg = OmegaConf.create(
+            {
+                "ckpt_path": None,
+                "resume_ref": "run123:best",
+                "resume_path": "entity/project",
+                "paths": {"output_dir": str(tmp_path)},
+            }
+        )
+
+        with patch("radiologist.registry.resolver._wandb") as mock_wandb:
+            mock_api = MagicMock()
+            mock_wandb.Api.return_value = mock_api
+            mock_api.artifact.return_value = art
+            art.download.return_value = str(tmp_path)
+
+            result = resolve_resume_ckpt(cfg)
+
+        assert result == ckpt_path
+        mock_api.artifact.assert_any_call(
+            type="model", name="entity/project/model-run123:best"
+        )
+
+    def test_raises_value_error_when_resume_path_missing(self) -> None:
+        from radiologist.core.resume import resolve_resume_ckpt
+
+        cfg = OmegaConf.create(
+            {"ckpt_path": None, "resume_ref": "run123:best", "resume_path": None}
+        )
+
+        with patch("radiologist.registry.resolver._wandb") as mock_wandb:
+            with pytest.raises(ValueError, match="resume_ref.*resume_path"):
+                resolve_resume_ckpt(cfg)
+            mock_wandb.Api.assert_not_called()
+
+    def test_raises_value_error_when_both_ckpt_path_and_resume_ref_set(
+        self, ckpt_path: str
+    ) -> None:
+        from radiologist.core.resume import resolve_resume_ckpt
+
+        cfg = OmegaConf.create(
+            {
+                "ckpt_path": ckpt_path,
+                "resume_ref": "run123:best",
+                "resume_path": "entity/project",
+            }
+        )
+
+        with patch("radiologist.registry.resolver._wandb") as mock_wandb:
+            with pytest.raises(ValueError, match="ckpt_path.*resume_ref"):
+                resolve_resume_ckpt(cfg)
+            mock_wandb.Api.assert_not_called()
+
+    @pytest.mark.parametrize(
+        "resume_ref",
+        [
+            "run123best",
+            "run123:",
+            ":best",
+            "run123:best:extra",
+        ],
+    )
+    def test_raises_value_error_for_malformed_resume_ref(self, resume_ref: str) -> None:
+        from radiologist.core.resume import resolve_resume_ckpt
+
+        cfg = OmegaConf.create(
+            {
+                "ckpt_path": None,
+                "resume_ref": resume_ref,
+                "resume_path": "entity/project",
+            }
+        )
+
+        with patch("radiologist.registry.resolver._wandb") as mock_wandb:
+            with pytest.raises(ValueError):
+                resolve_resume_ckpt(cfg)
+            mock_wandb.Api.assert_not_called()
+
+
+class TestRestorePrecision:
+    def test_restores_precision_from_checkpoint(self, ckpt_path: str) -> None:
+        from radiologist.core.resume import restore_precision
+
+        cfg = OmegaConf.create({"trainer": {"precision": 32}})
+
+        restore_precision(cfg, ckpt_path)
+
+        stored = torch.load(ckpt_path, weights_only=False)
+        assert cfg.trainer.precision == stored["precision"]
+
+    def test_is_noop_when_checkpoint_has_no_precision_entry(
+        self, tmp_path: Any, lmodule: Any
+    ) -> None:
+        from radiologist.core.resume import restore_precision
+
+        path = str(tmp_path / "no_precision.ckpt")
+        torch.save({"state_dict": lmodule.state_dict()}, path)
+
+        cfg = OmegaConf.create({"trainer": {"precision": 32}})
+
+        restore_precision(cfg, path)
+
+        assert cfg.trainer.precision == 32

--- a/radiologist-core/tests/test_resume_onnx_skeleton_contract.py
+++ b/radiologist-core/tests/test_resume_onnx_skeleton_contract.py
@@ -45,22 +45,6 @@ def test_onnx_export_callback_init_raises_not_implemented():
         )
 
 
-def test_resolve_resume_ckpt_raises_not_implemented():
-    from radiologist.core.resume import resolve_resume_ckpt
-
-    cfg = OmegaConf.create({"ckpt_path": None, "resume_ref": None, "resume_path": None})
-    with pytest.raises(NotImplementedError):
-        resolve_resume_ckpt(cfg)
-
-
-def test_restore_precision_raises_not_implemented(ckpt_path):
-    from radiologist.core.resume import restore_precision
-
-    cfg = OmegaConf.create({"trainer": {"precision": 32}})
-    with pytest.raises(NotImplementedError):
-        restore_precision(cfg, ckpt_path)
-
-
 def test_train_yaml_declares_resume_ref_and_resume_path_null():
     cfg = OmegaConf.load(_CONFIGS_DIR / "train.yaml")
     assert cfg.resume_ref is None

--- a/radiologist-core/tests/test_resume_onnx_skeleton_contract.py
+++ b/radiologist-core/tests/test_resume_onnx_skeleton_contract.py
@@ -1,0 +1,81 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+_CONFIGS_DIR = Path(__file__).parent.parent / "src" / "radiologist" / "core" / "configs"
+
+
+def test_onnx_export_callback_importable_from_public_api():
+    from radiologist.core import OnnxExportCallback
+
+    assert OnnxExportCallback is not None
+
+
+def test_onnx_export_callback_init_raises_not_implemented():
+    from radiologist.core import OnnxExportCallback
+
+    with pytest.raises(NotImplementedError):
+        OnnxExportCallback(
+            input_shape=(1, 3, 224, 224),
+            classes=["normal", "abnormal"],
+            cam_target_layer="layer4",
+        )
+
+
+def test_resolve_resume_ckpt_raises_not_implemented():
+    from radiologist.core.resume import resolve_resume_ckpt
+
+    cfg = OmegaConf.create({"ckpt_path": None, "resume_ref": None, "resume_path": None})
+    with pytest.raises(NotImplementedError):
+        resolve_resume_ckpt(cfg)
+
+
+def test_restore_precision_raises_not_implemented(ckpt_path):
+    from radiologist.core.resume import restore_precision
+
+    cfg = OmegaConf.create({"trainer": {"precision": 32}})
+    with pytest.raises(NotImplementedError):
+        restore_precision(cfg, ckpt_path)
+
+
+def test_train_yaml_declares_resume_ref_and_resume_path_null():
+    cfg = OmegaConf.load(_CONFIGS_DIR / "train.yaml")
+    assert cfg.resume_ref is None
+    assert cfg.resume_path is None
+    assert cfg.ckpt_path is None
+
+
+def test_onnx_export_config_exists_and_not_wired_into_default_callbacks():
+    onnx_export_yaml = _CONFIGS_DIR / "callbacks" / "onnx_export.yaml"
+    default_yaml = _CONFIGS_DIR / "callbacks" / "default.yaml"
+
+    assert onnx_export_yaml.exists()
+
+    cfg = OmegaConf.load(onnx_export_yaml)
+    assert cfg.onnx_export._target_ == "radiologist.core.OnnxExportCallback"
+    assert cfg.onnx_export.opset == 18
+
+    assert "onnx_export" not in default_yaml.read_text()

--- a/radiologist-core/tests/test_resume_onnx_skeleton_contract.py
+++ b/radiologist-core/tests/test_resume_onnx_skeleton_contract.py
@@ -22,7 +22,6 @@
 
 from pathlib import Path
 
-import pytest
 from omegaconf import OmegaConf
 
 _CONFIGS_DIR = Path(__file__).parent.parent / "src" / "radiologist" / "core" / "configs"
@@ -32,17 +31,6 @@ def test_onnx_export_callback_importable_from_public_api():
     from radiologist.core import OnnxExportCallback
 
     assert OnnxExportCallback is not None
-
-
-def test_onnx_export_callback_init_raises_not_implemented():
-    from radiologist.core import OnnxExportCallback
-
-    with pytest.raises(NotImplementedError):
-        OnnxExportCallback(
-            input_shape=(1, 3, 224, 224),
-            classes=["normal", "abnormal"],
-            cam_target_layer="layer4",
-        )
 
 
 def test_train_yaml_declares_resume_ref_and_resume_path_null():

--- a/radiologist-registry/src/radiologist/registry/__init__.py
+++ b/radiologist-registry/src/radiologist/registry/__init__.py
@@ -31,11 +31,11 @@ from radiologist.registry.models import (
 from radiologist.registry.wandb_registry import WandbRegistry
 
 __all__ = [
-    "ModelRegistry",
     "ArtifactRef",
+    "CollectionMember",
     "ExportResult",
+    "LoggedArtifacts",
+    "ModelRegistry",
     "PromoteResult",
     "WandbRegistry",
-    "LoggedArtifacts",
-    "CollectionMember",
 ]

--- a/radiologist-registry/src/radiologist/registry/__init__.py
+++ b/radiologist-registry/src/radiologist/registry/__init__.py
@@ -21,7 +21,13 @@
 # SOFTWARE.
 
 from radiologist.registry.interface import ModelRegistry
-from radiologist.registry.models import ArtifactRef, ExportResult, PromoteResult
+from radiologist.registry.models import (
+    ArtifactRef,
+    CollectionMember,
+    ExportResult,
+    LoggedArtifacts,
+    PromoteResult,
+)
 from radiologist.registry.wandb_registry import WandbRegistry
 
 __all__ = [
@@ -30,4 +36,6 @@ __all__ = [
     "ExportResult",
     "PromoteResult",
     "WandbRegistry",
+    "LoggedArtifacts",
+    "CollectionMember",
 ]

--- a/radiologist-registry/src/radiologist/registry/collection.py
+++ b/radiologist-registry/src/radiologist/registry/collection.py
@@ -20,22 +20,18 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from radiologist.core.callbacks import (
-    AttributionCallback,
-    BestMetricCallback,
-    OnnxExportCallback,
-    WandbDefineSummaryCallback,
-)
-from radiologist.core.data import WebDatasetDataModule
-from radiologist.core.losses import FocalLoss
-from radiologist.core.module import LModule
+from typing import List
 
-__all__ = [
-    "AttributionCallback",
-    "BestMetricCallback",
-    "FocalLoss",
-    "LModule",
-    "OnnxExportCallback",
-    "WandbDefineSummaryCallback",
-    "WebDatasetDataModule",
-]
+from radiologist.registry.models import CollectionMember
+from radiologist.registry.optional import _guard_wandb, _wandb  # noqa: F401
+
+
+class _WandbCollectionLister:
+    """W&B seam for listing the members (and aliases) of a registry collection."""
+
+    def list_collection_artifacts(
+        self,
+        type_name: str,
+        collection_name: str,
+    ) -> List[CollectionMember]:
+        raise NotImplementedError

--- a/radiologist-registry/src/radiologist/registry/collection.py
+++ b/radiologist-registry/src/radiologist/registry/collection.py
@@ -34,4 +34,12 @@ class _WandbCollectionLister:
         type_name: str,
         collection_name: str,
     ) -> List[CollectionMember]:
-        raise NotImplementedError
+        _guard_wandb()
+        api = _wandb.Api()  # type: ignore[union-attr]
+        collection = api.artifact_collection(type_name, collection_name)
+        return [
+            CollectionMember(
+                qualified_name=art.qualified_name, aliases=list(art.aliases)
+            )
+            for art in collection.artifacts()
+        ]

--- a/radiologist-registry/src/radiologist/registry/interface.py
+++ b/radiologist-registry/src/radiologist/registry/interface.py
@@ -20,9 +20,15 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List, Optional, Protocol, Union
+from typing import Any, List, Optional, Protocol, Union
 
-from radiologist.registry.models import ArtifactRef, ExportResult, PromoteResult
+from radiologist.registry.models import (
+    ArtifactRef,
+    CollectionMember,
+    ExportResult,
+    LoggedArtifacts,
+    PromoteResult,
+)
 
 
 class ModelRegistry(Protocol):
@@ -43,11 +49,32 @@ class ModelRegistry(Protocol):
 
     def pull(self, artifact_path: str, local_dir: str) -> str: ...
 
-    def promote(
+    def log_model_artifacts(
         self,
         export_result: ExportResult,
-        collection: str,
-        alias: str,
+        run: Any,
+        ckpt_path: str,
+        last_ckpt_path: Optional[str] = None,
+    ) -> LoggedArtifacts: ...
+
+    def list_collection_artifacts(
+        self,
+        type_name: str,
+        collection_name: str,
+    ) -> List[CollectionMember]: ...
+
+    def promote(
+        self,
+        path: str,
+        run_id: str,
+        det_collection: str,
+        mcd_collection: str,
+    ) -> PromoteResult: ...
+
+    def transition_to_production(
+        self,
+        det_collection: str,
+        mcd_collection: str,
     ) -> PromoteResult: ...
 
     def get_aliases(self, artifact_path: str) -> List[str]: ...

--- a/radiologist-registry/src/radiologist/registry/models.py
+++ b/radiologist-registry/src/radiologist/registry/models.py
@@ -47,7 +47,29 @@ class ExportResult:
 
 @dataclass(frozen=True)
 class PromoteResult:
-    """Artifact qualified names after upload — output of WandbRegistry.promote()."""
+    """Result of a link/transition transaction — det+mcd always share one alias."""
 
     det_qualified_name: str
     mcd_qualified_name: str
+    alias: str
+
+
+@dataclass(frozen=True)
+class LoggedArtifacts:
+    """Qualified names of the artifacts logged to the active run by the export callback.
+
+    These are logged-but-not-linked: resolvable by run_id, carrying version aliases
+    ('best'/'last'), but not yet attached to any registry collection.
+    """
+
+    det_qualified_name: str
+    mcd_qualified_name: str
+    run_id: str
+
+
+@dataclass(frozen=True)
+class CollectionMember:
+    """One artifact version in a W&B collection together with its current alias list."""
+
+    qualified_name: str
+    aliases: List[str]

--- a/radiologist-registry/src/radiologist/registry/models.py
+++ b/radiologist-registry/src/radiologist/registry/models.py
@@ -36,7 +36,10 @@ class ArtifactRef:
 
 @dataclass(frozen=True)
 class ExportResult:
-    """Paths to exported ONNX files — produced by core.export_onnx(), consumed by WandbRegistry.promote()."""
+    """Paths to exported ONNX files — produced by core.export_onnx().
+
+    Consumed by WandbRegistry.log_model_artifacts().
+    """
 
     det_path: str
     mcd_path: str

--- a/radiologist-registry/src/radiologist/registry/optional.py
+++ b/radiologist-registry/src/radiologist/registry/optional.py
@@ -30,6 +30,8 @@ _WANDB_MISSING_MSG = (
     "Install with: pip install 'radiologist-registry[wandb]'"
 )
 
+_MODEL_ARTIFACT_TYPE = "model"
+
 
 def _guard_wandb() -> None:
     if _wandb is None:

--- a/radiologist-registry/src/radiologist/registry/uploader.py
+++ b/radiologist-registry/src/radiologist/registry/uploader.py
@@ -24,7 +24,11 @@ from typing import Any, Optional
 
 from radiologist.registry.alias_manager import _WandbAliasManager
 from radiologist.registry.models import ExportResult, LoggedArtifacts, PromoteResult
-from radiologist.registry.optional import _guard_wandb, _wandb  # noqa: F401
+from radiologist.registry.optional import (  # noqa: F401
+    _MODEL_ARTIFACT_TYPE,
+    _guard_wandb,
+    _wandb,
+)
 
 
 class _WandbUploader:
@@ -45,17 +49,23 @@ class _WandbUploader:
         det_name = f"model-{run_id}"
         mcd_name = f"model-{run_id}-mcd"
 
-        det_art = _wandb.Artifact(det_name, type="model")  # type: ignore[union-attr]
+        det_art = _wandb.Artifact(  # type: ignore[union-attr]
+            det_name, type=_MODEL_ARTIFACT_TYPE
+        )
         det_art.add_file(export_result.det_path)
         det_art.add_file(ckpt_path)
         run.log_artifact(det_art, aliases=["best"])
 
-        mcd_art = _wandb.Artifact(mcd_name, type="model")  # type: ignore[union-attr]
+        mcd_art = _wandb.Artifact(  # type: ignore[union-attr]
+            mcd_name, type=_MODEL_ARTIFACT_TYPE
+        )
         mcd_art.add_file(export_result.mcd_path)
         run.log_artifact(mcd_art, aliases=["best"])
 
         if last_ckpt_path:
-            last_art = _wandb.Artifact(det_name, type="model")  # type: ignore[union-attr]
+            last_art = _wandb.Artifact(  # type: ignore[union-attr]
+                det_name, type=_MODEL_ARTIFACT_TYPE
+            )
             last_art.add_file(last_ckpt_path)
             run.log_artifact(last_art, aliases=["last"])
 

--- a/radiologist-registry/src/radiologist/registry/uploader.py
+++ b/radiologist-registry/src/radiologist/registry/uploader.py
@@ -71,4 +71,17 @@ class _WandbUploader:
         mcd_collection: str,
         alias: str,
     ) -> PromoteResult:
-        raise NotImplementedError
+        _guard_wandb()
+        api = _wandb.Api()  # type: ignore[union-attr]
+
+        det_art = api.artifact(det_qualified_name)
+        det_art.link(det_collection, aliases=[alias])
+
+        mcd_art = api.artifact(mcd_qualified_name)
+        mcd_art.link(mcd_collection, aliases=[alias])
+
+        return PromoteResult(
+            det_qualified_name=det_qualified_name,
+            mcd_qualified_name=mcd_qualified_name,
+            alias=alias,
+        )

--- a/radiologist-registry/src/radiologist/registry/uploader.py
+++ b/radiologist-registry/src/radiologist/registry/uploader.py
@@ -22,12 +22,16 @@
 
 from typing import Any, Optional
 
+from radiologist.registry.alias_manager import _WandbAliasManager
 from radiologist.registry.models import ExportResult, LoggedArtifacts, PromoteResult
 from radiologist.registry.optional import _guard_wandb, _wandb  # noqa: F401
 
 
 class _WandbUploader:
     """W&B seam for artifact upload operations."""
+
+    def __init__(self) -> None:
+        self._alias_manager = _WandbAliasManager()
 
     def log_model_artifacts(
         self,
@@ -77,8 +81,15 @@ class _WandbUploader:
         det_art = api.artifact(det_qualified_name)
         det_art.link(det_collection, aliases=[alias])
 
-        mcd_art = api.artifact(mcd_qualified_name)
-        mcd_art.link(mcd_collection, aliases=[alias])
+        try:
+            mcd_art = api.artifact(mcd_qualified_name)
+            mcd_art.link(mcd_collection, aliases=[alias])
+        except Exception:
+            try:
+                self._alias_manager.remove_alias(det_qualified_name, alias)
+            except Exception:
+                pass
+            raise
 
         return PromoteResult(
             det_qualified_name=det_qualified_name,

--- a/radiologist-registry/src/radiologist/registry/uploader.py
+++ b/radiologist-registry/src/radiologist/registry/uploader.py
@@ -36,7 +36,32 @@ class _WandbUploader:
         ckpt_path: str,
         last_ckpt_path: Optional[str] = None,
     ) -> LoggedArtifacts:
-        raise NotImplementedError
+        _guard_wandb()
+        run_id = export_result.run_id
+        det_name = f"model-{run_id}"
+        mcd_name = f"model-{run_id}-mcd"
+
+        det_art = _wandb.Artifact(det_name, type="model")  # type: ignore[union-attr]
+        det_art.add_file(export_result.det_path)
+        det_art.add_file(ckpt_path)
+        run.log_artifact(det_art, aliases=["best"])
+
+        mcd_art = _wandb.Artifact(mcd_name, type="model")  # type: ignore[union-attr]
+        mcd_art.add_file(export_result.mcd_path)
+        run.log_artifact(mcd_art, aliases=["best"])
+
+        if last_ckpt_path:
+            last_art = _wandb.Artifact(det_name, type="model")  # type: ignore[union-attr]
+            last_art.add_file(last_ckpt_path)
+            run.log_artifact(last_art, aliases=["last"])
+
+        entity = getattr(run, "entity", "")
+        project = getattr(run, "project", "")
+        return LoggedArtifacts(
+            det_qualified_name=f"{entity}/{project}/{det_name}:best",
+            mcd_qualified_name=f"{entity}/{project}/{mcd_name}:best",
+            run_id=run_id,
+        )
 
     def link_to_collection(
         self,

--- a/radiologist-registry/src/radiologist/registry/uploader.py
+++ b/radiologist-registry/src/radiologist/registry/uploader.py
@@ -20,37 +20,30 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from radiologist.registry.models import ExportResult, PromoteResult
-from radiologist.registry.optional import _guard_wandb, _wandb
+from typing import Any, Optional
+
+from radiologist.registry.models import ExportResult, LoggedArtifacts, PromoteResult
+from radiologist.registry.optional import _guard_wandb, _wandb  # noqa: F401
 
 
 class _WandbUploader:
     """W&B seam for artifact upload operations."""
 
-    def promote(
+    def log_model_artifacts(
         self,
         export_result: ExportResult,
-        collection: str,
+        run: Any,
+        ckpt_path: str,
+        last_ckpt_path: Optional[str] = None,
+    ) -> LoggedArtifacts:
+        raise NotImplementedError
+
+    def link_to_collection(
+        self,
+        det_qualified_name: str,
+        mcd_qualified_name: str,
+        det_collection: str,
+        mcd_collection: str,
         alias: str,
     ) -> PromoteResult:
-        _guard_wandb()
-        run = _wandb.init(job_type="registry-promote")  # type: ignore[union-attr]
-        try:
-            run_id = export_result.run_id
-
-            det_art = _wandb.Artifact(f"model-{run_id}", type="model")  # type: ignore[union-attr]
-            det_art.add_file(export_result.det_path)
-            run.log_artifact(det_art)
-            det_linked = run.link_artifact(det_art, collection, aliases=[alias])
-
-            mcd_art = _wandb.Artifact(f"model-{run_id}-mcd", type="model")  # type: ignore[union-attr]
-            mcd_art.add_file(export_result.mcd_path)
-            run.log_artifact(mcd_art)
-            mcd_linked = run.link_artifact(mcd_art, collection, aliases=[alias])
-
-            return PromoteResult(
-                det_qualified_name=det_linked.qualified_name,
-                mcd_qualified_name=mcd_linked.qualified_name,
-            )
-        finally:
-            run.finish()
+        raise NotImplementedError

--- a/radiologist-registry/src/radiologist/registry/wandb_registry.py
+++ b/radiologist-registry/src/radiologist/registry/wandb_registry.py
@@ -20,21 +20,29 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from typing import List, Optional, Union
+from typing import Any, List, Optional, Union
 
 from radiologist.registry.alias_manager import _WandbAliasManager
-from radiologist.registry.models import ArtifactRef, ExportResult, PromoteResult
+from radiologist.registry.collection import _WandbCollectionLister
+from radiologist.registry.models import (
+    ArtifactRef,
+    CollectionMember,
+    ExportResult,
+    LoggedArtifacts,
+    PromoteResult,
+)
 from radiologist.registry.resolver import _WandbResolver
 from radiologist.registry.uploader import _WandbUploader
 
 
 class WandbRegistry:
-    """Facade implementing the ModelRegistry Protocol by composing three W&B seams."""
+    """Facade implementing the ModelRegistry Protocol by composing four W&B seams."""
 
     def __init__(self) -> None:
         self._resolver = _WandbResolver()
         self._uploader = _WandbUploader()
         self._alias_manager = _WandbAliasManager()
+        self._lister = _WandbCollectionLister()
 
     def resolve(
         self,
@@ -62,13 +70,39 @@ class WandbRegistry:
     def pull(self, artifact_path: str, local_dir: str) -> str:
         return self._resolver.pull(artifact_path, local_dir)
 
-    def promote(
+    def log_model_artifacts(
         self,
         export_result: ExportResult,
-        collection: str,
-        alias: str,
+        run: Any,
+        ckpt_path: str,
+        last_ckpt_path: Optional[str] = None,
+    ) -> LoggedArtifacts:
+        return self._uploader.log_model_artifacts(
+            export_result, run, ckpt_path, last_ckpt_path
+        )
+
+    def list_collection_artifacts(
+        self,
+        type_name: str,
+        collection_name: str,
+    ) -> List[CollectionMember]:
+        return self._lister.list_collection_artifacts(type_name, collection_name)
+
+    def promote(
+        self,
+        path: str,
+        run_id: str,
+        det_collection: str,
+        mcd_collection: str,
     ) -> PromoteResult:
-        return self._uploader.promote(export_result, collection, alias)
+        raise NotImplementedError
+
+    def transition_to_production(
+        self,
+        det_collection: str,
+        mcd_collection: str,
+    ) -> PromoteResult:
+        raise NotImplementedError
 
     def get_aliases(self, artifact_path: str) -> List[str]:
         return self._alias_manager.get_aliases(artifact_path)

--- a/radiologist-registry/src/radiologist/registry/wandb_registry.py
+++ b/radiologist-registry/src/radiologist/registry/wandb_registry.py
@@ -31,8 +31,15 @@ from radiologist.registry.models import (
     LoggedArtifacts,
     PromoteResult,
 )
+from radiologist.registry.optional import _MODEL_ARTIFACT_TYPE
 from radiologist.registry.resolver import _WandbResolver
 from radiologist.registry.uploader import _WandbUploader
+
+
+def _find_by_alias(
+    members: List[CollectionMember], alias: str
+) -> Optional[CollectionMember]:
+    return next((m for m in members if alias in m.aliases), None)
 
 
 class WandbRegistry:
@@ -98,8 +105,12 @@ class WandbRegistry:
         det_ref = self._resolver.resolve(path, run_id=run_id, version="best")
         mcd_ref = self._resolver.resolve(path, run_id=f"{run_id}-mcd", version="best")
 
-        det_members = self._lister.list_collection_artifacts("model", det_collection)
-        mcd_members = self._lister.list_collection_artifacts("model", mcd_collection)
+        det_members = self._lister.list_collection_artifacts(
+            _MODEL_ARTIFACT_TYPE, det_collection
+        )
+        mcd_members = self._lister.list_collection_artifacts(
+            _MODEL_ARTIFACT_TYPE, mcd_collection
+        )
         has_production = any(
             "production" in m.aliases for m in (*det_members, *mcd_members)
         )
@@ -118,23 +129,23 @@ class WandbRegistry:
         det_collection: str,
         mcd_collection: str,
     ) -> PromoteResult:
-        det_members = self._lister.list_collection_artifacts("model", det_collection)
-        mcd_members = self._lister.list_collection_artifacts("model", mcd_collection)
+        det_members = self._lister.list_collection_artifacts(
+            _MODEL_ARTIFACT_TYPE, det_collection
+        )
+        mcd_members = self._lister.list_collection_artifacts(
+            _MODEL_ARTIFACT_TYPE, mcd_collection
+        )
 
-        det_staging = next((m for m in det_members if "staging" in m.aliases), None)
-        mcd_staging = next((m for m in mcd_members if "staging" in m.aliases), None)
+        det_staging = _find_by_alias(det_members, "staging")
+        mcd_staging = _find_by_alias(mcd_members, "staging")
         if det_staging is None or mcd_staging is None:
             raise LookupError(
                 "No 'staging' member found in one or both collections: "
                 f"{det_collection!r}, {mcd_collection!r}"
             )
 
-        det_production = next(
-            (m for m in det_members if "production" in m.aliases), None
-        )
-        mcd_production = next(
-            (m for m in mcd_members if "production" in m.aliases), None
-        )
+        det_production = _find_by_alias(det_members, "production")
+        mcd_production = _find_by_alias(mcd_members, "production")
 
         if det_production is not None:
             self._alias_manager.remove_alias(

--- a/radiologist-registry/src/radiologist/registry/wandb_registry.py
+++ b/radiologist-registry/src/radiologist/registry/wandb_registry.py
@@ -95,14 +95,61 @@ class WandbRegistry:
         det_collection: str,
         mcd_collection: str,
     ) -> PromoteResult:
-        raise NotImplementedError
+        det_ref = self._resolver.resolve(path, run_id=run_id, version="best")
+        mcd_ref = self._resolver.resolve(path, run_id=f"{run_id}-mcd", version="best")
+
+        members = self._lister.list_collection_artifacts("model", det_collection)
+        has_production = any("production" in m.aliases for m in members)
+        alias = "staging" if has_production else "production"
+
+        return self._uploader.link_to_collection(
+            det_ref.qualified_name,
+            mcd_ref.qualified_name,
+            det_collection,
+            mcd_collection,
+            alias,
+        )
 
     def transition_to_production(
         self,
         det_collection: str,
         mcd_collection: str,
     ) -> PromoteResult:
-        raise NotImplementedError
+        det_members = self._lister.list_collection_artifacts("model", det_collection)
+        mcd_members = self._lister.list_collection_artifacts("model", mcd_collection)
+
+        det_staging = next((m for m in det_members if "staging" in m.aliases), None)
+        mcd_staging = next((m for m in mcd_members if "staging" in m.aliases), None)
+        if det_staging is None or mcd_staging is None:
+            raise LookupError(
+                "No 'staging' member found in one or both collections: "
+                f"{det_collection!r}, {mcd_collection!r}"
+            )
+
+        det_production = next(
+            (m for m in det_members if "production" in m.aliases), None
+        )
+        mcd_production = next(
+            (m for m in mcd_members if "production" in m.aliases), None
+        )
+
+        if det_production is not None:
+            self._alias_manager.remove_alias(
+                det_production.qualified_name, "production"
+            )
+        self._alias_manager.set_alias(det_staging.qualified_name, "production")
+
+        if mcd_production is not None:
+            self._alias_manager.remove_alias(
+                mcd_production.qualified_name, "production"
+            )
+        self._alias_manager.set_alias(mcd_staging.qualified_name, "production")
+
+        return PromoteResult(
+            det_qualified_name=det_staging.qualified_name,
+            mcd_qualified_name=mcd_staging.qualified_name,
+            alias="production",
+        )
 
     def get_aliases(self, artifact_path: str) -> List[str]:
         return self._alias_manager.get_aliases(artifact_path)

--- a/radiologist-registry/src/radiologist/registry/wandb_registry.py
+++ b/radiologist-registry/src/radiologist/registry/wandb_registry.py
@@ -98,8 +98,11 @@ class WandbRegistry:
         det_ref = self._resolver.resolve(path, run_id=run_id, version="best")
         mcd_ref = self._resolver.resolve(path, run_id=f"{run_id}-mcd", version="best")
 
-        members = self._lister.list_collection_artifacts("model", det_collection)
-        has_production = any("production" in m.aliases for m in members)
+        det_members = self._lister.list_collection_artifacts("model", det_collection)
+        mcd_members = self._lister.list_collection_artifacts("model", mcd_collection)
+        has_production = any(
+            "production" in m.aliases for m in (*det_members, *mcd_members)
+        )
         alias = "staging" if has_production else "production"
 
         return self._uploader.link_to_collection(
@@ -139,11 +142,24 @@ class WandbRegistry:
             )
         self._alias_manager.set_alias(det_staging.qualified_name, "production")
 
-        if mcd_production is not None:
-            self._alias_manager.remove_alias(
-                mcd_production.qualified_name, "production"
-            )
-        self._alias_manager.set_alias(mcd_staging.qualified_name, "production")
+        try:
+            if mcd_production is not None:
+                self._alias_manager.remove_alias(
+                    mcd_production.qualified_name, "production"
+                )
+            self._alias_manager.set_alias(mcd_staging.qualified_name, "production")
+        except Exception:
+            try:
+                self._alias_manager.remove_alias(
+                    det_staging.qualified_name, "production"
+                )
+                if det_production is not None:
+                    self._alias_manager.set_alias(
+                        det_production.qualified_name, "production"
+                    )
+            except Exception:
+                pass
+            raise
 
         return PromoteResult(
             det_qualified_name=det_staging.qualified_name,

--- a/radiologist-registry/tests/test_artifact_promotion.py
+++ b/radiologist-registry/tests/test_artifact_promotion.py
@@ -184,6 +184,65 @@ class TestUploaderLinkToCollection:
         assert result.alias == "production"
 
 
+class TestUploaderLinkToCollectionRollback:
+    def test_reverts_det_link_alias_when_mcd_link_raises(self):
+        det_art = _make_artifact("entity/project/model-abc123:best", ["best"])
+        mcd_art = _make_artifact("entity/project/model-abc123-mcd:best", ["best"])
+        mcd_art.link.side_effect = RuntimeError("transient network error")
+        with (
+            patch("radiologist.registry.uploader._wandb") as mock_wandb,
+            patch("radiologist.registry.alias_manager._wandb") as alias_wandb,
+        ):
+            mock_api = MagicMock()
+            mock_wandb.Api.return_value = mock_api
+            mock_api.artifact.side_effect = [det_art, mcd_art]
+
+            alias_api = MagicMock()
+            alias_wandb.Api.return_value = alias_api
+            det_art.aliases.append("production")
+            alias_api.artifact.return_value = det_art
+
+            from radiologist.registry.uploader import _WandbUploader
+
+            with pytest.raises(RuntimeError, match="transient network error"):
+                _WandbUploader().link_to_collection(
+                    det_art.qualified_name,
+                    mcd_art.qualified_name,
+                    "det-collection",
+                    "mcd-collection",
+                    "production",
+                )
+
+        alias_api.artifact.assert_called_once_with(det_art.qualified_name)
+        assert "production" not in det_art.aliases
+        det_art.save.assert_called_once()
+
+    def test_revert_failure_does_not_swallow_original_exception(self):
+        det_art = _make_artifact("entity/project/model-abc123:best", ["best"])
+        mcd_art = _make_artifact("entity/project/model-abc123-mcd:best", ["best"])
+        mcd_art.link.side_effect = RuntimeError("original failure")
+        with (
+            patch("radiologist.registry.uploader._wandb") as mock_wandb,
+            patch("radiologist.registry.alias_manager._wandb") as alias_wandb,
+        ):
+            mock_api = MagicMock()
+            mock_wandb.Api.return_value = mock_api
+            mock_api.artifact.side_effect = [det_art, mcd_art]
+
+            alias_wandb.Api.side_effect = RuntimeError("revert also fails")
+
+            from radiologist.registry.uploader import _WandbUploader
+
+            with pytest.raises(RuntimeError, match="original failure"):
+                _WandbUploader().link_to_collection(
+                    det_art.qualified_name,
+                    mcd_art.qualified_name,
+                    "det-collection",
+                    "mcd-collection",
+                    "production",
+                )
+
+
 class TestWandbRegistryPromote:
     def test_applies_production_when_collection_has_no_production_member(self):
         det_art = _make_artifact("entity/project/model-abc123:best", ["best"])
@@ -236,6 +295,45 @@ class TestWandbRegistryPromote:
             det_collection_obj = MagicMock()
             det_collection_obj.artifacts.return_value = [existing_production]
             collection_api.artifact_collection.return_value = det_collection_obj
+
+            uploader_api = MagicMock()
+            uploader_wandb.Api.return_value = uploader_api
+            uploader_api.artifact.side_effect = [det_art, mcd_art]
+
+            registry = WandbRegistry()
+            result = registry.promote(
+                "entity/project", "abc123", "det-collection", "mcd-collection"
+            )
+
+        det_art.link.assert_called_once_with("det-collection", aliases=["staging"])
+        mcd_art.link.assert_called_once_with("mcd-collection", aliases=["staging"])
+        assert result.alias == "staging"
+
+    def test_applies_staging_when_only_mcd_collection_has_production_member(self):
+        det_art = _make_artifact("entity/project/model-abc123:best", ["best"])
+        mcd_art = _make_artifact("entity/project/model-abc123-mcd:best", ["best"])
+        with (
+            patch("radiologist.registry.resolver._wandb") as resolver_wandb,
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.uploader._wandb") as uploader_wandb,
+        ):
+            resolver_api = MagicMock()
+            resolver_wandb.Api.return_value = resolver_api
+            resolver_api.artifact.side_effect = [det_art, mcd_art]
+
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = []
+            existing_production = _make_artifact(
+                "entity/project/model-xyz-mcd:v0", ["production"]
+            )
+            mcd_collection_obj = MagicMock()
+            mcd_collection_obj.artifacts.return_value = [existing_production]
+            collection_api.artifact_collection.side_effect = [
+                det_collection_obj,
+                mcd_collection_obj,
+            ]
 
             uploader_api = MagicMock()
             uploader_wandb.Api.return_value = uploader_api
@@ -348,3 +446,73 @@ class TestWandbRegistryTransitionToProduction:
 
         alias_wandb.Api.assert_not_called()
         assert "production" in det_production.aliases
+
+    def test_reverts_det_alias_state_when_mcd_alias_change_raises(self):
+        det_staging = _make_artifact("entity/project/model-a:v0", ["staging"])
+        det_production = _make_artifact("entity/project/model-b:v0", ["production"])
+        mcd_staging = _make_artifact("entity/project/model-c-mcd:v0", ["staging"])
+        mcd_production = _make_artifact("entity/project/model-d-mcd:v0", ["production"])
+        with (
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.alias_manager._wandb") as alias_wandb,
+        ):
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = [det_staging, det_production]
+            mcd_collection_obj = MagicMock()
+            mcd_collection_obj.artifacts.return_value = [mcd_staging, mcd_production]
+            collection_api.artifact_collection.side_effect = [
+                det_collection_obj,
+                mcd_collection_obj,
+            ]
+
+            alias_api = MagicMock()
+            alias_wandb.Api.return_value = alias_api
+            alias_api.artifact.side_effect = [
+                det_production,
+                det_staging,
+                RuntimeError("mcd alias change failed"),
+                det_staging,
+                det_production,
+            ]
+
+            registry = WandbRegistry()
+            with pytest.raises(RuntimeError, match="mcd alias change failed"):
+                registry.transition_to_production("det-collection", "mcd-collection")
+
+        assert "production" in det_production.aliases
+        assert "production" not in det_staging.aliases
+
+    def test_revert_failure_does_not_swallow_original_transition_exception(self):
+        det_staging = _make_artifact("entity/project/model-a:v0", ["staging"])
+        det_production = _make_artifact("entity/project/model-b:v0", ["production"])
+        mcd_staging = _make_artifact("entity/project/model-c-mcd:v0", ["staging"])
+        mcd_production = _make_artifact("entity/project/model-d-mcd:v0", ["production"])
+        with (
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.alias_manager._wandb") as alias_wandb,
+        ):
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = [det_staging, det_production]
+            mcd_collection_obj = MagicMock()
+            mcd_collection_obj.artifacts.return_value = [mcd_staging, mcd_production]
+            collection_api.artifact_collection.side_effect = [
+                det_collection_obj,
+                mcd_collection_obj,
+            ]
+
+            alias_api = MagicMock()
+            alias_wandb.Api.return_value = alias_api
+            alias_api.artifact.side_effect = [
+                det_production,
+                det_staging,
+                RuntimeError("original mcd failure"),
+                RuntimeError("revert also fails"),
+            ]
+
+            registry = WandbRegistry()
+            with pytest.raises(RuntimeError, match="original mcd failure"):
+                registry.transition_to_production("det-collection", "mcd-collection")

--- a/radiologist-registry/tests/test_artifact_promotion.py
+++ b/radiologist-registry/tests/test_artifact_promotion.py
@@ -43,15 +43,112 @@ def export_result(tmp_path):
     )
 
 
-class TestUploaderStubContract:
-    def test_log_model_artifacts_raises_not_implemented(self, export_result):
+class TestUploaderLogModelArtifacts:
+    def test_logs_det_and_mcd_artifacts_with_best_alias(self, export_result, tmp_path):
         from radiologist.registry.uploader import _WandbUploader
 
-        with pytest.raises(NotImplementedError):
-            _WandbUploader().log_model_artifacts(
-                export_result, MagicMock(), "best.ckpt"
-            )
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.write_bytes(b"ckpt")
+        fake_run = MagicMock()
 
+        _WandbUploader().log_model_artifacts(export_result, fake_run, str(ckpt))
+
+        aliases_seen = [
+            call.kwargs.get("aliases") for call in fake_run.log_artifact.call_args_list
+        ]
+        assert aliases_seen.count(["best"]) == 2
+
+        names_logged = [
+            call.args[0].name for call in fake_run.log_artifact.call_args_list
+        ]
+        assert f"model-{export_result.run_id}" in names_logged
+        assert f"model-{export_result.run_id}-mcd" in names_logged
+
+    def test_det_artifact_contains_both_onnx_and_checkpoint_files(
+        self, export_result, tmp_path
+    ):
+        from radiologist.registry.uploader import _WandbUploader
+
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.write_bytes(b"ckpt")
+        fake_run = MagicMock()
+
+        _WandbUploader().log_model_artifacts(export_result, fake_run, str(ckpt))
+
+        det_art = next(
+            call.args[0]
+            for call in fake_run.log_artifact.call_args_list
+            if call.args[0].name == f"model-{export_result.run_id}"
+            and call.kwargs.get("aliases") == ["best"]
+        )
+        manifest_paths = {e.path for e in det_art.manifest.entries.values()}
+        assert any(p.endswith(".onnx") for p in manifest_paths)
+        assert any(p.endswith(".ckpt") for p in manifest_paths)
+
+    def test_logs_last_alias_version_when_last_checkpoint_given(
+        self, export_result, tmp_path
+    ):
+        from radiologist.registry.uploader import _WandbUploader
+
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.write_bytes(b"ckpt")
+        last_ckpt = tmp_path / "last.ckpt"
+        last_ckpt.write_bytes(b"last")
+        fake_run = MagicMock()
+
+        _WandbUploader().log_model_artifacts(
+            export_result, fake_run, str(ckpt), str(last_ckpt)
+        )
+
+        aliases_seen = [
+            call.kwargs.get("aliases") for call in fake_run.log_artifact.call_args_list
+        ]
+        assert ["last"] in aliases_seen
+
+    def test_no_last_alias_version_when_last_checkpoint_absent(
+        self, export_result, tmp_path
+    ):
+        from radiologist.registry.uploader import _WandbUploader
+
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.write_bytes(b"ckpt")
+        fake_run = MagicMock()
+
+        _WandbUploader().log_model_artifacts(export_result, fake_run, str(ckpt))
+
+        aliases_seen = [
+            call.kwargs.get("aliases") for call in fake_run.log_artifact.call_args_list
+        ]
+        assert ["last"] not in aliases_seen
+
+    def test_returns_logged_artifacts_carrying_run_id(self, export_result, tmp_path):
+        from radiologist.registry.uploader import _WandbUploader
+
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.write_bytes(b"ckpt")
+        fake_run = MagicMock()
+
+        result = _WandbUploader().log_model_artifacts(
+            export_result, fake_run, str(ckpt)
+        )
+
+        assert result.run_id == export_result.run_id
+        assert f"model-{export_result.run_id}" in result.det_qualified_name
+        assert f"model-{export_result.run_id}-mcd" in result.mcd_qualified_name
+
+    def test_does_not_link_artifacts_to_a_collection(self, export_result, tmp_path):
+        from radiologist.registry.uploader import _WandbUploader
+
+        ckpt = tmp_path / "best.ckpt"
+        ckpt.write_bytes(b"ckpt")
+        fake_run = MagicMock()
+
+        _WandbUploader().log_model_artifacts(export_result, fake_run, str(ckpt))
+
+        assert not fake_run.link_artifact.called
+
+
+class TestUploaderLinkToCollectionStubContract:
     def test_link_to_collection_raises_not_implemented(self):
         from radiologist.registry.uploader import _WandbUploader
 

--- a/radiologist-registry/tests/test_artifact_promotion.py
+++ b/radiologist-registry/tests/test_artifact_promotion.py
@@ -20,12 +20,11 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
-import radiologist.registry.uploader as uploader_mod
-from radiologist.registry.models import ExportResult, PromoteResult
+from radiologist.registry.models import ExportResult
 from radiologist.registry.wandb_registry import WandbRegistry
 
 
@@ -44,103 +43,35 @@ def export_result(tmp_path):
     )
 
 
-@pytest.fixture()
-def mock_wandb():
-    m = MagicMock()
-    run = MagicMock()
-    m.init.return_value = run
+class TestUploaderStubContract:
+    def test_log_model_artifacts_raises_not_implemented(self, export_result):
+        from radiologist.registry.uploader import _WandbUploader
 
-    det_art = MagicMock()
-    mcd_art = MagicMock()
-    det_linked = MagicMock()
-    mcd_linked = MagicMock()
-    det_linked.qualified_name = "entity/project/model-abc123:staging"
-    mcd_linked.qualified_name = "entity/project/model-abc123-mcd:staging"
+        with pytest.raises(NotImplementedError):
+            _WandbUploader().log_model_artifacts(
+                export_result, MagicMock(), "best.ckpt"
+            )
 
-    m.Artifact.side_effect = [det_art, mcd_art]
-    run.link_artifact.side_effect = [det_linked, mcd_linked]
+    def test_link_to_collection_raises_not_implemented(self):
+        from radiologist.registry.uploader import _WandbUploader
 
-    return m
+        with pytest.raises(NotImplementedError):
+            _WandbUploader().link_to_collection(
+                "entity/project/model-abc123:best",
+                "entity/project/model-abc123-mcd:best",
+                "det-collection",
+                "mcd-collection",
+                "staging",
+            )
 
 
-class TestPromoteViaRegistry:
-    def test_promote_returns_correct_qualified_names(self, export_result, mock_wandb):
-        with patch.object(uploader_mod, "_wandb", mock_wandb):
-            registry = WandbRegistry()
-            result = registry.promote(export_result, "entity/project", "staging")
+class TestWandbRegistryPromoteStubContract:
+    def test_promote_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            WandbRegistry().promote(
+                "entity/project", "abc123", "det-collection", "mcd-collection"
+            )
 
-        assert result.det_qualified_name == "entity/project/model-abc123:staging"
-        assert result.mcd_qualified_name == "entity/project/model-abc123-mcd:staging"
-
-    def test_promote_creates_run_with_correct_job_type(self, export_result, mock_wandb):
-        with patch.object(uploader_mod, "_wandb", mock_wandb):
-            registry = WandbRegistry()
-            registry.promote(export_result, "entity/project", "staging")
-
-        mock_wandb.init.assert_called_once_with(job_type="registry-promote")
-
-    def test_promote_calls_run_finish_after_upload(self, export_result, mock_wandb):
-        with patch.object(uploader_mod, "_wandb", mock_wandb):
-            registry = WandbRegistry()
-            registry.promote(export_result, "entity/project", "staging")
-
-        run = mock_wandb.init.return_value
-        run.finish.assert_called_once()
-
-    def test_promote_calls_run_finish_even_when_upload_raises(
-        self, export_result, mock_wandb
-    ):
-        run = mock_wandb.init.return_value
-        run.log_artifact.side_effect = RuntimeError("upload failed")
-
-        with patch.object(uploader_mod, "_wandb", mock_wandb):
-            registry = WandbRegistry()
-            with pytest.raises(RuntimeError, match="upload failed"):
-                registry.promote(export_result, "entity/project", "staging")
-
-        run.finish.assert_called_once()
-
-    def test_promote_creates_det_artifact_with_correct_name(
-        self, export_result, mock_wandb
-    ):
-        with patch.object(uploader_mod, "_wandb", mock_wandb):
-            registry = WandbRegistry()
-            registry.promote(export_result, "entity/project", "staging")
-
-        calls = mock_wandb.Artifact.call_args_list
-        assert calls[0][0][0] == "model-abc123"
-        assert calls[0][1]["type"] == "model"
-
-    def test_promote_creates_mcd_artifact_with_correct_name(
-        self, export_result, mock_wandb
-    ):
-        with patch.object(uploader_mod, "_wandb", mock_wandb):
-            registry = WandbRegistry()
-            registry.promote(export_result, "entity/project", "staging")
-
-        calls = mock_wandb.Artifact.call_args_list
-        assert calls[1][0][0] == "model-abc123-mcd"
-        assert calls[1][1]["type"] == "model"
-
-    def test_promote_links_artifacts_with_alias(self, export_result, mock_wandb):
-        with patch.object(uploader_mod, "_wandb", mock_wandb):
-            registry = WandbRegistry()
-            registry.promote(export_result, "entity/project", "staging")
-
-        run = mock_wandb.init.return_value
-        link_calls = run.link_artifact.call_args_list
-        assert link_calls[0][1]["aliases"] == ["staging"]
-        assert link_calls[1][1]["aliases"] == ["staging"]
-
-    def test_promote_raises_runtime_error_when_wandb_absent(self, export_result):
-        with patch("radiologist.registry.optional._wandb", None):
-            registry = WandbRegistry()
-            with pytest.raises(RuntimeError, match="wandb is required"):
-                registry.promote(export_result, "entity/project", "staging")
-
-    def test_promote_returns_promote_result_instance(self, export_result, mock_wandb):
-        with patch.object(uploader_mod, "_wandb", mock_wandb):
-            registry = WandbRegistry()
-            result = registry.promote(export_result, "entity/project", "staging")
-
-        assert isinstance(result, PromoteResult)
+    def test_transition_to_production_raises_not_implemented(self):
+        with pytest.raises(NotImplementedError):
+            WandbRegistry().transition_to_production("det-collection", "mcd-collection")

--- a/radiologist-registry/tests/test_artifact_promotion.py
+++ b/radiologist-registry/tests/test_artifact_promotion.py
@@ -20,7 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-from unittest.mock import MagicMock
+from typing import List
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -148,27 +149,202 @@ class TestUploaderLogModelArtifacts:
         assert not fake_run.link_artifact.called
 
 
-class TestUploaderLinkToCollectionStubContract:
-    def test_link_to_collection_raises_not_implemented(self):
-        from radiologist.registry.uploader import _WandbUploader
+def _make_artifact(qualified_name: str, aliases: List[str]) -> MagicMock:
+    art = MagicMock()
+    art.qualified_name = qualified_name
+    art.aliases = list(aliases)
+    art.save = MagicMock()
+    art.link = MagicMock()
+    return art
 
-        with pytest.raises(NotImplementedError):
-            _WandbUploader().link_to_collection(
-                "entity/project/model-abc123:best",
-                "entity/project/model-abc123-mcd:best",
+
+class TestUploaderLinkToCollection:
+    def test_links_det_and_mcd_artifacts_with_given_alias(self):
+        det_art = _make_artifact("entity/project/model-abc123:best", ["best"])
+        mcd_art = _make_artifact("entity/project/model-abc123-mcd:best", ["best"])
+        with patch("radiologist.registry.uploader._wandb") as mock_wandb:
+            mock_api = MagicMock()
+            mock_wandb.Api.return_value = mock_api
+            mock_api.artifact.side_effect = [det_art, mcd_art]
+
+            from radiologist.registry.uploader import _WandbUploader
+
+            result = _WandbUploader().link_to_collection(
+                det_art.qualified_name,
+                mcd_art.qualified_name,
                 "det-collection",
                 "mcd-collection",
-                "staging",
+                "production",
             )
 
+        det_art.link.assert_called_once_with("det-collection", aliases=["production"])
+        mcd_art.link.assert_called_once_with("mcd-collection", aliases=["production"])
+        assert result.det_qualified_name == det_art.qualified_name
+        assert result.mcd_qualified_name == mcd_art.qualified_name
+        assert result.alias == "production"
 
-class TestWandbRegistryPromoteStubContract:
-    def test_promote_raises_not_implemented(self):
-        with pytest.raises(NotImplementedError):
-            WandbRegistry().promote(
+
+class TestWandbRegistryPromote:
+    def test_applies_production_when_collection_has_no_production_member(self):
+        det_art = _make_artifact("entity/project/model-abc123:best", ["best"])
+        mcd_art = _make_artifact("entity/project/model-abc123-mcd:best", ["best"])
+        with (
+            patch("radiologist.registry.resolver._wandb") as resolver_wandb,
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.uploader._wandb") as uploader_wandb,
+        ):
+            resolver_api = MagicMock()
+            resolver_wandb.Api.return_value = resolver_api
+            resolver_api.artifact.side_effect = [det_art, mcd_art]
+
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = []
+            collection_api.artifact_collection.return_value = det_collection_obj
+
+            uploader_api = MagicMock()
+            uploader_wandb.Api.return_value = uploader_api
+            uploader_api.artifact.side_effect = [det_art, mcd_art]
+
+            registry = WandbRegistry()
+            result = registry.promote(
                 "entity/project", "abc123", "det-collection", "mcd-collection"
             )
 
-    def test_transition_to_production_raises_not_implemented(self):
-        with pytest.raises(NotImplementedError):
-            WandbRegistry().transition_to_production("det-collection", "mcd-collection")
+        det_art.link.assert_called_once_with("det-collection", aliases=["production"])
+        mcd_art.link.assert_called_once_with("mcd-collection", aliases=["production"])
+        assert result.alias == "production"
+
+    def test_applies_staging_when_collection_already_has_production_member(self):
+        det_art = _make_artifact("entity/project/model-abc123:best", ["best"])
+        mcd_art = _make_artifact("entity/project/model-abc123-mcd:best", ["best"])
+        with (
+            patch("radiologist.registry.resolver._wandb") as resolver_wandb,
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.uploader._wandb") as uploader_wandb,
+        ):
+            resolver_api = MagicMock()
+            resolver_wandb.Api.return_value = resolver_api
+            resolver_api.artifact.side_effect = [det_art, mcd_art]
+
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            existing_production = _make_artifact(
+                "entity/project/model-xyz:v0", ["production"]
+            )
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = [existing_production]
+            collection_api.artifact_collection.return_value = det_collection_obj
+
+            uploader_api = MagicMock()
+            uploader_wandb.Api.return_value = uploader_api
+            uploader_api.artifact.side_effect = [det_art, mcd_art]
+
+            registry = WandbRegistry()
+            result = registry.promote(
+                "entity/project", "abc123", "det-collection", "mcd-collection"
+            )
+
+        det_art.link.assert_called_once_with("det-collection", aliases=["staging"])
+        mcd_art.link.assert_called_once_with("mcd-collection", aliases=["staging"])
+        assert result.alias == "staging"
+
+    def test_does_not_download_any_local_file(self):
+        det_art = _make_artifact("entity/project/model-abc123:best", ["best"])
+        mcd_art = _make_artifact("entity/project/model-abc123-mcd:best", ["best"])
+        with (
+            patch("radiologist.registry.resolver._wandb") as resolver_wandb,
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.uploader._wandb") as uploader_wandb,
+        ):
+            resolver_api = MagicMock()
+            resolver_wandb.Api.return_value = resolver_api
+            resolver_api.artifact.side_effect = [det_art, mcd_art]
+
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = []
+            collection_api.artifact_collection.return_value = det_collection_obj
+
+            uploader_api = MagicMock()
+            uploader_wandb.Api.return_value = uploader_api
+            uploader_api.artifact.side_effect = [det_art, mcd_art]
+
+            registry = WandbRegistry()
+            registry.promote(
+                "entity/project", "abc123", "det-collection", "mcd-collection"
+            )
+
+        det_art.download.assert_not_called()
+        mcd_art.download.assert_not_called()
+
+
+class TestWandbRegistryTransitionToProduction:
+    def test_flips_staging_to_production_in_both_collections(self):
+        det_staging = _make_artifact("entity/project/model-a:v0", ["staging"])
+        det_production = _make_artifact("entity/project/model-b:v0", ["production"])
+        mcd_staging = _make_artifact("entity/project/model-c-mcd:v0", ["staging"])
+        mcd_production = _make_artifact("entity/project/model-d-mcd:v0", ["production"])
+        with (
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.alias_manager._wandb") as alias_wandb,
+        ):
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = [det_staging, det_production]
+            mcd_collection_obj = MagicMock()
+            mcd_collection_obj.artifacts.return_value = [mcd_staging, mcd_production]
+            collection_api.artifact_collection.side_effect = [
+                det_collection_obj,
+                mcd_collection_obj,
+            ]
+
+            alias_api = MagicMock()
+            alias_wandb.Api.return_value = alias_api
+            alias_api.artifact.side_effect = [
+                det_production,
+                det_staging,
+                mcd_production,
+                mcd_staging,
+            ]
+
+            registry = WandbRegistry()
+            result = registry.transition_to_production(
+                "det-collection", "mcd-collection"
+            )
+
+        assert "production" not in det_production.aliases
+        assert "production" in det_staging.aliases
+        assert "production" not in mcd_production.aliases
+        assert "production" in mcd_staging.aliases
+        assert result.alias == "production"
+        assert result.det_qualified_name == det_staging.qualified_name
+        assert result.mcd_qualified_name == mcd_staging.qualified_name
+
+    def test_raises_lookup_error_when_no_staging_member_in_a_collection(self):
+        det_production = _make_artifact("entity/project/model-b:v0", ["production"])
+        mcd_staging = _make_artifact("entity/project/model-c-mcd:v0", ["staging"])
+        with (
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.alias_manager._wandb") as alias_wandb,
+        ):
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = [det_production]
+            mcd_collection_obj = MagicMock()
+            mcd_collection_obj.artifacts.return_value = [mcd_staging]
+            collection_api.artifact_collection.side_effect = [
+                det_collection_obj,
+                mcd_collection_obj,
+            ]
+
+            registry = WandbRegistry()
+            with pytest.raises(LookupError):
+                registry.transition_to_production("det-collection", "mcd-collection")
+
+        alias_wandb.Api.assert_not_called()
+        assert "production" in det_production.aliases

--- a/radiologist-registry/tests/test_promotion_skeleton_contract.py
+++ b/radiologist-registry/tests/test_promotion_skeleton_contract.py
@@ -20,8 +20,6 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-import pytest
-
 
 def test_logged_artifacts_and_collection_member_importable_from_public_api():
     from radiologist.registry import CollectionMember, LoggedArtifacts
@@ -45,20 +43,6 @@ def test_promote_result_carries_alias_field():
         alias="staging",
     )
     assert result.alias == "staging"
-
-
-def test_collection_lister_list_collection_artifacts_raises_not_implemented():
-    from radiologist.registry.collection import _WandbCollectionLister
-
-    with pytest.raises(NotImplementedError):
-        _WandbCollectionLister().list_collection_artifacts("model", "det-collection")
-
-
-def test_wandb_registry_list_collection_artifacts_raises_not_implemented():
-    from radiologist.registry.wandb_registry import WandbRegistry
-
-    with pytest.raises(NotImplementedError):
-        WandbRegistry().list_collection_artifacts("model", "det-collection")
 
 
 def test_model_registry_protocol_declares_new_methods():

--- a/radiologist-registry/tests/test_promotion_skeleton_contract.py
+++ b/radiologist-registry/tests/test_promotion_skeleton_contract.py
@@ -1,0 +1,90 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import pytest
+
+
+def test_logged_artifacts_and_collection_member_importable_from_public_api():
+    from radiologist.registry import CollectionMember, LoggedArtifacts
+
+    assert LoggedArtifacts(
+        det_qualified_name="entity/project/model-abc123:best",
+        mcd_qualified_name="entity/project/model-abc123-mcd:best",
+        run_id="abc123",
+    )
+    assert CollectionMember(
+        qualified_name="entity/project/model-abc123:best", aliases=["best"]
+    )
+
+
+def test_promote_result_carries_alias_field():
+    from radiologist.registry.models import PromoteResult
+
+    result = PromoteResult(
+        det_qualified_name="entity/project/model-abc123:staging",
+        mcd_qualified_name="entity/project/model-abc123-mcd:staging",
+        alias="staging",
+    )
+    assert result.alias == "staging"
+
+
+def test_collection_lister_list_collection_artifacts_raises_not_implemented():
+    from radiologist.registry.collection import _WandbCollectionLister
+
+    with pytest.raises(NotImplementedError):
+        _WandbCollectionLister().list_collection_artifacts("model", "det-collection")
+
+
+def test_wandb_registry_log_model_artifacts_raises_not_implemented():
+    from unittest.mock import MagicMock
+
+    from radiologist.registry.models import ExportResult
+    from radiologist.registry.wandb_registry import WandbRegistry
+
+    export_result = ExportResult(
+        det_path="/tmp/model.onnx",
+        mcd_path="/tmp/model_mcd.onnx",
+        run_id="abc123",
+        input_shape=(1, 3, 224, 224),
+        classes=["normal", "abnormal"],
+    )
+    with pytest.raises(NotImplementedError):
+        WandbRegistry().log_model_artifacts(export_result, MagicMock(), "best.ckpt")
+
+
+def test_wandb_registry_list_collection_artifacts_raises_not_implemented():
+    from radiologist.registry.wandb_registry import WandbRegistry
+
+    with pytest.raises(NotImplementedError):
+        WandbRegistry().list_collection_artifacts("model", "det-collection")
+
+
+def test_model_registry_protocol_declares_new_methods():
+    from radiologist.registry.interface import ModelRegistry
+
+    for name in (
+        "log_model_artifacts",
+        "list_collection_artifacts",
+        "promote",
+        "transition_to_production",
+    ):
+        assert hasattr(ModelRegistry, name)

--- a/radiologist-registry/tests/test_promotion_skeleton_contract.py
+++ b/radiologist-registry/tests/test_promotion_skeleton_contract.py
@@ -54,23 +54,6 @@ def test_collection_lister_list_collection_artifacts_raises_not_implemented():
         _WandbCollectionLister().list_collection_artifacts("model", "det-collection")
 
 
-def test_wandb_registry_log_model_artifacts_raises_not_implemented():
-    from unittest.mock import MagicMock
-
-    from radiologist.registry.models import ExportResult
-    from radiologist.registry.wandb_registry import WandbRegistry
-
-    export_result = ExportResult(
-        det_path="/tmp/model.onnx",
-        mcd_path="/tmp/model_mcd.onnx",
-        run_id="abc123",
-        input_shape=(1, 3, 224, 224),
-        classes=["normal", "abnormal"],
-    )
-    with pytest.raises(NotImplementedError):
-        WandbRegistry().log_model_artifacts(export_result, MagicMock(), "best.ckpt")
-
-
 def test_wandb_registry_list_collection_artifacts_raises_not_implemented():
     from radiologist.registry.wandb_registry import WandbRegistry
 


### PR DESCRIPTION
## Summary

Implements the full "🚀 Train-time ONNX export, W&B-ref resume, and smart staging/production promotion" epic (milestone #8), delivered phase-by-phase per the epic spec:

- **#108** — Skeleton: typed public API contract across `radiologist-core` and `radiologist-registry` (stubs only, no behavior).
- **#109** — `OnnxExportCallback` opt-in end-of-fit ONNX export, logging det/mcd artifacts to the active W&B run with `best`/`last` aliases (no collection link yet).
- **#110** — Resume training from a dedicated `resume_ref`/`resume_path` config-key pair (distinct from local-path `ckpt_path`), with checkpoint precision restored from the saved payload.
- **#111** — Smart `promote()` (auto-tags `production` if none exists in the collection, else `staging`) and explicit `transition_to_production()` (staging → production as one det+mcd transaction).
- **#112** — Cleanup pass: confirmed the monolithic three-arg `promote()` was already fully removed by #108/#111; fixed one stale docstring reference.

Minimal-impact strategy throughout: reuses `export_onnx()`, `_WandbResolver`, `_WandbAliasManager`, and the plain-`wandb` active-run convention unchanged; new surface is limited to one core callback, one core resume module, two new train-config keys, one new registry seam (`_WandbCollectionLister`), and orchestration methods on the `WandbRegistry` facade.

Closes #108, closes #109, closes #110, closes #111, closes #112.

## Test plan

- [x] `radiologist-core` test suite: 126 passed
- [x] `radiologist-registry` test suite: 42 passed
- [x] `mypy` clean on both packages' `src` (one pre-existing, unrelated error at `module.py:107`, confirmed present on `main` before this branch)
- [x] Each of the 5 issues implemented via strict TDD in its own worktree/branch, then rebase-merged into this epic branch with a full-suite re-verification after every merge
