### PR TITLE
docs(worktree): require dedicated pyenv venv per worktree

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -127,7 +127,26 @@ Run `pyenv [command] --help` to display `pyenv`'s help.
 
 Always create worktrees in `PROJECT-ROOT`/.claude/worktrees to maintain clean repo. Never nest worktrees - No exceptions.
 
-[Environment setup](#environment-setup) still apply in worktrees - No exceptions.
+**Never share the `radiologist` venv with a worktree.** Editable installs (`uv sync`) write `.pth` files that point at absolute paths. Running `uv sync --active` inside a worktree while activated on the shared `radiologist` venv rewrites those `.pth` files to point at the worktree's path — when the worktree is later deleted, the main checkout's venv silently breaks (imports resolve to a path that no longer exists).
+
+Instead, each worktree gets its own dedicated pyenv virtualenv, named after the worktree:
+
+```bash
+pyenv virtualenv 3.10.16 radiologist-<worktree-name>
+pyenv activate radiologist-<worktree-name>   # do not rely on .python-version here — activate explicitly
+make dev-install
+```
+
+[Environment setup](#environment-setup) otherwise still applies (same Python version, same `make dev-install` target) — only the venv name changes.
+
+At the end of the task, before removing the worktree:
+
+```bash
+pyenv deactivate
+pyenv virtualenv-delete -f radiologist-<worktree-name>
+```
+
+Do not leave orphaned `radiologist-<worktree-name>` venvs behind — delete the venv in the same step as the worktree.
 
 When an subagent ends his work in a worktree:
 


### PR DESCRIPTION
Sharing the `radiologist` venv between the main checkout and a worktree lets `uv sync --active` rewrite editable-install `.pth` files to the worktree's absolute path. Once the worktree is deleted, those paths go stale and the main checkout's imports silently break.

Document that each worktree must get its own
`radiologist-<worktree-name>` pyenv virtualenv, created and activated explicitly, and deleted together with the worktree at task end.