### PR TITLE
feat: operationalize the radiologist workspace (CLIs, guards, docs)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -27,7 +27,7 @@ This project adopts a mono-repo layout managed by `UV`.
 | Path | Contents |
 |---|---|
 | `radiologist-app/` | UI |
-| `radiologist-core/` | Modeling library — datamodule, VGG-11 backbone, focal loss, training loop |
+| `radiologist-core/` | Modeling library — datamodule, configurable backbone (`module` Hydra group, defaults to ResNet-50), focal loss, training loop |
 | `radiologist-etl/` | Data preparation — outlier removal (Haralick GLCM), ImageFolder builder |
 | `radiologist-inference/` | ONNX inference & serving — pull models from W&B Registry, serve via ONNX Runtime, FastAPI HTTP server, Typer CLI |
 | `radiologist-utils/` | Useful helpers |

--- a/Makefile
+++ b/Makefile
@@ -236,7 +236,7 @@ format:  ## run black + isort in-place
 	@uv run --active isort .
 
 type-check:  ## run mypy across all packages
-	@uv run --active mypy $(PKG_CORE)/src $(PKG_ETL)/src $(PKG_UTILS)/src
+	@uv run --active mypy $(PKG_CORE)/src $(PKG_ETL)/src $(PKG_UTILS)/src $(PKG_INFERENCE)/src $(PKG_REGISTRY)/src
 
 # --------------------------------------------------------------------------- #
 #  Maintenance                                                                 #

--- a/README.md
+++ b/README.md
@@ -97,20 +97,31 @@ uv run --active python -m radiologist.core.train \
 
 ### 4 — Promote to the model registry
 
-```python
-from radiologist.core.registry import promote_to_registry
+Training already logged both ONNX exports (deterministic + MC-Dropout) as W&B artifacts. Link them into a registry collection:
 
-promote_to_registry(
-    artifact="entity/project/model-artifact:v3",
-    collection="chest-xray-classifier",
-    registry_alias="production",
-    input_shape=(1, 1, 224, 224),
-    classes=["healthy", "viral", "opacity"],
-    cam_target_layer="layer4.1.conv2",
+```bash
+radiologist-registry promote entity/project/model-artifact \
+    --run-id wandb-run-id \
+    --det-collection chest-xray-classifier \
+    --mcd-collection chest-xray-classifier-mcd
+```
+
+This resolves the deterministic artifact by `run_id` and the MC-Dropout artifact by the `{run_id}-mcd` convention, then links both into their collections under the same alias — `production` if neither collection has one yet, `staging` otherwise.
+
+Equivalent Python API:
+
+```python
+from radiologist.registry import WandbRegistry
+
+result = WandbRegistry().promote(
+    path="entity/project/model-artifact",
+    run_id="wandb-run-id",
+    det_collection="chest-xray-classifier",
+    mcd_collection="chest-xray-classifier-mcd",
 )
 ```
 
-This exports two ONNX models — deterministic (with GradCAM activation output) and MC-Dropout (for uncertainty estimation) — and links them to the W&B registry.
+See [`radiologist-registry/README.md`](radiologist-registry/README.md) for the full CLI reference (`push`, `pull`, `resolve`, `list`, `alias`, `transition-to-production`).
 
 ### 5 — Run the test suite
 

--- a/radiologist-core/README.md
+++ b/radiologist-core/README.md
@@ -38,8 +38,7 @@ radiologist-core/src/radiologist/core/
 │   ├── best_metric.py  # best-epoch metric tracking
 │   └── wandb_summary.py
 ├── registry/
-│   ├── promote.py      # promote_to_registry (ONNX export + W&B upload)
-│   └── pull.py         # pull_checkpoint
+│   └── export.py       # export_onnx (checkpoint → deterministic + MC-Dropout ONNX)
 └── configs/            # Hydra config tree
 ```
 
@@ -156,39 +155,29 @@ Writes `best_{monitor}` to `trainer.callback_metrics` after every validation epo
 
 Calls `wandb.run.define_metric` at fit start so the W&B run summary panel highlights the best validation score automatically.
 
-## Promoting a trained model to the registry
+## Exporting and promoting a trained model
+
+`radiologist.core.registry.export_onnx` turns a Lightning checkpoint into two local ONNX files — it has no W&B interaction:
 
 ```python
-from radiologist.core.registry import promote_to_registry
+from radiologist.core.registry import export_onnx
 
-promote_to_registry(
-    artifact="entity/project/model-artifact:v3",
-    collection="chest-xray-classifier",
-    registry_alias="production",
+result = export_onnx(
+    ckpt_path="/path/to/checkpoint.ckpt",
+    run_id="wandb-run-id",
     input_shape=(1, 1, 224, 224),
     classes=["healthy", "viral", "opacity"],
     cam_target_layer="layer4.1.conv2",
+    out_dir="/tmp/onnx-export",
 )
 ```
 
-This exports two ONNX models from the checkpoint:
+This produces:
 
 1. **Deterministic** — `_CamWrapper` forward hook returns `(logits, activation)`. Useful for inference with visual explanation.
 2. **MC-Dropout** — `nn.Dropout` layers left in training mode (`TrainingMode.PRESERVE`, no constant folding). Run multiple forward passes and aggregate for uncertainty estimation.
 
-Both are uploaded as W&B artifacts and linked to the registry collection under `registry_alias`.
-
-### Pulling a checkpoint
-
-```python
-from radiologist.core.registry import pull_checkpoint
-
-ckpt_path = pull_checkpoint(
-    run_id="wandb-run-id",           # resolve by run ID
-    metric="best_val_score",
-    # or: tags=["production"], groups=["experiment-v2"]  to filter runs
-)
-```
+Uploading the exported ONNX files as W&B artifacts and linking them into a registry collection is handled by `radiologist-registry` (`WandbRegistry.log_model_artifacts()` then `WandbRegistry.promote()`, or the `radiologist-registry push` / `promote` CLI). See [`radiologist-registry/README.md`](../radiologist-registry/README.md) for the full flow.
 
 ## Configuration reference
 

--- a/radiologist-core/pyproject.toml
+++ b/radiologist-core/pyproject.toml
@@ -23,6 +23,9 @@ description = "Modeling library for the radiologist pipeline"
 license = { file = "../LICENSE" }
 requires-python = ">=3.10"
 
+[project.scripts]
+radiologist-core = "radiologist.core.train:main"
+
 [project.optional-dependencies]
 all = [
     "captum>=0.9.0",

--- a/radiologist-core/src/radiologist/core/callbacks/attribution.py
+++ b/radiologist-core/src/radiologist/core/callbacks/attribution.py
@@ -43,7 +43,10 @@ except ImportError:
     LayerGradCam = None  # type: ignore[assignment,misc]
     _CAPTUM_AVAILABLE = False
 
-import wandb
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 
 
 @dataclass

--- a/radiologist-core/src/radiologist/core/callbacks/onnx_export.py
+++ b/radiologist-core/src/radiologist/core/callbacks/onnx_export.py
@@ -23,7 +23,11 @@
 from typing import Any, List, Tuple
 
 import lightning as L
-import wandb
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 
 from radiologist.core.registry import export_onnx
 from radiologist.registry import WandbRegistry

--- a/radiologist-core/src/radiologist/core/callbacks/wandb_summary.py
+++ b/radiologist-core/src/radiologist/core/callbacks/wandb_summary.py
@@ -23,7 +23,11 @@
 from typing import Any
 
 import lightning as L
-import wandb
+
+try:
+    import wandb
+except ImportError:
+    wandb = None  # type: ignore[assignment]
 
 
 class WandbDefineSummaryCallback(L.Callback):

--- a/radiologist-core/tests/test_wandb_import_guards.py
+++ b/radiologist-core/tests/test_wandb_import_guards.py
@@ -1,0 +1,111 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+import builtins
+import importlib
+from unittest.mock import patch
+
+import lightning as L
+import pytest
+import torch
+
+from radiologist.core import OnnxExportCallback, WandbDefineSummaryCallback
+from radiologist.core.callbacks import attribution as attribution_mod
+from radiologist.core.callbacks import onnx_export as onnx_export_mod
+from radiologist.core.callbacks import wandb_summary as wandb_summary_mod
+
+_GUARDED_MODULES = [attribution_mod, onnx_export_mod, wandb_summary_mod]
+
+
+@pytest.fixture
+def wandb_import_blocked():
+    real_import = builtins.__import__
+
+    def fake_import(name, *args, **kwargs):
+        if name == "wandb":
+            raise ImportError("simulated missing wandb")
+        return real_import(name, *args, **kwargs)
+
+    try:
+        with patch("builtins.__import__", side_effect=fake_import):
+            for mod in _GUARDED_MODULES:
+                importlib.reload(mod)
+        yield
+    finally:
+        for mod in _GUARDED_MODULES:
+            importlib.reload(mod)
+
+
+def test_callback_modules_reload_succeeds_when_wandb_unavailable(
+    wandb_import_blocked,
+):
+    for mod in _GUARDED_MODULES:
+        assert mod.wandb is None
+
+
+def test_wandb_summary_callback_noop_when_wandb_sentinel_none(lmodule, dm):
+    with patch.object(wandb_summary_mod, "wandb", None, create=True):
+        cb = WandbDefineSummaryCallback(monitor="val_score", mode="max")
+        trainer = L.Trainer(
+            fast_dev_run=True,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            callbacks=[cb],
+            logger=False,
+        )
+        trainer.fit(lmodule, datamodule=dm)
+
+
+def test_onnx_export_callback_noop_when_wandb_sentinel_none(lmodule, dm):
+    with patch.object(onnx_export_mod, "wandb", None, create=True):
+        cb = OnnxExportCallback(
+            input_shape=(1, 3, 8, 8),
+            classes=["healthy", "sick"],
+            cam_target_layer="2",
+        )
+        trainer = L.Trainer(
+            fast_dev_run=True,
+            accelerator="cpu",
+            enable_progress_bar=False,
+            enable_model_summary=False,
+            callbacks=[cb],
+            logger=False,
+        )
+        trainer.fit(lmodule, datamodule=dm)
+
+
+def test_attribution_log_gallery_noop_when_wandb_sentinel_none():
+    from radiologist.core.callbacks.attribution import AttributionCallback, _Panel
+
+    cb = AttributionCallback(
+        target_layer="0", every_n_val_epochs=1, output_subdir="attributions"
+    )
+    panel = _Panel(
+        key="sample_0",
+        image=torch.zeros(3, 4, 4),
+        caption="caption",
+        filename="sample_0.png",
+    )
+
+    with patch.object(attribution_mod, "wandb", None, create=True):
+        cb._log_gallery([panel], stage="val", step=0)

--- a/radiologist-etl/pyproject.toml
+++ b/radiologist-etl/pyproject.toml
@@ -28,6 +28,10 @@ all = [
     "gcsfs>=2026.4.0",
     "prefect>=3.7.0"
 ]
+
+[project.scripts]
+radiologist-etl = "radiologist.etl.prefect_pipelines:main"
+
 [tool.commitizen]
 name = "cz_conventional_commits"
 version = "0.1.0"

--- a/radiologist-etl/tests/test_console_script.py
+++ b/radiologist-etl/tests/test_console_script.py
@@ -1,0 +1,51 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ETL_ROOT = Path(__file__).resolve().parents[1]
+PYPROJECT_PATH = ETL_ROOT / "pyproject.toml"
+
+
+def test_console_script_entry_point_targets_hydra_main():
+    content = PYPROJECT_PATH.read_text()
+    match = re.search(r'^radiologist-etl\s*=\s*"([^"]+)"', content, flags=re.MULTILINE)
+
+    assert match is not None
+    assert match.group(1) == "radiologist.etl.prefect_pipelines:main"
+
+
+def test_console_script_help_composes_and_exits_zero():
+    result = subprocess.run(
+        [sys.executable, "-m", "radiologist.etl.prefect_pipelines", "--help"],
+        cwd=ETL_ROOT,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0
+    assert "Powered by Hydra" in result.stdout

--- a/radiologist-inference/src/radiologist/inference/app.py
+++ b/radiologist-inference/src/radiologist/inference/app.py
@@ -63,7 +63,8 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
     ``Explainer`` additionally gets ``/explain``, and ``MCDropoutPredictor``
     gets ``/uncertainty``. When ``predictor`` is ``None`` the type is unknown,
     so every route is wired and each falls back to the 503 "no model loaded"
-    guard until a predictor is injected. ``/healthz`` is always wired.
+    guard until a predictor is injected. ``/healthz`` (pure liveness) and
+    ``/readyz`` (readiness, 503 until a predictor is loaded) are always wired.
 
     Args:
         fastapi_mod: The imported fastapi module (passed to avoid re-importing).
@@ -164,12 +165,11 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
 
     @app.get("/healthz")
     def healthz() -> Dict[str, str]:
-        _get_predictor()
         return {"status": "ok"}
 
     @app.get("/readyz")
     def readyz() -> Dict[str, str]:
-        # contract (implemented in #6): 503 when no predictor loaded, 200 once one is.
-        raise NotImplementedError
+        _get_predictor()
+        return {"status": "ready"}
 
     return app

--- a/radiologist-inference/src/radiologist/inference/app.py
+++ b/radiologist-inference/src/radiologist/inference/app.py
@@ -167,4 +167,9 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
         _get_predictor()
         return {"status": "ok"}
 
+    @app.get("/readyz")
+    def readyz() -> Dict[str, str]:
+        # contract (implemented in #6): 503 when no predictor loaded, 200 once one is.
+        raise NotImplementedError
+
     return app

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -41,6 +41,7 @@ from radiologist.registry.wandb_registry import WandbRegistry
 
 if TYPE_CHECKING:
     from radiologist.registry.interface import ModelRegistry
+    from radiologist.registry.selector import RegistrySelector
 
 
 @dataclass
@@ -116,6 +117,29 @@ class BasePredictor:
         reg = registry if registry is not None else WandbRegistry()
         det_path = reg.pull(artifact_path=artifact_path, local_dir=local_dir)
         return cls.from_path(det_path=det_path)
+
+    @classmethod
+    def from_selector(
+        cls,
+        selector: "RegistrySelector",
+        local_dir: str,
+        registry: Optional["ModelRegistry"] = None,
+    ) -> "BasePredictor":
+        """Resolve a selector against a registry and load via from_path.
+
+        Args:
+            selector: Declarative description of which artifact to resolve.
+            local_dir: Local directory where the ONNX file will be saved.
+            registry: Registry to resolve/download from. Defaults to
+                WandbRegistry() when omitted.
+
+        Returns:
+            Loaded instance of the calling subclass.
+
+        Raises:
+            RuntimeError: When the ``registry`` extra (wandb) is not installed.
+        """
+        raise NotImplementedError
 
 
 def _read_metadata(session: "ort.InferenceSession") -> Dict[str, str]:

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -37,11 +37,17 @@ import onnxruntime as ort  # type: ignore[import-untyped]
 from PIL import Image as PILImage  # type: ignore[import-untyped]
 
 from radiologist.inference.models import ModelMetadata
+from radiologist.registry.selector import resolve_selector
 from radiologist.registry.wandb_registry import WandbRegistry
 
 if TYPE_CHECKING:
     from radiologist.registry.interface import ModelRegistry
     from radiologist.registry.selector import RegistrySelector
+
+_INFERENCE_WANDB_MISSING_MSG = (
+    "wandb is required for registry operations. "
+    "Install with: pip install 'radiologist-inference[registry]'"
+)
 
 
 @dataclass
@@ -115,7 +121,10 @@ class BasePredictor:
             RuntimeError: When the ``registry`` extra (wandb) is not installed.
         """
         reg = registry if registry is not None else WandbRegistry()
-        det_path = reg.pull(artifact_path=artifact_path, local_dir=local_dir)
+        try:
+            det_path = reg.pull(artifact_path=artifact_path, local_dir=local_dir)
+        except RuntimeError as exc:
+            raise RuntimeError(_INFERENCE_WANDB_MISSING_MSG) from exc
         return cls.from_path(det_path=det_path)
 
     @classmethod
@@ -139,7 +148,27 @@ class BasePredictor:
         Raises:
             RuntimeError: When the ``registry`` extra (wandb) is not installed.
         """
-        raise NotImplementedError
+        det_path = _resolve_and_pull(selector, local_dir, registry)
+        return cls.from_path(det_path=det_path)
+
+
+def _resolve_and_pull(
+    selector: "RegistrySelector",
+    local_dir: str,
+    registry: Optional["ModelRegistry"] = None,
+) -> str:
+    """Resolve a selector to an artifact ref, then pull its ONNX file.
+
+    Shared by from_selector() and the CLI uncertainty command's separate
+    deterministic/MC-Dropout resolution, so both surfaces share the same
+    wandb-missing error translation.
+    """
+    reg = registry if registry is not None else WandbRegistry()
+    try:
+        ref = resolve_selector(selector, reg)
+        return reg.pull(artifact_path=ref.qualified_name, local_dir=local_dir)
+    except RuntimeError as exc:
+        raise RuntimeError(_INFERENCE_WANDB_MISSING_MSG) from exc
 
 
 def _read_metadata(session: "ort.InferenceSession") -> Dict[str, str]:

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -157,12 +157,7 @@ def _resolve_and_pull(
     local_dir: str,
     registry: Optional["ModelRegistry"] = None,
 ) -> str:
-    """Resolve a selector to an artifact ref, then pull its ONNX file.
-
-    Shared by from_selector() and the CLI uncertainty command's separate
-    deterministic/MC-Dropout resolution, so both surfaces share the same
-    wandb-missing error translation.
-    """
+    """Resolve a selector to an artifact ref, then pull its ONNX file."""
     reg = registry if registry is not None else WandbRegistry()
     try:
         ref = resolve_selector(selector, reg)

--- a/radiologist-inference/src/radiologist/inference/cam.py
+++ b/radiologist-inference/src/radiologist/inference/cam.py
@@ -32,14 +32,17 @@ def score_cam(
     feature_maps: np.ndarray,
     logits: np.ndarray,
 ) -> np.ndarray:
-    """Compute a Score-CAM saliency map from feature maps and logits.
+    """Compute a Score-CAM saliency map from feature maps via GAP weighting.
 
-    Uses global-average-pooling of each channel as the channel weight
-    (approximation when no ONNX session is available for masked passes).
+    Uses global-average-pooling of each channel as the channel weight —
+    the approximation path used when no ONNX session is available for
+    masked forward passes. ``logits`` is accepted for interface symmetry
+    with ``score_cam_with_session`` but does not affect the result.
 
     Args:
         feature_maps: Feature maps of shape (C, H, W).
-        logits: Model logits of shape (num_classes,).
+        logits: Unused GAP-approximation fallback argument, kept for
+            interface symmetry with score_cam_with_session.
 
     Returns:
         Saliency map of shape (H, W) with values in [0, 1].

--- a/radiologist-inference/src/radiologist/inference/cli.py
+++ b/radiologist-inference/src/radiologist/inference/cli.py
@@ -38,7 +38,7 @@ from radiologist.inference.classifier import Classifier
 from radiologist.inference.explainer import Explainer
 from radiologist.inference.mc_dropout import MCDropoutPredictor
 from radiologist.inference.optional import _typer, _uvicorn
-from radiologist.registry import RegistrySelector
+from radiologist.registry import selector_from_flags
 
 F = TypeVar("F", bound=Callable[..., None])
 
@@ -58,7 +58,7 @@ def _load_predictor(
     local_dir: str,
 ) -> Any:
     """Dispatch to a registry selector or a local path, per predictor_cls."""
-    selector = RegistrySelector(
+    selector = selector_from_flags(
         path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
     )
     if selector.is_registry_backed():
@@ -78,13 +78,13 @@ def _load_uncertainty_predictor(
     mcd_model: Optional[str],
 ) -> "MCDropoutPredictor":
     """Load det+mcd models: registry pair (run_id / {run_id}-mcd) or local paths."""
-    selector = RegistrySelector(
+    selector = selector_from_flags(
         path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
     )
     if selector.is_registry_backed():
         det_path = _resolve_and_pull(selector, local_dir)
         mcd_run_id = f"{run_id}-mcd" if run_id else None
-        mcd_selector = RegistrySelector(
+        mcd_selector = selector_from_flags(
             path=model or "",
             run_id=mcd_run_id,
             tags=tags,
@@ -220,7 +220,7 @@ if _typer is not None:
                 "The 'serve' extra is required to use the serve command. "
                 "Install it with: pip install radiologist-inference[serve]"
             )
-        selector = RegistrySelector(
+        selector = selector_from_flags(
             path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
         )
         if selector.is_registry_backed():

--- a/radiologist-inference/src/radiologist/inference/cli.py
+++ b/radiologist-inference/src/radiologist/inference/cli.py
@@ -32,12 +32,71 @@ from typing import Any, Callable, List, Optional, TypeVar
 
 import numpy as np
 
+from radiologist.inference.app import create_app
+from radiologist.inference.base_predictor import _resolve_and_pull
 from radiologist.inference.classifier import Classifier
 from radiologist.inference.explainer import Explainer
 from radiologist.inference.mc_dropout import MCDropoutPredictor
 from radiologist.inference.optional import _typer, _uvicorn
+from radiologist.registry import RegistrySelector
 
 F = TypeVar("F", bound=Callable[..., None])
+
+_SELECTOR_REQUIRED_MSG = (
+    "Provide either --model or a registry selector "
+    "(--run-id/--tags/--groups/--metric)."
+)
+
+
+def _load_predictor(
+    predictor_cls: Any,
+    model: Optional[str],
+    run_id: Optional[str],
+    tags: Optional[List[str]],
+    groups: Optional[List[str]],
+    metric: Optional[str],
+    local_dir: str,
+) -> Any:
+    """Dispatch to a registry selector or a local path, per predictor_cls."""
+    selector = RegistrySelector(
+        path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
+    )
+    if selector.is_registry_backed():
+        return predictor_cls.from_selector(selector, local_dir=local_dir)
+    if model is not None:
+        return predictor_cls.from_path(det_path=model)
+    raise ValueError(_SELECTOR_REQUIRED_MSG)
+
+
+def _load_uncertainty_predictor(
+    model: Optional[str],
+    run_id: Optional[str],
+    tags: Optional[List[str]],
+    groups: Optional[List[str]],
+    metric: Optional[str],
+    local_dir: str,
+    mcd_model: Optional[str],
+) -> "MCDropoutPredictor":
+    """Load det+mcd models: registry pair (run_id / {run_id}-mcd) or local paths."""
+    selector = RegistrySelector(
+        path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
+    )
+    if selector.is_registry_backed():
+        det_path = _resolve_and_pull(selector, local_dir)
+        mcd_run_id = f"{run_id}-mcd" if run_id else None
+        mcd_selector = RegistrySelector(
+            path=model or "",
+            run_id=mcd_run_id,
+            tags=tags,
+            groups=groups,
+            metric=metric,
+        )
+        mcd_path = _resolve_and_pull(mcd_selector, local_dir)
+        return MCDropoutPredictor.from_path(det_path=det_path, mcd_path=mcd_path)
+    if model is not None:
+        return MCDropoutPredictor.from_path(det_path=model, mcd_path=mcd_model)
+    raise ValueError(_SELECTOR_REQUIRED_MSG)
+
 
 if _typer is not None:
     import typer
@@ -73,14 +132,13 @@ if _typer is not None:
         local_dir: str = typer.Option(".", "--local-dir"),
     ) -> None:
         """Run classification inference on a chest X-ray image."""
-        if model is not None:
-            classifier = Classifier.from_path(det_path=model)
-            result = classifier.predict(image=image_path)
-            typer.echo(f"Predicted class: {result.predicted_class}")
-            for cls, prob in result.probabilities.items():
-                typer.echo(f"  {cls}: {prob:.4f}")
-        else:
-            raise NotImplementedError
+        classifier = _load_predictor(
+            Classifier, model, run_id, tags, groups, metric, local_dir
+        )
+        result = classifier.predict(image=image_path)
+        typer.echo(f"Predicted class: {result.predicted_class}")
+        for cls, prob in result.probabilities.items():
+            typer.echo(f"  {cls}: {prob:.4f}")
 
     @app.command()
     @_exit_on_error
@@ -101,17 +159,16 @@ if _typer is not None:
         ),
     ) -> None:
         """Produce a Score-CAM explanation for a chest X-ray image."""
-        if model is not None:
-            explainer = Explainer.from_path(det_path=model)
-            result = explainer.explain(image=image_path)
-            typer.echo(f"Predicted class: {result.predicted_class}")
-            if out is not None:
-                np.save(out, result.saliency_map)
-                typer.echo(f"Saliency map saved to: {out}")
-            else:
-                typer.echo(f"Saliency map shape: {result.saliency_map.shape}")
+        explainer = _load_predictor(
+            Explainer, model, run_id, tags, groups, metric, local_dir
+        )
+        result = explainer.explain(image=image_path)
+        typer.echo(f"Predicted class: {result.predicted_class}")
+        if out is not None:
+            np.save(out, result.saliency_map)
+            typer.echo(f"Saliency map saved to: {out}")
         else:
-            raise NotImplementedError
+            typer.echo(f"Saliency map shape: {result.saliency_map.shape}")
 
     @app.command()
     @_exit_on_error
@@ -135,18 +192,15 @@ if _typer is not None:
         ),
     ) -> None:
         """Estimate MC-Dropout uncertainty for a chest X-ray image."""
-        if model is not None:
-            predictor = MCDropoutPredictor.from_path(det_path=model, mcd_path=mcd_model)
-            result = predictor.predict_with_uncertainty(
-                image=image_path, n_passes=n_passes
-            )
-            typer.echo("Mean probabilities:")
-            for cls, prob in result.mean_probabilities.items():
-                std = result.std_per_class[cls]
-                typer.echo(f"  {cls}: {prob:.4f} (std={std:.4f})")
-            typer.echo(f"Predictive entropy: {result.predictive_entropy:.4f}")
-        else:
-            raise NotImplementedError
+        predictor = _load_uncertainty_predictor(
+            model, run_id, tags, groups, metric, local_dir, mcd_model
+        )
+        result = predictor.predict_with_uncertainty(image=image_path, n_passes=n_passes)
+        typer.echo("Mean probabilities:")
+        for cls, prob in result.mean_probabilities.items():
+            std = result.std_per_class[cls]
+            typer.echo(f"  {cls}: {prob:.4f} (std={std:.4f})")
+        typer.echo(f"Predictive entropy: {result.predictive_entropy:.4f}")
 
     @app.command()
     @_exit_on_error
@@ -166,7 +220,19 @@ if _typer is not None:
                 "The 'serve' extra is required to use the serve command. "
                 "Install it with: pip install radiologist-inference[serve]"
             )
-        raise NotImplementedError
+        selector = RegistrySelector(
+            path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
+        )
+        if selector.is_registry_backed():
+            predictor: Optional[Explainer] = Explainer.from_selector(
+                selector, local_dir=local_dir
+            )
+        elif model is not None:
+            predictor = Explainer.from_path(det_path=model)
+        else:
+            predictor = None
+        fastapi_app = create_app(predictor)
+        _uvicorn.run(fastapi_app, host=host, port=port)
 
 else:
     app = None  # type: ignore[assignment]

--- a/radiologist-inference/src/radiologist/inference/cli.py
+++ b/radiologist-inference/src/radiologist/inference/cli.py
@@ -28,14 +28,14 @@ Entry points: predict <image> --model <det_path>
 """
 
 import functools
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, List, Optional, TypeVar
 
 import numpy as np
 
 from radiologist.inference.classifier import Classifier
 from radiologist.inference.explainer import Explainer
 from radiologist.inference.mc_dropout import MCDropoutPredictor
-from radiologist.inference.optional import _typer
+from radiologist.inference.optional import _typer, _uvicorn
 
 F = TypeVar("F", bound=Callable[..., None])
 
@@ -63,16 +63,24 @@ if _typer is not None:
         image_path: str = typer.Argument(
             ..., help="Path to the input chest X-ray image."
         ),
-        model: str = typer.Option(
-            ..., "--model", help="Path to the deterministic ONNX model."
+        model: Optional[str] = typer.Option(
+            None, "--model", help="Path to the deterministic ONNX model."
         ),
+        run_id: Optional[str] = typer.Option(None, "--run-id"),
+        tags: Optional[List[str]] = typer.Option(None, "--tags"),
+        groups: Optional[List[str]] = typer.Option(None, "--groups"),
+        metric: Optional[str] = typer.Option(None, "--metric"),
+        local_dir: str = typer.Option(".", "--local-dir"),
     ) -> None:
         """Run classification inference on a chest X-ray image."""
-        classifier = Classifier.from_path(det_path=model)
-        result = classifier.predict(image=image_path)
-        typer.echo(f"Predicted class: {result.predicted_class}")
-        for cls, prob in result.probabilities.items():
-            typer.echo(f"  {cls}: {prob:.4f}")
+        if model is not None:
+            classifier = Classifier.from_path(det_path=model)
+            result = classifier.predict(image=image_path)
+            typer.echo(f"Predicted class: {result.predicted_class}")
+            for cls, prob in result.probabilities.items():
+                typer.echo(f"  {cls}: {prob:.4f}")
+        else:
+            raise NotImplementedError
 
     @app.command()
     @_exit_on_error
@@ -80,22 +88,30 @@ if _typer is not None:
         image_path: str = typer.Argument(
             ..., help="Path to the input chest X-ray image."
         ),
-        model: str = typer.Option(
-            ..., "--model", help="Path to the deterministic ONNX model."
+        model: Optional[str] = typer.Option(
+            None, "--model", help="Path to the deterministic ONNX model."
         ),
+        run_id: Optional[str] = typer.Option(None, "--run-id"),
+        tags: Optional[List[str]] = typer.Option(None, "--tags"),
+        groups: Optional[List[str]] = typer.Option(None, "--groups"),
+        metric: Optional[str] = typer.Option(None, "--metric"),
+        local_dir: str = typer.Option(".", "--local-dir"),
         out: Optional[str] = typer.Option(
             None, "--out", help="Path to save the saliency map as a .npy file."
         ),
     ) -> None:
         """Produce a Score-CAM explanation for a chest X-ray image."""
-        explainer = Explainer.from_path(det_path=model)
-        result = explainer.explain(image=image_path)
-        typer.echo(f"Predicted class: {result.predicted_class}")
-        if out is not None:
-            np.save(out, result.saliency_map)
-            typer.echo(f"Saliency map saved to: {out}")
+        if model is not None:
+            explainer = Explainer.from_path(det_path=model)
+            result = explainer.explain(image=image_path)
+            typer.echo(f"Predicted class: {result.predicted_class}")
+            if out is not None:
+                np.save(out, result.saliency_map)
+                typer.echo(f"Saliency map saved to: {out}")
+            else:
+                typer.echo(f"Saliency map shape: {result.saliency_map.shape}")
         else:
-            typer.echo(f"Saliency map shape: {result.saliency_map.shape}")
+            raise NotImplementedError
 
     @app.command()
     @_exit_on_error
@@ -103,24 +119,54 @@ if _typer is not None:
         image_path: str = typer.Argument(
             ..., help="Path to the input chest X-ray image."
         ),
-        model: str = typer.Option(
-            ..., "--model", help="Path to the deterministic ONNX model."
+        model: Optional[str] = typer.Option(
+            None, "--model", help="Path to the deterministic ONNX model."
         ),
-        mcd_model: str = typer.Option(
-            ..., "--mcd-model", help="Path to the MC-Dropout ONNX model."
+        run_id: Optional[str] = typer.Option(None, "--run-id"),
+        tags: Optional[List[str]] = typer.Option(None, "--tags"),
+        groups: Optional[List[str]] = typer.Option(None, "--groups"),
+        metric: Optional[str] = typer.Option(None, "--metric"),
+        local_dir: str = typer.Option(".", "--local-dir"),
+        mcd_model: Optional[str] = typer.Option(
+            None, "--mcd-model", help="Path to the MC-Dropout ONNX model."
         ),
         n_passes: int = typer.Option(
             30, "--n-passes", help="Number of stochastic forward passes."
         ),
     ) -> None:
         """Estimate MC-Dropout uncertainty for a chest X-ray image."""
-        predictor = MCDropoutPredictor.from_path(det_path=model, mcd_path=mcd_model)
-        result = predictor.predict_with_uncertainty(image=image_path, n_passes=n_passes)
-        typer.echo("Mean probabilities:")
-        for cls, prob in result.mean_probabilities.items():
-            std = result.std_per_class[cls]
-            typer.echo(f"  {cls}: {prob:.4f} (std={std:.4f})")
-        typer.echo(f"Predictive entropy: {result.predictive_entropy:.4f}")
+        if model is not None:
+            predictor = MCDropoutPredictor.from_path(det_path=model, mcd_path=mcd_model)
+            result = predictor.predict_with_uncertainty(
+                image=image_path, n_passes=n_passes
+            )
+            typer.echo("Mean probabilities:")
+            for cls, prob in result.mean_probabilities.items():
+                std = result.std_per_class[cls]
+                typer.echo(f"  {cls}: {prob:.4f} (std={std:.4f})")
+            typer.echo(f"Predictive entropy: {result.predictive_entropy:.4f}")
+        else:
+            raise NotImplementedError
+
+    @app.command()
+    @_exit_on_error
+    def serve(
+        model: Optional[str] = typer.Option(None, "--model"),
+        run_id: Optional[str] = typer.Option(None, "--run-id"),
+        tags: Optional[List[str]] = typer.Option(None, "--tags"),
+        groups: Optional[List[str]] = typer.Option(None, "--groups"),
+        metric: Optional[str] = typer.Option(None, "--metric"),
+        local_dir: str = typer.Option(".", "--local-dir"),
+        host: str = typer.Option("127.0.0.1", "--host"),
+        port: int = typer.Option(8000, "--port"),
+    ) -> None:
+        """Launch the FastAPI inference server via uvicorn."""
+        if _uvicorn is None:
+            raise RuntimeError(
+                "The 'serve' extra is required to use the serve command. "
+                "Install it with: pip install radiologist-inference[serve]"
+            )
+        raise NotImplementedError
 
 else:
     app = None  # type: ignore[assignment]

--- a/radiologist-inference/src/radiologist/inference/optional.py
+++ b/radiologist-inference/src/radiologist/inference/optional.py
@@ -36,3 +36,8 @@ try:
     import typer as _typer  # type: ignore[import-untyped]
 except ImportError:
     _typer = None  # type: ignore[assignment]
+
+try:
+    import uvicorn as _uvicorn  # type: ignore[import-untyped]
+except ImportError:
+    _uvicorn = None  # type: ignore[assignment]

--- a/radiologist-inference/tests/test_app.py
+++ b/radiologist-inference/tests/test_app.py
@@ -100,6 +100,11 @@ class TestClassifierApp:
         assert response.status_code == 200
         assert response.json() == {"status": "ok"}
 
+    def test_readyz_returns_200(self, client: TestClient) -> None:
+        response = client.get("/readyz")
+        assert response.status_code == 200
+        assert response.json() == {"status": "ready"}
+
     def test_predict_returns_400_on_missing_image(self, client: TestClient) -> None:
         response = client.post("/predict")
         assert response.status_code == 400
@@ -189,6 +194,10 @@ class TestMCDropoutApp:
         response = client.get("/healthz")
         assert response.status_code == 200
 
+    def test_readyz_returns_200(self, client: TestClient) -> None:
+        response = client.get("/readyz")
+        assert response.status_code == 200
+
 
 # ---------------------------------------------------------------------------
 # AC: a wired route with no predictor injected returns 503.
@@ -221,8 +230,14 @@ class TestNoPredictorInjected:
         )
         assert response.status_code == 503
 
-    def test_healthz_returns_503(self, client: TestClient) -> None:
+    def test_healthz_returns_200(self, client: TestClient) -> None:
+        """healthz is pure liveness: 200 even with no predictor loaded."""
         response = client.get("/healthz")
+        assert response.status_code == 200
+
+    def test_readyz_returns_503(self, client: TestClient) -> None:
+        """readyz owns readiness: 503 when no predictor is loaded."""
+        response = client.get("/readyz")
         assert response.status_code == 503
 
 

--- a/radiologist-inference/tests/test_classifier.py
+++ b/radiologist-inference/tests/test_classifier.py
@@ -29,7 +29,7 @@ boundary is exercised via a fake registry or the shared optional._wandb
 sentinel.
 """
 
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 from unittest.mock import patch
 
 import numpy as np
@@ -37,6 +37,7 @@ import pytest
 from _helpers import build_det_onnx
 
 from radiologist.inference import BasePredictor, Classifier, Prediction
+from radiologist.registry import ArtifactRef, RegistrySelector
 
 CLASSES = ["NORMAL", "ABNORMAL"]
 
@@ -48,6 +49,36 @@ class _FakeRegistry:
 
     def pull(self, artifact_path: str, local_dir: str) -> str:
         self.calls.append((artifact_path, local_dir))
+        return self._det_path
+
+
+class _FakeSelectorRegistry:
+    def __init__(self, det_path: str) -> None:
+        self._det_path = det_path
+        self.resolve_calls: List[Tuple[str, Optional[str]]] = []
+        self.pull_calls: List[Tuple[str, str]] = []
+
+    def resolve(
+        self,
+        path: str,
+        run_id=None,
+        groups=None,
+        tags=None,
+        metric=None,
+        version=None,
+        include_sweeps: bool = False,
+    ) -> ArtifactRef:
+        self.resolve_calls.append((path, run_id))
+        resolved_run_id = run_id or "resolved-run"
+        return ArtifactRef(
+            qualified_name=f"{path}/model-{resolved_run_id}:best",
+            run_id=resolved_run_id,
+            artifact_name=f"model-{resolved_run_id}",
+            version="best",
+        )
+
+    def pull(self, artifact_path: str, local_dir: str) -> str:
+        self.pull_calls.append((artifact_path, local_dir))
         return self._det_path
 
 
@@ -152,3 +183,58 @@ class TestClassifierFromRegistry:
                     artifact_path="entity/project/name:v0",
                     local_dir=str(tmp_path),
                 )
+
+    def test_from_registry_names_inference_extra_not_registry_extra(self, tmp_path):
+        """The wandb-missing message must name radiologist-inference[registry],
+        not radiologist-registry[wandb] (bugfix b)."""
+        import radiologist.registry.optional as optional_mod
+
+        with patch.object(optional_mod, "_wandb", None):
+            with pytest.raises(
+                RuntimeError, match=r"radiologist-inference\[registry\]"
+            ):
+                Classifier.from_registry(
+                    artifact_path="entity/project/name:v0",
+                    local_dir=str(tmp_path),
+                )
+
+
+class TestClassifierFromSelector:
+    def test_from_selector_with_injected_registry_resolves_and_pulls(
+        self, det_onnx_path, tmp_path
+    ):
+        """from_selector must resolve the selector then pull the resolved
+        artifact, returning a Classifier equivalent to from_path."""
+        fake_registry = _FakeSelectorRegistry(det_onnx_path)
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        classifier = Classifier.from_selector(
+            selector, local_dir=str(tmp_path), registry=fake_registry
+        )
+        path_classifier = Classifier.from_path(det_path=det_onnx_path)
+
+        image = np.zeros((224, 224, 3), dtype=np.uint8)
+        selector_result = classifier.predict(image=image)
+        path_result = path_classifier.predict(image=image)
+
+        assert isinstance(classifier, Classifier)
+        assert selector_result.predicted_class == path_result.predicted_class
+        assert fake_registry.resolve_calls == [("entity/project/model", "run123")]
+        assert fake_registry.pull_calls == [
+            ("entity/project/model/model-run123:best", str(tmp_path))
+        ]
+
+    def test_from_selector_raises_runtime_error_naming_inference_extra_when_wandb_absent(
+        self, tmp_path
+    ):
+        """from_selector with no injected registry and wandb absent must raise
+        RuntimeError naming radiologist-inference[registry] (bugfix b)."""
+        import radiologist.registry.optional as optional_mod
+
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        with patch.object(optional_mod, "_wandb", None):
+            with pytest.raises(
+                RuntimeError, match=r"radiologist-inference\[registry\]"
+            ):
+                Classifier.from_selector(selector, local_dir=str(tmp_path))

--- a/radiologist-inference/tests/test_cli.py
+++ b/radiologist-inference/tests/test_cli.py
@@ -53,8 +53,8 @@ def _make_png_path(tmp_path, width: int = 64, height: int = 64) -> str:
 
 
 def test_cli_exposes_predict_explain_uncertainty_commands():
-    """The CLI must expose exactly predict, explain, and uncertainty."""
-    assert _command_names() == {"predict", "explain", "uncertainty"}
+    """The CLI must expose predict, explain, uncertainty, and serve."""
+    assert _command_names() == {"predict", "explain", "uncertainty", "serve"}
 
 
 def test_cli_no_longer_exposes_pull_command():

--- a/radiologist-inference/tests/test_cli.py
+++ b/radiologist-inference/tests/test_cli.py
@@ -27,7 +27,7 @@ Classifier/Explainer/MCDropoutPredictor, the absence of a pull subcommand,
 and the typer-absent RuntimeError guard.
 """
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import numpy as np
 import pytest
@@ -38,6 +38,32 @@ from typer.testing import CliRunner
 from radiologist.inference.cli import app
 
 runner = CliRunner()
+
+
+def _make_registry_wandb_mock(qualified_name: str = "entity/project/model-run1:best"):
+    """A wandb mock distinguishing resolve()'s kwargs artifact() call from
+    pull()'s positional artifact() call, per _WandbResolver's two call shapes.
+    """
+    mock_wandb = MagicMock()
+
+    resolved_art = MagicMock()
+    resolved_art.qualified_name = qualified_name
+    resolved_art.version = "best"
+
+    pulled_art = MagicMock()
+
+    best_run = MagicMock()
+    best_run.id = "run1"
+
+    api_instance = MagicMock()
+    api_instance.runs.return_value = [best_run]
+
+    def _artifact(*args, **kwargs):
+        return resolved_art if kwargs else pulled_art
+
+    api_instance.artifact.side_effect = _artifact
+    mock_wandb.Api.return_value = api_instance
+    return mock_wandb, pulled_art
 
 
 def _command_names():
@@ -137,3 +163,161 @@ class TestUncertaintyCommand:
 
         assert result.exit_code == 0
         assert "entropy" in result.output.lower()
+
+
+class TestRegistrySelectorDispatch:
+    def test_predict_with_run_id_resolves_from_registry(self, tmp_path):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        image_path = _make_png_path(tmp_path)
+        mock_wandb, pulled_art = _make_registry_wandb_mock()
+        pulled_art.download.return_value = str(tmp_path)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            result = runner.invoke(
+                app,
+                [
+                    "predict",
+                    image_path,
+                    "--run-id",
+                    "run1",
+                    "--local-dir",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "Predicted class:" in result.output
+        assert det_path is not None
+
+    def test_predict_with_tags_passes_repeatable_list(self, tmp_path):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        image_path = _make_png_path(tmp_path)
+        mock_wandb, pulled_art = _make_registry_wandb_mock()
+        pulled_art.download.return_value = str(tmp_path)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            result = runner.invoke(
+                app,
+                [
+                    "predict",
+                    image_path,
+                    "--tags",
+                    "a",
+                    "--tags",
+                    "b",
+                    "--local-dir",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        api_instance = mock_wandb.Api.return_value
+        _, kwargs = api_instance.runs.call_args
+        assert kwargs["filters"]["tags"]["$in"] == ["a", "b"]
+        assert det_path is not None
+
+    def test_predict_without_model_or_selector_exits_nonzero(self, tmp_path):
+        image_path = _make_png_path(tmp_path)
+
+        result = runner.invoke(app, ["predict", image_path])
+
+        assert result.exit_code != 0
+        assert "--model" in result.output
+        assert "--run-id" in result.output or "selector" in result.output.lower()
+
+    def test_predict_with_run_id_and_tags_exits_nonzero(self, tmp_path):
+        image_path = _make_png_path(tmp_path)
+
+        result = runner.invoke(
+            app,
+            ["predict", image_path, "--run-id", "run1", "--tags", "a"],
+        )
+
+        assert result.exit_code != 0
+
+    def test_uncertainty_with_run_id_resolves_det_and_mcd_models(self, tmp_path):
+        det_dir = tmp_path / "det"
+        mcd_dir = tmp_path / "mcd"
+        det_dir.mkdir()
+        mcd_dir.mkdir()
+        build_det_onnx(det_dir, filename="det.onnx")
+        build_mcd_onnx(mcd_dir, filename="mcd.onnx")
+        image_path = _make_png_path(tmp_path)
+
+        mock_wandb, pulled_art = _make_registry_wandb_mock()
+        pulled_art.download.side_effect = [str(det_dir), str(mcd_dir)]
+
+        import radiologist.registry.resolver as resolver_mod
+
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            result = runner.invoke(
+                app,
+                [
+                    "uncertainty",
+                    image_path,
+                    "--run-id",
+                    "run1",
+                    "--local-dir",
+                    str(tmp_path),
+                    "--n-passes",
+                    "5",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "entropy" in result.output.lower()
+
+    def test_predict_with_run_id_fails_naming_inference_extra_when_wandb_absent(
+        self, tmp_path
+    ):
+        image_path = _make_png_path(tmp_path)
+        import radiologist.registry.optional as optional_mod
+
+        with patch.object(optional_mod, "_wandb", None):
+            result = runner.invoke(app, ["predict", image_path, "--run-id", "run1"])
+
+        assert result.exit_code != 0
+        assert "radiologist-inference[registry]" in result.output
+
+
+class TestServeCommand:
+    def test_serve_with_model_invokes_uvicorn_run(self, tmp_path):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        import radiologist.inference.cli as cli_mod
+
+        mock_uvicorn = MagicMock()
+        with patch.object(cli_mod, "_uvicorn", mock_uvicorn):
+            result = runner.invoke(
+                app,
+                [
+                    "serve",
+                    "--model",
+                    det_path,
+                    "--host",
+                    "0.0.0.0",
+                    "--port",
+                    "9000",
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_uvicorn.run.assert_called_once()
+        _, kwargs = mock_uvicorn.run.call_args
+        assert kwargs["host"] == "0.0.0.0"
+        assert kwargs["port"] == 9000
+
+    def test_serve_raises_runtime_error_naming_serve_extra_when_uvicorn_absent(
+        self, tmp_path
+    ):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        import radiologist.inference.cli as cli_mod
+
+        with patch.object(cli_mod, "_uvicorn", None):
+            result = runner.invoke(app, ["serve", "--model", det_path])
+
+        assert result.exit_code != 0
+        assert "serve" in result.output

--- a/radiologist-inference/tests/test_score_cam.py
+++ b/radiologist-inference/tests/test_score_cam.py
@@ -23,8 +23,8 @@
 """Behavioral tests for the standalone score_cam() saliency function.
 
 Tests drive through the public API only. Explainer.explain()'s behavioral
-coverage lives in test_explainer.py, which exercises the same saliency
-computation through Explainer.explain().
+coverage lives in test_explainer.py, which exercises the different
+score_cam_with_session() masked-ONNX-pass computation, not score_cam().
 """
 
 import numpy as np

--- a/radiologist-registry/README.md
+++ b/radiologist-registry/README.md
@@ -1,0 +1,106 @@
+# radiologist-registry
+
+W&B model registry facade — resolve, download, push, and promote ONNX/checkpoint
+artifacts for the radiologist pipeline. Ships a `WandbRegistry` library and a
+Typer CLI (`radiologist-registry`) built on top of it.
+
+## Installation
+
+### Hard dependencies (always installed)
+
+```bash
+pip install radiologist-registry
+```
+
+### Optional extras
+
+| Extra | Installs | Enables |
+|---|---|---|
+| `wandb` | `wandb` | `WandbRegistry` (all registry operations) |
+| `cli` | `typer` | `radiologist-registry` CLI entry point |
+
+```bash
+pip install "radiologist-registry[cli,wandb]"
+```
+
+## Public API
+
+Exported from `radiologist.registry`:
+
+- **`ModelRegistry`** — `Protocol` describing the registry backend contract:
+  `resolve`, `download`, `pull`, `log_model_artifacts`,
+  `list_collection_artifacts`, `promote`, `transition_to_production`,
+  `get_aliases`, `set_alias`, `remove_alias`.
+- **`WandbRegistry`** — the W&B-backed implementation of `ModelRegistry`.
+  Constructs eagerly (no injected dependencies needed for CLI use).
+- **`RegistrySelector`** / **`resolve_selector`** — a declarative,
+  framework-neutral description of which artifact to resolve
+  (`path`, `run_id`, `groups`, `tags`, `metric`, `version`,
+  `include_sweeps`). `resolve_selector(selector, registry)` validates that
+  `run_id` and `tags` are not both set, then delegates to
+  `registry.resolve(...)`.
+- **`ArtifactRef`** — resolved artifact pointer (`qualified_name`, `run_id`,
+  `artifact_name`, `version`).
+- **`ExportResult`** — paths and metadata for a freshly exported model pair
+  (`det_path`, `mcd_path`, `run_id`, `input_shape`, `classes`).
+- **`LoggedArtifacts`** — qualified names of artifacts logged to an active run
+  but not yet linked to a collection (`det_qualified_name`,
+  `mcd_qualified_name`, `run_id`).
+- **`PromoteResult`** — outcome of a link/transition transaction; the
+  deterministic and MC-Dropout artifacts always share one `alias`
+  (`det_qualified_name`, `mcd_qualified_name`, `alias`).
+- **`CollectionMember`** — one artifact version in a collection together with
+  its current alias list (`qualified_name`, `aliases`).
+
+```python
+from radiologist.registry import RegistrySelector, WandbRegistry, resolve_selector
+
+registry = WandbRegistry()
+selector = RegistrySelector(path="entity/project", run_id="abc123")
+ref = resolve_selector(selector, registry)
+local_ckpt = registry.download(ref, local_dir="./models")
+```
+
+## CLI reference
+
+All commands construct a `WandbRegistry()` internally — no separate wiring
+required. Errors surface as `Error: {message}` on stderr with a non-zero exit
+code.
+
+| Command | Flags | Description |
+|---|---|---|
+| `resolve <path>` | `--run-id`, `--tags`, `--groups`, `--metric`, `--version`, `--include-sweeps` | Resolve a selector to a qualified name and version. |
+| `pull <path>` | `--local-dir`, `--run-id`, `--tags`, `--groups`, `--metric`, `--version`, `--include-sweeps` | Resolve (if any selector flag is given) then download, or treat `path` as a raw artifact path. |
+| `push` | `--det-path`, `--mcd-path`, `--run-id`, `--det-collection`, `--mcd-collection`, `--input-shape` (repeatable), `--classes` (repeatable) | Open an ephemeral W&B run and log the deterministic and MC-Dropout artifacts. |
+| `promote <path>` | `--run-id`, `--det-collection`, `--mcd-collection`, `--force` | Link both artifacts to their collections with `staging`/`production` alias; prompts unless `--force`. |
+| `transition-to-production` | `--det-collection`, `--mcd-collection`, `--force` | Flip the `staging` member of each collection to `production`; prompts unless `--force`. |
+| `list` | `--type`, `--collection` | List every member of a collection with its current aliases. |
+| `alias get <artifact_path>` | — | Print the artifact's current aliases. |
+| `alias set <artifact_path> <alias>` | — | Add an alias to the artifact. |
+| `alias remove <artifact_path> <alias>` | — | Remove an alias from the artifact. |
+
+### Examples
+
+```bash
+radiologist-registry resolve entity/project --run-id abc123
+
+radiologist-registry pull entity/project --local-dir ./models --run-id abc123
+
+radiologist-registry push \
+  --det-path model.onnx --mcd-path model_mcd.onnx --run-id abc123 \
+  --det-collection det-models --mcd-collection mcd-models \
+  --input-shape 1 --input-shape 3 --input-shape 224 --input-shape 224 \
+  --classes NORMAL --classes PNEUMONIA
+
+radiologist-registry promote entity/project --run-id abc123 \
+  --det-collection det-models --mcd-collection mcd-models --force
+
+radiologist-registry transition-to-production \
+  --det-collection det-models --mcd-collection mcd-models --force
+
+radiologist-registry list --type model --collection det-models
+
+radiologist-registry alias set entity/project/model-abc123:best staging
+radiologist-registry alias get entity/project/model-abc123:best
+radiologist-registry alias remove entity/project/model-abc123:best staging
+```

--- a/radiologist-registry/pyproject.toml
+++ b/radiologist-registry/pyproject.toml
@@ -10,6 +10,10 @@ dependencies = [
 
 [project.optional-dependencies]
 wandb = ["wandb>=0.27.0"]
+cli = ["typer>=0.9.0"]
+
+[project.scripts]
+radiologist-registry = "radiologist.registry.cli:main"
 
 [build-system]
 requires = ["uv_build>=0.9.28,<0.10.0"]

--- a/radiologist-registry/src/radiologist/registry/__init__.py
+++ b/radiologist-registry/src/radiologist/registry/__init__.py
@@ -28,7 +28,11 @@ from radiologist.registry.models import (
     LoggedArtifacts,
     PromoteResult,
 )
-from radiologist.registry.selector import RegistrySelector, resolve_selector
+from radiologist.registry.selector import (
+    RegistrySelector,
+    resolve_selector,
+    selector_from_flags,
+)
 from radiologist.registry.wandb_registry import WandbRegistry
 
 __all__ = [
@@ -41,4 +45,5 @@ __all__ = [
     "RegistrySelector",
     "WandbRegistry",
     "resolve_selector",
+    "selector_from_flags",
 ]

--- a/radiologist-registry/src/radiologist/registry/__init__.py
+++ b/radiologist-registry/src/radiologist/registry/__init__.py
@@ -28,6 +28,7 @@ from radiologist.registry.models import (
     LoggedArtifacts,
     PromoteResult,
 )
+from radiologist.registry.selector import RegistrySelector, resolve_selector
 from radiologist.registry.wandb_registry import WandbRegistry
 
 __all__ = [
@@ -37,5 +38,7 @@ __all__ = [
     "LoggedArtifacts",
     "ModelRegistry",
     "PromoteResult",
+    "RegistrySelector",
     "WandbRegistry",
+    "resolve_selector",
 ]

--- a/radiologist-registry/src/radiologist/registry/cli.py
+++ b/radiologist-registry/src/radiologist/registry/cli.py
@@ -1,0 +1,126 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Typer-based CLI for radiologist-registry.
+
+Entry points: push, pull, resolve, promote, transition-to-production, list,
+              alias get/set/remove
+"""
+
+from typing import List, Optional
+
+from radiologist.registry.optional import _TYPER_MISSING_MSG, _typer
+
+if _typer is not None:
+    import typer
+
+    app = typer.Typer(name="radiologist-registry", add_completion=False)
+
+    @app.command()
+    def push(
+        det_path: str = typer.Option(..., "--det-path"),
+        mcd_path: str = typer.Option(..., "--mcd-path"),
+        run_id: str = typer.Option(..., "--run-id"),
+        det_collection: str = typer.Option(..., "--det-collection"),
+        mcd_collection: str = typer.Option(..., "--mcd-collection"),
+        input_shape: List[int] = typer.Option(..., "--input-shape"),
+        classes: List[str] = typer.Option(..., "--classes"),
+    ) -> None:
+        raise NotImplementedError
+
+    @app.command()
+    def pull(
+        path: str = typer.Argument(...),
+        local_dir: str = typer.Option(..., "--local-dir"),
+        run_id: Optional[str] = typer.Option(None, "--run-id"),
+        tags: Optional[List[str]] = typer.Option(None, "--tags"),
+        groups: Optional[List[str]] = typer.Option(None, "--groups"),
+        metric: Optional[str] = typer.Option(None, "--metric"),
+        version: Optional[str] = typer.Option(None, "--version"),
+        include_sweeps: bool = typer.Option(False, "--include-sweeps"),
+    ) -> None:
+        raise NotImplementedError
+
+    @app.command()
+    def resolve(
+        path: str = typer.Argument(...),
+        run_id: Optional[str] = typer.Option(None, "--run-id"),
+        tags: Optional[List[str]] = typer.Option(None, "--tags"),
+        groups: Optional[List[str]] = typer.Option(None, "--groups"),
+        metric: Optional[str] = typer.Option(None, "--metric"),
+        version: Optional[str] = typer.Option(None, "--version"),
+        include_sweeps: bool = typer.Option(False, "--include-sweeps"),
+    ) -> None:
+        raise NotImplementedError
+
+    @app.command()
+    def promote(
+        path: str = typer.Argument(...),
+        run_id: str = typer.Option(..., "--run-id"),
+        det_collection: str = typer.Option(..., "--det-collection"),
+        mcd_collection: str = typer.Option(..., "--mcd-collection"),
+        force: bool = typer.Option(False, "--force"),
+    ) -> None:
+        raise NotImplementedError
+
+    @app.command(name="transition-to-production")
+    def transition_to_production(
+        det_collection: str = typer.Option(..., "--det-collection"),
+        mcd_collection: str = typer.Option(..., "--mcd-collection"),
+        force: bool = typer.Option(False, "--force"),
+    ) -> None:
+        raise NotImplementedError
+
+    @app.command(name="list")
+    def list_(
+        type_name: str = typer.Option(..., "--type"),
+        collection_name: str = typer.Option(..., "--collection"),
+    ) -> None:
+        raise NotImplementedError
+
+    alias_app = typer.Typer(name="alias", add_completion=False)
+    app.add_typer(alias_app, name="alias")
+
+    @alias_app.command("get")
+    def alias_get(artifact_path: str = typer.Argument(...)) -> None:
+        raise NotImplementedError
+
+    @alias_app.command("set")
+    def alias_set(
+        artifact_path: str = typer.Argument(...), alias: str = typer.Argument(...)
+    ) -> None:
+        raise NotImplementedError
+
+    @alias_app.command("remove")
+    def alias_remove(
+        artifact_path: str = typer.Argument(...), alias: str = typer.Argument(...)
+    ) -> None:
+        raise NotImplementedError
+
+else:
+    app = None  # type: ignore[assignment]
+
+
+def main() -> None:
+    if _typer is None:
+        raise RuntimeError(_TYPER_MISSING_MSG)
+    app()  # type: ignore[misc]

--- a/radiologist-registry/src/radiologist/registry/cli.py
+++ b/radiologist-registry/src/radiologist/registry/cli.py
@@ -32,7 +32,7 @@ from typing import Any, Callable, List, Optional, TypeVar
 from radiologist.registry.models import ExportResult
 from radiologist.registry.optional import _wandb  # noqa: F401
 from radiologist.registry.optional import _TYPER_MISSING_MSG, _guard_wandb, _typer
-from radiologist.registry.selector import RegistrySelector, resolve_selector
+from radiologist.registry.selector import resolve_selector, selector_from_flags
 from radiologist.registry.wandb_registry import WandbRegistry
 
 F = TypeVar("F", bound=Callable[..., None])
@@ -95,7 +95,7 @@ if _typer is not None:
         include_sweeps: bool = typer.Option(False, "--include-sweeps"),
     ) -> None:
         registry = WandbRegistry()
-        selector = RegistrySelector(
+        selector = selector_from_flags(
             path=path,
             run_id=run_id,
             groups=groups,
@@ -122,7 +122,7 @@ if _typer is not None:
         version: Optional[str] = typer.Option(None, "--version"),
         include_sweeps: bool = typer.Option(False, "--include-sweeps"),
     ) -> None:
-        selector = RegistrySelector(
+        selector = selector_from_flags(
             path=path,
             run_id=run_id,
             groups=groups,

--- a/radiologist-registry/src/radiologist/registry/cli.py
+++ b/radiologist-registry/src/radiologist/registry/cli.py
@@ -26,16 +26,37 @@ Entry points: push, pull, resolve, promote, transition-to-production, list,
               alias get/set/remove
 """
 
-from typing import List, Optional
+import functools
+from typing import Any, Callable, List, Optional, TypeVar
 
-from radiologist.registry.optional import _TYPER_MISSING_MSG, _typer
+from radiologist.registry.models import ExportResult
+from radiologist.registry.optional import _wandb  # noqa: F401
+from radiologist.registry.optional import _TYPER_MISSING_MSG, _guard_wandb, _typer
+from radiologist.registry.selector import RegistrySelector, resolve_selector
+from radiologist.registry.wandb_registry import WandbRegistry
+
+F = TypeVar("F", bound=Callable[..., None])
 
 if _typer is not None:
     import typer
 
     app = typer.Typer(name="radiologist-registry", add_completion=False)
 
+    def _exit_on_error(func: F) -> F:
+        """Wrap a CLI command so unhandled exceptions become a clean exit(1)."""
+
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> None:
+            try:
+                func(*args, **kwargs)
+            except Exception as exc:
+                typer.echo(f"Error: {exc}", err=True)
+                raise typer.Exit(code=1)
+
+        return wrapper  # type: ignore[return-value]
+
     @app.command()
+    @_exit_on_error
     def push(
         det_path: str = typer.Option(..., "--det-path"),
         mcd_path: str = typer.Option(..., "--mcd-path"),
@@ -45,9 +66,24 @@ if _typer is not None:
         input_shape: List[int] = typer.Option(..., "--input-shape"),
         classes: List[str] = typer.Option(..., "--classes"),
     ) -> None:
-        raise NotImplementedError
+        _guard_wandb()
+        export_result = ExportResult(
+            det_path=det_path,
+            mcd_path=mcd_path,
+            run_id=run_id,
+            input_shape=tuple(input_shape),
+            classes=classes,
+        )
+        run = _wandb.init(job_type="push")  # type: ignore[union-attr]
+        logged = WandbRegistry().log_model_artifacts(
+            export_result, run=run, ckpt_path=det_path
+        )
+        run.finish()
+        typer.echo(logged.det_qualified_name)
+        typer.echo(logged.mcd_qualified_name)
 
     @app.command()
+    @_exit_on_error
     def pull(
         path: str = typer.Argument(...),
         local_dir: str = typer.Option(..., "--local-dir"),
@@ -58,9 +94,25 @@ if _typer is not None:
         version: Optional[str] = typer.Option(None, "--version"),
         include_sweeps: bool = typer.Option(False, "--include-sweeps"),
     ) -> None:
-        raise NotImplementedError
+        registry = WandbRegistry()
+        selector = RegistrySelector(
+            path=path,
+            run_id=run_id,
+            groups=groups,
+            tags=tags,
+            metric=metric,
+            version=version,
+            include_sweeps=include_sweeps,
+        )
+        if selector.is_registry_backed():
+            ref = resolve_selector(selector, registry)
+            local_path = registry.download(ref, local_dir)
+        else:
+            local_path = registry.pull(path, local_dir)
+        typer.echo(local_path)
 
     @app.command()
+    @_exit_on_error
     def resolve(
         path: str = typer.Argument(...),
         run_id: Optional[str] = typer.Option(None, "--run-id"),
@@ -70,9 +122,21 @@ if _typer is not None:
         version: Optional[str] = typer.Option(None, "--version"),
         include_sweeps: bool = typer.Option(False, "--include-sweeps"),
     ) -> None:
-        raise NotImplementedError
+        selector = RegistrySelector(
+            path=path,
+            run_id=run_id,
+            groups=groups,
+            tags=tags,
+            metric=metric,
+            version=version,
+            include_sweeps=include_sweeps,
+        )
+        ref = resolve_selector(selector, WandbRegistry())
+        typer.echo(ref.qualified_name)
+        typer.echo(ref.version)
 
     @app.command()
+    @_exit_on_error
     def promote(
         path: str = typer.Argument(...),
         run_id: str = typer.Option(..., "--run-id"),
@@ -80,41 +144,66 @@ if _typer is not None:
         mcd_collection: str = typer.Option(..., "--mcd-collection"),
         force: bool = typer.Option(False, "--force"),
     ) -> None:
-        raise NotImplementedError
+        if not force and not typer.confirm(
+            f"Promote {path!r} (run {run_id!r}) to "
+            f"{det_collection!r}/{mcd_collection!r}?"
+        ):
+            raise typer.Abort()
+        result = WandbRegistry().promote(path, run_id, det_collection, mcd_collection)
+        typer.echo(f"{result.det_qualified_name} -> {result.alias}")
+        typer.echo(f"{result.mcd_qualified_name} -> {result.alias}")
 
     @app.command(name="transition-to-production")
+    @_exit_on_error
     def transition_to_production(
         det_collection: str = typer.Option(..., "--det-collection"),
         mcd_collection: str = typer.Option(..., "--mcd-collection"),
         force: bool = typer.Option(False, "--force"),
     ) -> None:
-        raise NotImplementedError
+        if not force and not typer.confirm(
+            f"Transition {det_collection!r}/{mcd_collection!r} to production?"
+        ):
+            raise typer.Abort()
+        result = WandbRegistry().transition_to_production(
+            det_collection, mcd_collection
+        )
+        typer.echo(f"{result.det_qualified_name} -> {result.alias}")
+        typer.echo(f"{result.mcd_qualified_name} -> {result.alias}")
 
     @app.command(name="list")
+    @_exit_on_error
     def list_(
         type_name: str = typer.Option(..., "--type"),
         collection_name: str = typer.Option(..., "--collection"),
     ) -> None:
-        raise NotImplementedError
+        members = WandbRegistry().list_collection_artifacts(type_name, collection_name)
+        for member in members:
+            typer.echo(f"{member.qualified_name} {member.aliases}")
 
     alias_app = typer.Typer(name="alias", add_completion=False)
     app.add_typer(alias_app, name="alias")
 
     @alias_app.command("get")
+    @_exit_on_error
     def alias_get(artifact_path: str = typer.Argument(...)) -> None:
-        raise NotImplementedError
+        aliases = WandbRegistry().get_aliases(artifact_path)
+        typer.echo(" ".join(aliases))
 
     @alias_app.command("set")
+    @_exit_on_error
     def alias_set(
         artifact_path: str = typer.Argument(...), alias: str = typer.Argument(...)
     ) -> None:
-        raise NotImplementedError
+        WandbRegistry().set_alias(artifact_path, alias)
+        typer.echo(f"Set alias {alias!r} on {artifact_path!r}")
 
     @alias_app.command("remove")
+    @_exit_on_error
     def alias_remove(
         artifact_path: str = typer.Argument(...), alias: str = typer.Argument(...)
     ) -> None:
-        raise NotImplementedError
+        WandbRegistry().remove_alias(artifact_path, alias)
+        typer.echo(f"Removed alias {alias!r} from {artifact_path!r}")
 
 else:
     app = None  # type: ignore[assignment]

--- a/radiologist-registry/src/radiologist/registry/optional.py
+++ b/radiologist-registry/src/radiologist/registry/optional.py
@@ -36,3 +36,14 @@ _MODEL_ARTIFACT_TYPE = "model"
 def _guard_wandb() -> None:
     if _wandb is None:
         raise RuntimeError(_WANDB_MISSING_MSG)
+
+
+try:
+    import typer as _typer  # type: ignore[import-untyped]
+except ImportError:
+    _typer = None  # type: ignore[assignment]
+
+_TYPER_MISSING_MSG = (
+    "typer is required for the radiologist-registry CLI. "
+    "Install with: pip install 'radiologist-registry[cli]'"
+)

--- a/radiologist-registry/src/radiologist/registry/selector.py
+++ b/radiologist-registry/src/radiologist/registry/selector.py
@@ -1,0 +1,63 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from radiologist.registry.interface import ModelRegistry
+from radiologist.registry.models import ArtifactRef
+
+
+@dataclass(frozen=True)
+class RegistrySelector:
+    """Declarative description of which artifact to resolve, framework-neutral.
+
+    Precedence when resolved: run_id (direct lookup) else tags (filtered search)
+    else path (raw artifact path / local file). See resolve_selector for the
+    strict validation the CLI layer adds on top of the underlying resolve().
+    """
+
+    path: str
+    run_id: Optional[str] = None
+    groups: Optional[List[str]] = None
+    tags: Optional[List[str]] = None
+    metric: Optional[str] = None
+    version: Optional[str] = None
+    include_sweeps: bool = False
+
+    def is_registry_backed(self) -> bool:
+        # contract: True when any registry selector field (run_id/tags/groups/
+        #   metric/version) is set; False when only a raw path/local file is
+        #   implied. Single dispatch rule for "local file vs registry".
+        raise NotImplementedError
+
+
+def resolve_selector(
+    selector: RegistrySelector, registry: ModelRegistry
+) -> ArtifactRef:
+    # contract: forwards selector fields to registry.resolve(...) applying the
+    #   run_id -> tags -> path cascade and returns the resolved ArtifactRef.
+    #   Raises ValueError when BOTH run_id and tags are set (strict CLI-facing
+    #   validation, stricter than the underlying resolve()). Propagates whatever
+    #   registry.resolve raises (ValueError on no match, RuntimeError when wandb
+    #   missing).
+    raise NotImplementedError

--- a/radiologist-registry/src/radiologist/registry/selector.py
+++ b/radiologist-registry/src/radiologist/registry/selector.py
@@ -50,6 +50,27 @@ class RegistrySelector:
         )
 
 
+def selector_from_flags(
+    path: str,
+    run_id: Optional[str] = None,
+    tags: Optional[List[str]] = None,
+    groups: Optional[List[str]] = None,
+    metric: Optional[str] = None,
+    version: Optional[str] = None,
+    include_sweeps: bool = False,
+) -> RegistrySelector:
+    """Build a RegistrySelector from CLI-style flag values."""
+    return RegistrySelector(
+        path=path,
+        run_id=run_id,
+        tags=tags,
+        groups=groups,
+        metric=metric,
+        version=version,
+        include_sweeps=include_sweeps,
+    )
+
+
 def resolve_selector(
     selector: RegistrySelector, registry: ModelRegistry
 ) -> ArtifactRef:

--- a/radiologist-registry/src/radiologist/registry/selector.py
+++ b/radiologist-registry/src/radiologist/registry/selector.py
@@ -45,19 +45,22 @@ class RegistrySelector:
     include_sweeps: bool = False
 
     def is_registry_backed(self) -> bool:
-        # contract: True when any registry selector field (run_id/tags/groups/
-        #   metric/version) is set; False when only a raw path/local file is
-        #   implied. Single dispatch rule for "local file vs registry".
-        raise NotImplementedError
+        return bool(
+            self.run_id or self.tags or self.groups or self.metric or self.version
+        )
 
 
 def resolve_selector(
     selector: RegistrySelector, registry: ModelRegistry
 ) -> ArtifactRef:
-    # contract: forwards selector fields to registry.resolve(...) applying the
-    #   run_id -> tags -> path cascade and returns the resolved ArtifactRef.
-    #   Raises ValueError when BOTH run_id and tags are set (strict CLI-facing
-    #   validation, stricter than the underlying resolve()). Propagates whatever
-    #   registry.resolve raises (ValueError on no match, RuntimeError when wandb
-    #   missing).
-    raise NotImplementedError
+    if selector.run_id and selector.tags:
+        raise ValueError("Provide either --run-id or --tags, not both.")
+    return registry.resolve(
+        path=selector.path,
+        run_id=selector.run_id,
+        groups=selector.groups,
+        tags=selector.tags,
+        metric=selector.metric,
+        version=selector.version,
+        include_sweeps=selector.include_sweeps,
+    )

--- a/radiologist-registry/tests/test_cli.py
+++ b/radiologist-registry/tests/test_cli.py
@@ -1,0 +1,326 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from radiologist.registry.cli import app
+
+runner = CliRunner()
+
+
+def _make_artifact(qualified_name: str, version: str, aliases=None):
+    art = MagicMock()
+    art.qualified_name = qualified_name
+    art.version = version
+    art.aliases = list(aliases or [])
+    art.save = MagicMock()
+    art.link = MagicMock()
+    return art
+
+
+class TestResolveCommand:
+    def test_prints_resolved_qualified_name_and_version(self):
+        art = _make_artifact("entity/project/model-R:best", "v3")
+        with patch("radiologist.registry.resolver._wandb") as mock_wandb:
+            mock_api = MagicMock()
+            mock_wandb.Api.return_value = mock_api
+            mock_api.artifact.return_value = art
+
+            result = runner.invoke(app, ["resolve", "entity/project", "--run-id", "R"])
+
+        assert result.exit_code == 0
+        assert "entity/project/model-R:best" in result.output
+        assert "v3" in result.output
+
+    def test_run_id_and_tags_together_exits_non_zero(self):
+        result = runner.invoke(
+            app,
+            ["resolve", "entity/project", "--run-id", "R", "--tags", "a"],
+        )
+
+        assert result.exit_code != 0
+
+
+class TestPullCommand:
+    def test_registry_backed_selector_resolves_then_downloads(self, tmp_path):
+        art = _make_artifact("entity/project/model-R:best", "best")
+        download_dir = tmp_path / "downloaded"
+        download_dir.mkdir()
+        ckpt = download_dir / "model.ckpt"
+        ckpt.write_bytes(b"ckpt")
+        art.download.return_value = str(download_dir)
+        local_dir = tmp_path / "out"
+
+        with patch("radiologist.registry.resolver._wandb") as mock_wandb:
+            mock_api = MagicMock()
+            mock_wandb.Api.return_value = mock_api
+            mock_api.artifact.return_value = art
+
+            result = runner.invoke(
+                app,
+                [
+                    "pull",
+                    "entity/project",
+                    "--local-dir",
+                    str(local_dir),
+                    "--run-id",
+                    "R",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert str(ckpt) in result.output
+
+    def test_no_selector_flags_treats_positional_as_raw_artifact_path(self, tmp_path):
+        art = MagicMock()
+        download_dir = tmp_path / "downloaded"
+        download_dir.mkdir()
+        onnx = download_dir / "model.onnx"
+        onnx.write_bytes(b"onnx")
+        art.download.return_value = str(download_dir)
+        local_dir = tmp_path / "out"
+
+        with patch("radiologist.registry.resolver._wandb") as mock_wandb:
+            mock_api = MagicMock()
+            mock_wandb.Api.return_value = mock_api
+            mock_api.artifact.return_value = art
+
+            result = runner.invoke(
+                app,
+                ["pull", "entity/project/model:v1", "--local-dir", str(local_dir)],
+            )
+
+        assert result.exit_code == 0
+        assert str(onnx) in result.output
+        art.download.assert_called_once_with(str(local_dir))
+
+
+class TestPushCommand:
+    def test_opens_run_logs_both_artifacts_and_prints_qualified_names(self, tmp_path):
+        det_path = tmp_path / "det.onnx"
+        mcd_path = tmp_path / "mcd.onnx"
+        det_path.write_bytes(b"det")
+        mcd_path.write_bytes(b"mcd")
+        fake_run = MagicMock()
+        fake_run.entity = "entity"
+        fake_run.project = "project"
+
+        with (
+            patch("radiologist.registry.cli._wandb") as cli_wandb,
+            patch("radiologist.registry.uploader._wandb") as uploader_wandb,
+        ):
+            cli_wandb.init.return_value = fake_run
+            uploader_wandb.Artifact.return_value = MagicMock()
+
+            result = runner.invoke(
+                app,
+                [
+                    "push",
+                    "--det-path",
+                    str(det_path),
+                    "--mcd-path",
+                    str(mcd_path),
+                    "--run-id",
+                    "R",
+                    "--det-collection",
+                    "DC",
+                    "--mcd-collection",
+                    "MC",
+                    "--input-shape",
+                    "1",
+                    "--input-shape",
+                    "1",
+                    "--input-shape",
+                    "224",
+                    "--input-shape",
+                    "224",
+                    "--classes",
+                    "a",
+                    "--classes",
+                    "b",
+                ],
+            )
+
+        assert result.exit_code == 0
+        cli_wandb.init.assert_called_once_with(job_type="push")
+        fake_run.finish.assert_called_once()
+        assert "model-R:best" in result.output
+        assert "model-R-mcd:best" in result.output
+
+
+class TestPromoteCommand:
+    def test_without_force_declined_confirmation_aborts_and_does_not_promote(self):
+        with patch("radiologist.registry.resolver._wandb") as resolver_wandb:
+            result = runner.invoke(
+                app,
+                [
+                    "promote",
+                    "entity/project",
+                    "--run-id",
+                    "R",
+                    "--det-collection",
+                    "DC",
+                    "--mcd-collection",
+                    "MC",
+                ],
+                input="n\n",
+            )
+
+        assert result.exit_code != 0
+        resolver_wandb.Api.assert_not_called()
+
+    def test_with_force_promotes_without_prompting_and_prints_alias(self):
+        det_art = _make_artifact("entity/project/model-R:best", "best", ["best"])
+        mcd_art = _make_artifact("entity/project/model-R-mcd:best", "best", ["best"])
+
+        with (
+            patch("radiologist.registry.resolver._wandb") as resolver_wandb,
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.uploader._wandb") as uploader_wandb,
+        ):
+            resolver_api = MagicMock()
+            resolver_wandb.Api.return_value = resolver_api
+            resolver_api.artifact.side_effect = [det_art, mcd_art]
+
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = []
+            collection_api.artifact_collection.return_value = det_collection_obj
+
+            uploader_api = MagicMock()
+            uploader_wandb.Api.return_value = uploader_api
+            uploader_api.artifact.side_effect = [det_art, mcd_art]
+
+            result = runner.invoke(
+                app,
+                [
+                    "promote",
+                    "entity/project",
+                    "--run-id",
+                    "R",
+                    "--det-collection",
+                    "DC",
+                    "--mcd-collection",
+                    "MC",
+                    "--force",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "production" in result.output
+
+
+class TestTransitionToProductionCommand:
+    def test_force_prints_production_result(self):
+        det_staging = _make_artifact("entity/project/model-a:v0", "v0", ["staging"])
+        mcd_staging = _make_artifact("entity/project/model-c-mcd:v0", "v0", ["staging"])
+
+        with (
+            patch("radiologist.registry.collection._wandb") as collection_wandb,
+            patch("radiologist.registry.alias_manager._wandb") as alias_wandb,
+        ):
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            det_collection_obj = MagicMock()
+            det_collection_obj.artifacts.return_value = [det_staging]
+            mcd_collection_obj = MagicMock()
+            mcd_collection_obj.artifacts.return_value = [mcd_staging]
+            collection_api.artifact_collection.side_effect = [
+                det_collection_obj,
+                mcd_collection_obj,
+            ]
+
+            alias_api = MagicMock()
+            alias_wandb.Api.return_value = alias_api
+            alias_api.artifact.side_effect = [det_staging, mcd_staging]
+
+            result = runner.invoke(
+                app,
+                [
+                    "transition-to-production",
+                    "--det-collection",
+                    "DC",
+                    "--mcd-collection",
+                    "MC",
+                    "--force",
+                ],
+            )
+
+        assert result.exit_code == 0
+        assert "production" in result.output
+
+
+class TestListCommand:
+    def test_prints_one_line_per_member_with_aliases(self):
+        member = _make_artifact("entity/project/model-a:v0", "v0", ["staging"])
+
+        with patch("radiologist.registry.collection._wandb") as collection_wandb:
+            collection_api = MagicMock()
+            collection_wandb.Api.return_value = collection_api
+            collection_obj = MagicMock()
+            collection_obj.artifacts.return_value = [member]
+            collection_api.artifact_collection.return_value = collection_obj
+
+            result = runner.invoke(
+                app, ["list", "--type", "model", "--collection", "C"]
+            )
+
+        assert result.exit_code == 0
+        assert "entity/project/model-a:v0" in result.output
+        assert "staging" in result.output
+
+
+class TestAliasCommands:
+    def test_set_then_get_reflects_and_remove_removes(self):
+        art = _make_artifact("entity/project/model:v1", "v1", [])
+
+        with patch("radiologist.registry.alias_manager._wandb") as mock_wandb:
+            mock_api = MagicMock()
+            mock_wandb.Api.return_value = mock_api
+            mock_api.artifact.return_value = art
+
+            set_result = runner.invoke(
+                app, ["alias", "set", "entity/project/model:v1", "staging"]
+            )
+            get_result = runner.invoke(app, ["alias", "get", "entity/project/model:v1"])
+            remove_result = runner.invoke(
+                app, ["alias", "remove", "entity/project/model:v1", "staging"]
+            )
+
+        assert set_result.exit_code == 0
+        assert get_result.exit_code == 0
+        assert "staging" in get_result.output
+        assert remove_result.exit_code == 0
+        assert "staging" not in art.aliases
+
+
+class TestMainEntryPoint:
+    def test_raises_runtime_error_when_typer_absent(self):
+        import radiologist.registry.cli as cli_mod
+
+        with patch.object(cli_mod, "_typer", None):
+            with pytest.raises(RuntimeError, match="cli"):
+                cli_mod.main()

--- a/radiologist-registry/tests/test_registry_selector.py
+++ b/radiologist-registry/tests/test_registry_selector.py
@@ -24,7 +24,12 @@ from typing import Any, List, Optional, Union
 
 import pytest
 
-from radiologist.registry import ArtifactRef, RegistrySelector, resolve_selector
+from radiologist.registry import (
+    ArtifactRef,
+    RegistrySelector,
+    resolve_selector,
+    selector_from_flags,
+)
 
 
 class FakeModelRegistry:
@@ -160,6 +165,34 @@ def test_resolve_selector_with_only_path_returns_ref_for_raw_path(
 
     assert result == canned_ref
     assert registry.calls[0]["path"] == "models/local.onnx"
+
+
+def test_selector_from_flags_builds_equivalent_registry_selector() -> None:
+    selector = selector_from_flags(
+        path="entity/project/model",
+        run_id="run-123",
+        tags=["prod"],
+        groups=["group-a"],
+        metric="val_f1",
+        version="v2",
+        include_sweeps=True,
+    )
+
+    assert selector == RegistrySelector(
+        path="entity/project/model",
+        run_id="run-123",
+        tags=["prod"],
+        groups=["group-a"],
+        metric="val_f1",
+        version="v2",
+        include_sweeps=True,
+    )
+
+
+def test_selector_from_flags_defaults_match_registry_selector_defaults() -> None:
+    selector = selector_from_flags(path="models/local.onnx")
+
+    assert selector == RegistrySelector(path="models/local.onnx")
 
 
 def test_resolve_selector_raises_valueerror_when_run_id_and_tags_both_set(

--- a/radiologist-registry/tests/test_registry_selector.py
+++ b/radiologist-registry/tests/test_registry_selector.py
@@ -1,0 +1,175 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from typing import Any, List, Optional, Union
+
+import pytest
+
+from radiologist.registry import ArtifactRef, RegistrySelector, resolve_selector
+
+
+class FakeModelRegistry:
+    """Owned in-memory ModelRegistry stub — records args, returns a canned ref."""
+
+    def __init__(self, ref: ArtifactRef) -> None:
+        self.ref = ref
+        self.calls: List[dict] = []
+
+    def resolve(
+        self,
+        path: str,
+        run_id: Optional[str] = None,
+        groups: Optional[Union[str, List[str]]] = None,
+        tags: Optional[Union[str, List[str]]] = None,
+        metric: Optional[str] = None,
+        version: Optional[str] = None,
+        include_sweeps: bool = False,
+    ) -> ArtifactRef:
+        self.calls.append(
+            {
+                "path": path,
+                "run_id": run_id,
+                "groups": groups,
+                "tags": tags,
+                "metric": metric,
+                "version": version,
+                "include_sweeps": include_sweeps,
+            }
+        )
+        return self.ref
+
+    def download(self, ref: ArtifactRef, local_dir: str) -> str:
+        raise NotImplementedError
+
+    def pull(self, artifact_path: str, local_dir: str) -> str:
+        raise NotImplementedError
+
+    def log_model_artifacts(
+        self,
+        export_result: Any,
+        run: Any,
+        ckpt_path: str,
+        last_ckpt_path: Optional[str] = None,
+    ) -> Any:
+        raise NotImplementedError
+
+    def list_collection_artifacts(self, type_name: str, collection_name: str) -> Any:
+        raise NotImplementedError
+
+    def promote(
+        self, path: str, run_id: str, det_collection: str, mcd_collection: str
+    ) -> Any:
+        raise NotImplementedError
+
+    def transition_to_production(self, det_collection: str, mcd_collection: str) -> Any:
+        raise NotImplementedError
+
+    def get_aliases(self, artifact_path: str) -> List[str]:
+        raise NotImplementedError
+
+    def set_alias(self, artifact_path: str, alias: str) -> None:
+        raise NotImplementedError
+
+    def remove_alias(self, artifact_path: str, alias: str) -> None:
+        raise NotImplementedError
+
+
+@pytest.fixture
+def canned_ref() -> ArtifactRef:
+    return ArtifactRef(
+        qualified_name="entity/project/model:v1",
+        run_id="run-123",
+        artifact_name="model",
+        version="v1",
+    )
+
+
+@pytest.fixture
+def registry(canned_ref: ArtifactRef) -> FakeModelRegistry:
+    return FakeModelRegistry(canned_ref)
+
+
+def test_is_registry_backed_false_when_only_path_set() -> None:
+    selector = RegistrySelector(path="models/local.onnx")
+    assert selector.is_registry_backed() is False
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"run_id": "run-123"},
+        {"tags": ["prod"]},
+        {"groups": ["group-a"]},
+        {"metric": "val_f1"},
+        {"version": "v2"},
+    ],
+)
+def test_is_registry_backed_true_when_registry_field_set(kwargs: dict) -> None:
+    selector = RegistrySelector(path="entity/project/model", **kwargs)
+    assert selector.is_registry_backed() is True
+
+
+def test_resolve_selector_with_run_id_returns_ref_and_forwards_run_id(
+    registry: FakeModelRegistry, canned_ref: ArtifactRef
+) -> None:
+    selector = RegistrySelector(path="entity/project/model", run_id="run-123")
+
+    result = resolve_selector(selector, registry)
+
+    assert result == canned_ref
+    assert registry.calls[0]["run_id"] == "run-123"
+
+
+def test_resolve_selector_with_tags_forwards_tags_as_list(
+    registry: FakeModelRegistry, canned_ref: ArtifactRef
+) -> None:
+    selector = RegistrySelector(path="entity/project/model", tags=["prod", "best"])
+
+    result = resolve_selector(selector, registry)
+
+    assert result == canned_ref
+    assert registry.calls[0]["tags"] == ["prod", "best"]
+    assert isinstance(registry.calls[0]["tags"], list)
+
+
+def test_resolve_selector_with_only_path_returns_ref_for_raw_path(
+    registry: FakeModelRegistry, canned_ref: ArtifactRef
+) -> None:
+    selector = RegistrySelector(path="models/local.onnx")
+
+    result = resolve_selector(selector, registry)
+
+    assert result == canned_ref
+    assert registry.calls[0]["path"] == "models/local.onnx"
+
+
+def test_resolve_selector_raises_valueerror_when_run_id_and_tags_both_set(
+    registry: FakeModelRegistry,
+) -> None:
+    selector = RegistrySelector(
+        path="entity/project/model", run_id="run-123", tags=["prod"]
+    )
+
+    with pytest.raises(ValueError):
+        resolve_selector(selector, registry)
+
+    assert registry.calls == []

--- a/radiologist-utils/README.md
+++ b/radiologist-utils/README.md
@@ -25,13 +25,13 @@ All symbols below are importable from `radiologist.utils` or `radiologist.utils.
 | `ImageReader(source, storage_options)` | Factory returning `LocalImageReader` or `RemoteImageReader` based on URI scheme |
 | `read_image(source, storage_options)` | Read a single PNG/JPEG from any fsspec URI → `(np.ndarray, metadata)` |
 
-`BaseImageReader` is an abstract lazy iterator over `(np.ndarray, dict)` tuples. Iterate it to stream images without loading the entire dataset into memory.
+`BaseImageReader` is an abstract lazy iterator over `(np.ndarray, dict)` tuples via `.iterate()`. Call it to stream images without loading the entire dataset into memory.
 
 ```python
 from radiologist.utils import ImageReader
 
 reader = ImageReader("gs://my-bucket/images/", storage_options={"token": "anon"})
-for image, meta in reader:
+for image, meta in reader.iterate():
     process(image, meta)
 ```
 


### PR DESCRIPTION
## Summary

Implements Epic/milestone #9 — every workspace package now exposes a runnable console entry point, optional `wandb` imports no longer crash `radiologist-core` at import time, and both `radiologist-registry` and `radiologist-inference` CLIs resolve models from the W&B registry through one shared `RegistrySelector`/`resolve_selector()` seam.

- `radiologist-registry`: new Typer CLI (`push`/`pull`/`resolve`/`promote`/`transition-to-production`/`list`/`alias`) + `cli` extra + `radiologist-registry` console script + README. New `RegistrySelector` frozen dataclass + `resolve_selector()`.
- `radiologist-inference`: `predict`/`explain`/`uncertainty` accept registry-selector flags (`--run-id`/`--tags`/`--groups`/`--metric`/`--local-dir`) alongside the existing `--model PATH`; new `serve` command; `/healthz` (pure liveness) split from new `/readyz` (readiness); `BasePredictor.from_selector` added beside untouched `from_registry`; Score-CAM docstring fix; corrected wandb-missing extra message.
- `radiologist-core`: guarded `wandb` imports in three callbacks (attribution, onnx_export, wandb_summary) + new console script.
- `radiologist-etl`: new console script exposing the existing `@hydra.main` entry point.
- Docs sync: root/core/utils READMEs, root `.claude/CLAUDE.md`, `Makefile` `type-check` target now cover all 5 packages.

Closes #120, #121, #122, #123, #124, #125, #126.

## Test plan

- [x] `radiologist-core`, `radiologist-registry`, `radiologist-inference`, `radiologist-utils` suites: 367/367 passing
- [x] `radiologist-etl` suite: 43/51 passing (8 pre-existing Prefect-ephemeral-server sandbox failures, reproduced identically on `main`, unrelated to this diff)
- [x] mypy across all 5 packages: 3 pre-existing errors (`module.py:107`, `prefect_pipelines.py:58`, `rich_utils.py:65`), all reproduced on `main`, none introduced by this branch
- [x] `from radiologist.core import LModule` succeeds without `wandb` installed
- [x] `radiologist predict IMG --run-id R` resolves from registry; `--model PATH` unchanged
- [x] `--run-id` + `--tags` together raise `ValueError`
- [x] `GET /healthz` always 200; `GET /readyz` 503 → 200 once a predictor loads
