### PR TITLE
feat(inference): add configurable mean/std/input_shape for preprocessing

### DIFF
--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -21,5 +21,6 @@
 - [Typer CLI + wandb process boundary](feedback_typer_cli_wandb_process_boundary.md) — a CLI module's own `_wandb` sentinel and a facade submodule's `_wandb` are separate bindings; patch each independently
 - [Registry download vs pull semantics](feedback_registry_download_vs_pull_semantics.md) — `.download()` is ckpt-only (training resume), `.pull()` is onnx-only (inference load); don't conflate even if a spec says "download"
 - [Pytest worktree isolation](feedback_pytest_worktree_isolation.md) — stale `.pth` cross-worktree pointers and cross-package plugin-name collisions; run pytest per-package with `--confcutdir=.`
+- [pyenv activate needs shell init](feedback_pyenv_activate_needs_shell_init.md) — Bash calls need `eval "$(pyenv init -)"; eval "$(pyenv virtualenv-init -)"` before `pyenv activate`, else installs silently land in the shared venv
 
 See also: [[shared/MEMORY.md]] for cross-agent rules (TDD).

--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -22,5 +22,6 @@
 - [Registry download vs pull semantics](feedback_registry_download_vs_pull_semantics.md) — `.download()` is ckpt-only (training resume), `.pull()` is onnx-only (inference load); don't conflate even if a spec says "download"
 - [Pytest worktree isolation](feedback_pytest_worktree_isolation.md) — stale `.pth` cross-worktree pointers and cross-package plugin-name collisions; run pytest per-package with `--confcutdir=.`
 - [pyenv activate needs shell init](feedback_pyenv_activate_needs_shell_init.md) — Bash calls need `eval "$(pyenv init -)"; eval "$(pyenv virtualenv-init -)"` before `pyenv activate`, else installs silently land in the shared venv
+- [Worktree branch already checked out](feedback_worktree_branch_already_checked_out.md) — git refuses a 2nd worktree for a branch checked out elsewhere; work in-place instead; also watch for uv.lock revision noise from `make dev-install`
 
 See also: [[shared/MEMORY.md]] for cross-agent rules (TDD).

--- a/.claude/agent-memory/tdd-developer/feedback_pyenv_activate_needs_shell_init.md
+++ b/.claude/agent-memory/tdd-developer/feedback_pyenv_activate_needs_shell_init.md
@@ -1,0 +1,32 @@
+---
+name: pyenv-activate-needs-shell-init
+description: Bash tool calls need `eval "$(pyenv init -)"` and `eval "$(pyenv virtualenv-init -)"` before `pyenv activate` works — otherwise it silently no-ops and installs land in whatever venv the .python-version shim resolves to.
+metadata:
+  type: feedback
+---
+
+`pyenv activate <name>` in a fresh non-interactive Bash tool call fails with
+"pyenv-virtualenv to be loaded into your shell" unless you first run
+`eval "$(pyenv init -)"; eval "$(pyenv virtualenv-init -)"` in the same
+command. If you skip this and the command "succeeds" anyway (no activation,
+but no hard error either), `make dev-install`/`uv sync --active` will run
+against whatever venv the ambient `.python-version` shim resolves to — in a
+worktree, that shim commonly resolves back to the **shared** project venv,
+so the install silently rewrites the shared venv's `.pth` files to the
+worktree's absolute path. This is exactly the venv-corruption hazard
+CLAUDE.md's worktree section warns about, and it happens *before* any error
+surfaces.
+
+**Why:** caught this only because I ran `pip show`/`.pth` diffing after the
+fact — `make dev-install`'s own success message gives no signal that it
+landed in the wrong venv.
+
+**How to apply:** every worktree Bash call that touches `pyenv activate`
+must chain the two `eval` init lines first. After creating/activating a
+worktree venv, verify with `python -c "import sys; print(sys.prefix)"`
+before running `make dev-install` — confirm it matches
+`~/.pyenv/versions/<worktree-venv-name>`, not the shared `radiologist` venv.
+If a bad install already happened, fix it immediately: reactivate the
+shared venv properly and re-run `make dev-install` from the **main
+checkout** path to restore its `.pth` files before continuing any other
+work.

--- a/.claude/agent-memory/tdd-developer/feedback_worktree_branch_already_checked_out.md
+++ b/.claude/agent-memory/tdd-developer/feedback_worktree_branch_already_checked_out.md
@@ -1,0 +1,37 @@
+---
+name: worktree-branch-already-checked-out
+description: git refuses a second worktree for a branch already checked out elsewhere — work directly in the checkout that has it instead
+metadata:
+  type: feedback
+---
+
+When asked to amend an existing feature branch and the task instructions say
+"create a worktree for this", first check whether the primary checkout (or
+any existing worktree) already has that branch checked out
+(`git worktree list`, `git branch --show-current`). `git worktree add
+<path> <branch>` fails with "already used by worktree at ..." if so — git
+disallows checking the same branch out twice.
+
+**Why:** this happened on issue #139 (amending
+`feat/129-configurable-preprocessing-normalization`): the main checkout at
+`/workspaces/radiologist` was already on that branch from prior work.
+Attempting `git worktree add .claude/worktrees/139-selector-fix
+feat/129-configurable-preprocessing-normalization` failed immediately.
+
+**How to apply:** when this happens, skip the worktree/dedicated-venv setup
+entirely and just work in the checkout that already has the branch, using
+its already-synced venv (activate via `pyenv activate <existing-venv>`, no
+need for `make dev-install` if deps are already synced — verify with a quick
+`uv sync --active` no-op check or just try running tests first). Don't force
+a worktree that git structurally can't create. Still follow all other rules
+(no direct commits to main, Commitizen messages, etc.) — only the
+worktree/venv isolation step is skipped, because it's redundant when the
+branch is already isolated to that one checkout.
+
+Also noteworthy: `make dev-install` / `uv sync --active` inside a
+repo can non-destructively regenerate `uv.lock` with a different `revision`
+field (e.g. uv version skew) even with no dependency changes — check
+`git diff uv.lock` before committing and `git checkout -- uv.lock` if the
+diff is just noise unrelated to the task.
+
+See also: [[feedback_pyenv_activate_needs_shell_init]].

--- a/radiologist-inference/README.md
+++ b/radiologist-inference/README.md
@@ -84,7 +84,10 @@ classifier = Classifier.from_path(
 ```
 
 `mean` and `std` must be provided together — passing only one raises
-`ValueError`. `input_shape` (`[N, C, H, W]`) is a fallback used only when the
+`ValueError` eagerly at load time (`from_path`/`from_registry`/
+`from_selector`), before any inference request and, for the registry-backed
+loaders, before the ONNX artifact is pulled. `input_shape` (`[N, C, H, W]`)
+is a fallback used only when the
 ONNX file's embedded metadata has no `input_shape` key; if metadata has no
 `input_shape` and none is passed, loading raises `ValueError`.
 

--- a/radiologist-inference/README.md
+++ b/radiologist-inference/README.md
@@ -67,6 +67,33 @@ classifier = Classifier.from_registry(
 )
 ```
 
+`from_path`/`from_registry` accept optional `mean`, `std`, and `input_shape`
+kwargs. This is a **behavior-relevant** addition: existing callers that omit
+them keep getting exactly today's `/255.0`-only preprocessing (fully
+backward compatible). Passing both `mean` and `std` applies
+`(arr / 255 - mean) / std` instead, letting inference match the model's
+actual training-time normalization without a custom fork — e.g. this
+project's `radiologist-core` training pipeline uses `Normalize(mean=[128],
+std=[65])` after `[0, 1]`-scaling, so `mean=128.0, std=65.0` reproduces
+train/serve-consistent preprocessing:
+
+```python
+classifier = Classifier.from_path(
+    det_path="model.onnx", mean=128.0, std=65.0,
+)
+```
+
+`mean` and `std` must be provided together — passing only one raises
+`ValueError`. `input_shape` (`[N, C, H, W]`) is a fallback used only when the
+ONNX file's embedded metadata has no `input_shape` key; if metadata has no
+`input_shape` and none is passed, loading raises `ValueError`.
+
+```python
+classifier = Classifier.from_path(
+    det_path="model_without_shape_metadata.onnx", input_shape=[1, 3, 224, 224],
+)
+```
+
 ### HTTP server (requires `serve` extra)
 
 `create_app` dispatches routes based on `isinstance` checks against the
@@ -108,6 +135,16 @@ radiologist explain chest_xray.png --model model.onnx --out saliency.npy
 radiologist uncertainty chest_xray.png --model model.onnx --mcd-model model_mcd.onnx
 ```
 
+`predict`, `explain`, and `uncertainty` all accept optional `--mean`,
+`--std`, and `--input-shape` flags, threaded straight to `from_path`.
+`--input-shape` takes a comma-separated `N,C,H,W`, e.g. `1,3,224,224`.
+Omitting all three keeps today's default `/255.0`-only preprocessing:
+
+```bash
+radiologist predict chest_xray.png --model model.onnx \
+    --mean 128 --std 65 --input-shape 1,3,224,224
+```
+
 ## Public API reference
 
 ### `BasePredictor`
@@ -116,8 +153,8 @@ Common loading surface shared by every predictor class.
 
 | Method | Signature | Description |
 |---|---|---|
-| `from_path` | `(det_path: str, mcd_path: Optional[str] = None) -> BasePredictor` | Load from local ONNX files |
-| `from_registry` | `(artifact_path: str, local_dir: str, registry=None) -> BasePredictor` | Download from W&B Registry and load; requires `registry` extra |
+| `from_path` | `(det_path: str, mcd_path: Optional[str] = None, mean: Optional[float] = None, std: Optional[float] = None, input_shape: Optional[List[int]] = None) -> BasePredictor` | Load from local ONNX files |
+| `from_registry` | `(artifact_path: str, local_dir: str, registry=None, mean: Optional[float] = None, std: Optional[float] = None, input_shape: Optional[List[int]] = None) -> BasePredictor` | Download from W&B Registry and load; requires `registry` extra |
 
 ### `Classifier(BasePredictor)`
 

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -94,6 +94,7 @@ class BasePredictor:
             ValueError: If exactly one of mean/std is provided, or if no
                 input_shape can be resolved from metadata or the argument.
         """
+        _validate_mean_std(mean, std)
         det_session = ort.InferenceSession(det_path)
         metadata = _read_metadata(det_session)
 
@@ -145,7 +146,9 @@ class BasePredictor:
 
         Raises:
             RuntimeError: When the ``registry`` extra (wandb) is not installed.
+            ValueError: If exactly one of mean/std is provided.
         """
+        _validate_mean_std(mean, std)
         reg = registry if registry is not None else WandbRegistry()
         try:
             det_path = reg.pull(artifact_path=artifact_path, local_dir=local_dir)
@@ -182,7 +185,9 @@ class BasePredictor:
 
         Raises:
             RuntimeError: When the ``registry`` extra (wandb) is not installed.
+            ValueError: If exactly one of mean/std is provided.
         """
+        _validate_mean_std(mean, std)
         det_path = _resolve_and_pull(selector, local_dir, registry)
         return cls.from_path(
             det_path=det_path, mean=mean, std=std, input_shape=input_shape
@@ -201,6 +206,20 @@ def _resolve_and_pull(
         return reg.pull(artifact_path=ref.qualified_name, local_dir=local_dir)
     except RuntimeError as exc:
         raise RuntimeError(_INFERENCE_WANDB_MISSING_MSG) from exc
+
+
+def _validate_mean_std(mean: Optional[float], std: Optional[float]) -> None:
+    """Ensure mean and std are either both given or both omitted.
+
+    Args:
+        mean: Optional normalization mean.
+        std: Optional normalization std.
+
+    Raises:
+        ValueError: If exactly one of mean/std is provided.
+    """
+    if (mean is None) != (std is None):
+        raise ValueError("mean and std must be provided together")
 
 
 def _read_metadata(session: "ort.InferenceSession") -> Dict[str, str]:
@@ -283,8 +302,7 @@ def _normalize_pil(
     Raises:
         ValueError: If exactly one of mean/std is provided.
     """
-    if (mean is None) != (std is None):
-        raise ValueError("mean and std must be provided together")
+    _validate_mean_std(mean, std)
     _, _, h, w = input_shape
     pil_img = pil_img.resize((w, h), PILImage.Resampling.BILINEAR)
     arr = np.array(pil_img, dtype=np.float32) / 255.0

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -56,6 +56,8 @@ class _PredictorState:
     metadata: Dict[str, str]
     model_metadata: ModelMetadata
     mcd_session: Optional[ort.InferenceSession] = field(default=None)
+    mean: Optional[float] = field(default=None)
+    std: Optional[float] = field(default=None)
 
 
 class BasePredictor:
@@ -65,19 +67,32 @@ class BasePredictor:
 
     @classmethod
     def from_path(
-        cls, det_path: str, mcd_path: Optional[str] = None
+        cls,
+        det_path: str,
+        mcd_path: Optional[str] = None,
+        mean: Optional[float] = None,
+        std: Optional[float] = None,
+        input_shape: Optional[List[int]] = None,
     ) -> "BasePredictor":
         """Load a predictor instance from local ONNX file paths.
 
         Args:
             det_path: Path to the deterministic ONNX model file.
             mcd_path: Optional path to the MC-Dropout ONNX model file.
+            mean: Optional normalization mean. When omitted (with std also
+                omitted), preprocessing keeps today's /255.0-only scaling.
+            std: Optional normalization std. Must be provided together with
+                mean.
+            input_shape: Optional [N, C, H, W] fallback used when the ONNX
+                file's metadata has no input_shape key.
 
         Returns:
             Loaded instance of the calling subclass.
 
         Raises:
             FileNotFoundError: If det_path does not exist.
+            ValueError: If exactly one of mean/std is provided, or if no
+                input_shape can be resolved from metadata or the argument.
         """
         det_session = ort.InferenceSession(det_path)
         metadata = _read_metadata(det_session)
@@ -87,7 +102,9 @@ class BasePredictor:
             mcd_session = ort.InferenceSession(mcd_path)
 
         model_metadata = _parse_model_metadata(
-            metadata, mc_dropout=mcd_session is not None
+            metadata,
+            mc_dropout=mcd_session is not None,
+            default_input_shape=input_shape,
         )
 
         instance = cls.__new__(cls)
@@ -96,6 +113,8 @@ class BasePredictor:
             metadata=metadata,
             model_metadata=model_metadata,
             mcd_session=mcd_session,
+            mean=mean,
+            std=std,
         )
         return instance
 
@@ -105,6 +124,9 @@ class BasePredictor:
         artifact_path: str,
         local_dir: str,
         registry: Optional["ModelRegistry"] = None,
+        mean: Optional[float] = None,
+        std: Optional[float] = None,
+        input_shape: Optional[List[int]] = None,
     ) -> "BasePredictor":
         """Download a model from a registry and load it via from_path.
 
@@ -113,6 +135,10 @@ class BasePredictor:
             local_dir: Local directory where the ONNX file will be saved.
             registry: Registry to pull from. Defaults to WandbRegistry() when
                 omitted.
+            mean: Optional normalization mean, forwarded to from_path.
+            std: Optional normalization std, forwarded to from_path.
+            input_shape: Optional input_shape fallback, forwarded to
+                from_path.
 
         Returns:
             Loaded instance of the calling subclass.
@@ -125,7 +151,9 @@ class BasePredictor:
             det_path = reg.pull(artifact_path=artifact_path, local_dir=local_dir)
         except RuntimeError as exc:
             raise RuntimeError(_INFERENCE_WANDB_MISSING_MSG) from exc
-        return cls.from_path(det_path=det_path)
+        return cls.from_path(
+            det_path=det_path, mean=mean, std=std, input_shape=input_shape
+        )
 
     @classmethod
     def from_selector(
@@ -171,19 +199,37 @@ def _read_metadata(session: "ort.InferenceSession") -> Dict[str, str]:
     return dict(session.get_modelmeta().custom_metadata_map)
 
 
-def _parse_model_metadata(metadata: Dict[str, str], mc_dropout: bool) -> ModelMetadata:
+def _parse_model_metadata(
+    metadata: Dict[str, str],
+    mc_dropout: bool,
+    default_input_shape: Optional[List[int]] = None,
+) -> ModelMetadata:
     """Parse the raw ONNX metadata dict into a typed ModelMetadata.
 
     Args:
         metadata: Raw custom_metadata_map from the deterministic session.
         mc_dropout: Whether a stochastic (MC-Dropout) session was also loaded.
+        default_input_shape: Fallback [N, C, H, W] used when the metadata has
+            no input_shape key.
 
     Returns:
         Typed ModelMetadata with JSON fields decoded.
+
+    Raises:
+        ValueError: If the metadata has no input_shape key and
+            default_input_shape is not provided.
     """
+    if "input_shape" in metadata:
+        input_shape = json.loads(metadata["input_shape"])
+    else:
+        input_shape = default_input_shape
+    if input_shape is None:
+        raise ValueError(
+            "ONNX model has no input_shape metadata; pass input_shape" " explicitly."
+        )
     return ModelMetadata(
         classes=json.loads(metadata["classes"]),
-        input_shape=json.loads(metadata["input_shape"]),
+        input_shape=input_shape,
         cam_target_layer=metadata["cam_target_layer"],
         output_names=json.loads(metadata["output_names"]),
         mc_dropout=mc_dropout,
@@ -206,19 +252,35 @@ def _to_pil(image: Union[str, "np.ndarray", "PILImage.Image"]) -> "PILImage.Imag
     return image.convert("RGB")
 
 
-def _normalize_pil(pil_img: "PILImage.Image", input_shape: List[int]) -> "np.ndarray":
+def _normalize_pil(
+    pil_img: "PILImage.Image",
+    input_shape: List[int],
+    mean: Optional[float] = None,
+    std: Optional[float] = None,
+) -> "np.ndarray":
     """Resize and normalize an already-decoded PIL image to a float32 NCHW array.
 
     Args:
         pil_img: RGB-converted PIL Image.
         input_shape: [N, C, H, W] as stored in model metadata.
+        mean: Optional normalization mean. When omitted (with std also
+            omitted), the array is left in [0, 1] (today's default).
+        std: Optional normalization std. Must be provided together with mean.
 
     Returns:
-        Float32 array of shape (1, C, H, W) with values in [0, 1].
+        Float32 array of shape (1, C, H, W): raw [0, 1] scale by default, or
+        (arr - mean) / std when both mean and std are given.
+
+    Raises:
+        ValueError: If exactly one of mean/std is provided.
     """
+    if (mean is None) != (std is None):
+        raise ValueError("mean and std must be provided together")
     _, _, h, w = input_shape
     pil_img = pil_img.resize((w, h), PILImage.Resampling.BILINEAR)
     arr = np.array(pil_img, dtype=np.float32) / 255.0
+    if mean is not None and std is not None:
+        arr = (arr - mean) / std
     arr = arr.transpose(2, 0, 1)[np.newaxis, ...]
     return arr
 
@@ -226,17 +288,21 @@ def _normalize_pil(pil_img: "PILImage.Image", input_shape: List[int]) -> "np.nda
 def _preprocess_image(
     image: Union[str, "np.ndarray", "PILImage.Image"],
     input_shape: List[int],
+    mean: Optional[float] = None,
+    std: Optional[float] = None,
 ) -> "np.ndarray":
     """Load, resize, and normalize image to a float32 NCHW array.
 
     Args:
         image: File path, numpy HWC uint8 array, or PIL Image.
         input_shape: [N, C, H, W] as stored in model metadata.
+        mean: Optional normalization mean, forwarded to _normalize_pil.
+        std: Optional normalization std, forwarded to _normalize_pil.
 
     Returns:
-        Float32 array of shape (1, C, H, W) with values in [0, 1].
+        Float32 array of shape (1, C, H, W).
     """
-    return _normalize_pil(_to_pil(image), input_shape)
+    return _normalize_pil(_to_pil(image), input_shape, mean=mean, std=std)
 
 
 def _softmax(logits: "np.ndarray") -> "np.ndarray":

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -161,6 +161,9 @@ class BasePredictor:
         selector: "RegistrySelector",
         local_dir: str,
         registry: Optional["ModelRegistry"] = None,
+        mean: Optional[float] = None,
+        std: Optional[float] = None,
+        input_shape: Optional[List[int]] = None,
     ) -> "BasePredictor":
         """Resolve a selector against a registry and load via from_path.
 
@@ -169,6 +172,10 @@ class BasePredictor:
             local_dir: Local directory where the ONNX file will be saved.
             registry: Registry to resolve/download from. Defaults to
                 WandbRegistry() when omitted.
+            mean: Optional normalization mean, forwarded to from_path.
+            std: Optional normalization std, forwarded to from_path.
+            input_shape: Optional input_shape fallback, forwarded to
+                from_path.
 
         Returns:
             Loaded instance of the calling subclass.
@@ -177,7 +184,9 @@ class BasePredictor:
             RuntimeError: When the ``registry`` extra (wandb) is not installed.
         """
         det_path = _resolve_and_pull(selector, local_dir, registry)
-        return cls.from_path(det_path=det_path)
+        return cls.from_path(
+            det_path=det_path, mean=mean, std=std, input_shape=input_shape
+        )
 
 
 def _resolve_and_pull(

--- a/radiologist-inference/src/radiologist/inference/classifier.py
+++ b/radiologist-inference/src/radiologist/inference/classifier.py
@@ -63,7 +63,9 @@ class Classifier(BasePredictor):
         model_metadata = self._state.model_metadata
         input_shape = model_metadata.input_shape
 
-        arr = _preprocess_image(image, input_shape)
+        arr = _preprocess_image(
+            image, input_shape, mean=self._state.mean, std=self._state.std
+        )
 
         session = self._state.det_session
         input_name = session.get_inputs()[0].name

--- a/radiologist-inference/src/radiologist/inference/cli.py
+++ b/radiologist-inference/src/radiologist/inference/cli.py
@@ -48,6 +48,13 @@ _SELECTOR_REQUIRED_MSG = (
 )
 
 
+def _parse_int_list(value: Optional[str]) -> Optional[List[int]]:
+    """Parse a comma-separated string of ints, e.g. "1,3,224,224"."""
+    if value is None:
+        return None
+    return [int(part) for part in value.split(",")]
+
+
 def _load_predictor(
     predictor_cls: Any,
     model: Optional[str],
@@ -56,15 +63,21 @@ def _load_predictor(
     groups: Optional[List[str]],
     metric: Optional[str],
     local_dir: str,
+    mean: Optional[float] = None,
+    std: Optional[float] = None,
+    input_shape: Optional[str] = None,
 ) -> Any:
     """Dispatch to a registry selector or a local path, per predictor_cls."""
     selector = selector_from_flags(
         path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
     )
+    parsed_input_shape = _parse_int_list(input_shape)
     if selector.is_registry_backed():
         return predictor_cls.from_selector(selector, local_dir=local_dir)
     if model is not None:
-        return predictor_cls.from_path(det_path=model)
+        return predictor_cls.from_path(
+            det_path=model, mean=mean, std=std, input_shape=parsed_input_shape
+        )
     raise ValueError(_SELECTOR_REQUIRED_MSG)
 
 
@@ -76,11 +89,15 @@ def _load_uncertainty_predictor(
     metric: Optional[str],
     local_dir: str,
     mcd_model: Optional[str],
+    mean: Optional[float] = None,
+    std: Optional[float] = None,
+    input_shape: Optional[str] = None,
 ) -> "MCDropoutPredictor":
     """Load det+mcd models: registry pair (run_id / {run_id}-mcd) or local paths."""
     selector = selector_from_flags(
         path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
     )
+    parsed_input_shape = _parse_int_list(input_shape)
     if selector.is_registry_backed():
         det_path = _resolve_and_pull(selector, local_dir)
         mcd_run_id = f"{run_id}-mcd" if run_id else None
@@ -92,9 +109,21 @@ def _load_uncertainty_predictor(
             metric=metric,
         )
         mcd_path = _resolve_and_pull(mcd_selector, local_dir)
-        return MCDropoutPredictor.from_path(det_path=det_path, mcd_path=mcd_path)
+        return MCDropoutPredictor.from_path(
+            det_path=det_path,
+            mcd_path=mcd_path,
+            mean=mean,
+            std=std,
+            input_shape=parsed_input_shape,
+        )
     if model is not None:
-        return MCDropoutPredictor.from_path(det_path=model, mcd_path=mcd_model)
+        return MCDropoutPredictor.from_path(
+            det_path=model,
+            mcd_path=mcd_model,
+            mean=mean,
+            std=std,
+            input_shape=parsed_input_shape,
+        )
     raise ValueError(_SELECTOR_REQUIRED_MSG)
 
 
@@ -130,10 +159,30 @@ if _typer is not None:
         groups: Optional[List[str]] = typer.Option(None, "--groups"),
         metric: Optional[str] = typer.Option(None, "--metric"),
         local_dir: str = typer.Option(".", "--local-dir"),
+        mean: Optional[float] = typer.Option(
+            None, "--mean", help="Normalization mean (requires --std)."
+        ),
+        std: Optional[float] = typer.Option(
+            None, "--std", help="Normalization std (requires --mean)."
+        ),
+        input_shape: Optional[str] = typer.Option(
+            None,
+            "--input-shape",
+            help="Fallback [N,C,H,W] as comma-separated ints, e.g. 1,3,224,224.",
+        ),
     ) -> None:
         """Run classification inference on a chest X-ray image."""
         classifier = _load_predictor(
-            Classifier, model, run_id, tags, groups, metric, local_dir
+            Classifier,
+            model,
+            run_id,
+            tags,
+            groups,
+            metric,
+            local_dir,
+            mean=mean,
+            std=std,
+            input_shape=input_shape,
         )
         result = classifier.predict(image=image_path)
         typer.echo(f"Predicted class: {result.predicted_class}")
@@ -157,10 +206,30 @@ if _typer is not None:
         out: Optional[str] = typer.Option(
             None, "--out", help="Path to save the saliency map as a .npy file."
         ),
+        mean: Optional[float] = typer.Option(
+            None, "--mean", help="Normalization mean (requires --std)."
+        ),
+        std: Optional[float] = typer.Option(
+            None, "--std", help="Normalization std (requires --mean)."
+        ),
+        input_shape: Optional[str] = typer.Option(
+            None,
+            "--input-shape",
+            help="Fallback [N,C,H,W] as comma-separated ints, e.g. 1,3,224,224.",
+        ),
     ) -> None:
         """Produce a Score-CAM explanation for a chest X-ray image."""
         explainer = _load_predictor(
-            Explainer, model, run_id, tags, groups, metric, local_dir
+            Explainer,
+            model,
+            run_id,
+            tags,
+            groups,
+            metric,
+            local_dir,
+            mean=mean,
+            std=std,
+            input_shape=input_shape,
         )
         result = explainer.explain(image=image_path)
         typer.echo(f"Predicted class: {result.predicted_class}")
@@ -190,10 +259,30 @@ if _typer is not None:
         n_passes: int = typer.Option(
             30, "--n-passes", help="Number of stochastic forward passes."
         ),
+        mean: Optional[float] = typer.Option(
+            None, "--mean", help="Normalization mean (requires --std)."
+        ),
+        std: Optional[float] = typer.Option(
+            None, "--std", help="Normalization std (requires --mean)."
+        ),
+        input_shape: Optional[str] = typer.Option(
+            None,
+            "--input-shape",
+            help="Fallback [N,C,H,W] as comma-separated ints, e.g. 1,3,224,224.",
+        ),
     ) -> None:
         """Estimate MC-Dropout uncertainty for a chest X-ray image."""
         predictor = _load_uncertainty_predictor(
-            model, run_id, tags, groups, metric, local_dir, mcd_model
+            model,
+            run_id,
+            tags,
+            groups,
+            metric,
+            local_dir,
+            mcd_model,
+            mean=mean,
+            std=std,
+            input_shape=input_shape,
         )
         result = predictor.predict_with_uncertainty(image=image_path, n_passes=n_passes)
         typer.echo("Mean probabilities:")

--- a/radiologist-inference/src/radiologist/inference/cli.py
+++ b/radiologist-inference/src/radiologist/inference/cli.py
@@ -33,7 +33,6 @@ from typing import Any, Callable, List, Optional, TypeVar
 import numpy as np
 
 from radiologist.inference.app import create_app
-from radiologist.inference.base_predictor import _resolve_and_pull
 from radiologist.inference.classifier import Classifier
 from radiologist.inference.explainer import Explainer
 from radiologist.inference.mc_dropout import MCDropoutPredictor
@@ -73,7 +72,13 @@ def _load_predictor(
     )
     parsed_input_shape = _parse_int_list(input_shape)
     if selector.is_registry_backed():
-        return predictor_cls.from_selector(selector, local_dir=local_dir)
+        return predictor_cls.from_selector(
+            selector,
+            local_dir=local_dir,
+            mean=mean,
+            std=std,
+            input_shape=parsed_input_shape,
+        )
     if model is not None:
         return predictor_cls.from_path(
             det_path=model, mean=mean, std=std, input_shape=parsed_input_shape
@@ -99,19 +104,9 @@ def _load_uncertainty_predictor(
     )
     parsed_input_shape = _parse_int_list(input_shape)
     if selector.is_registry_backed():
-        det_path = _resolve_and_pull(selector, local_dir)
-        mcd_run_id = f"{run_id}-mcd" if run_id else None
-        mcd_selector = selector_from_flags(
-            path=model or "",
-            run_id=mcd_run_id,
-            tags=tags,
-            groups=groups,
-            metric=metric,
-        )
-        mcd_path = _resolve_and_pull(mcd_selector, local_dir)
-        return MCDropoutPredictor.from_path(
-            det_path=det_path,
-            mcd_path=mcd_path,
+        return MCDropoutPredictor.from_selector(
+            selector,
+            local_dir=local_dir,
             mean=mean,
             std=std,
             input_shape=parsed_input_shape,

--- a/radiologist-inference/src/radiologist/inference/explainer.py
+++ b/radiologist-inference/src/radiologist/inference/explainer.py
@@ -61,7 +61,9 @@ class Explainer(Classifier):
         model_metadata = self._state.model_metadata
         input_shape = model_metadata.input_shape
 
-        preprocessed = _normalize_pil(pil_orig, input_shape)
+        preprocessed = _normalize_pil(
+            pil_orig, input_shape, mean=self._state.mean, std=self._state.std
+        )
 
         session = self._state.det_session
         input_name = session.get_inputs()[0].name

--- a/radiologist-inference/src/radiologist/inference/mc_dropout.py
+++ b/radiologist-inference/src/radiologist/inference/mc_dropout.py
@@ -38,6 +38,7 @@ from radiologist.inference.base_predictor import (
     _read_metadata,
     _resolve_and_pull,
     _softmax,
+    _validate_mean_std,
 )
 from radiologist.inference.models import UncertaintyResult
 from radiologist.registry.wandb_registry import WandbRegistry
@@ -82,7 +83,9 @@ class MCDropoutPredictor(BasePredictor):
         Raises:
             RuntimeError: When the ``registry`` extra (wandb) is not
                 installed.
+            ValueError: If exactly one of mean/std is provided.
         """
+        _validate_mean_std(mean, std)
         reg = registry if registry is not None else WandbRegistry()
         det_path = _resolve_and_pull(selector, local_dir, reg)
         mcd_run_id = f"{selector.run_id}-mcd" if selector.run_id else selector.run_id

--- a/radiologist-inference/src/radiologist/inference/mc_dropout.py
+++ b/radiologist-inference/src/radiologist/inference/mc_dropout.py
@@ -60,7 +60,9 @@ class MCDropoutPredictor(BasePredictor):
                 " loading the predictor via from_path()."
             )
         input_shape = self._state.model_metadata.input_shape
-        arr = _preprocess_image(image, input_shape)
+        arr = _preprocess_image(
+            image, input_shape, mean=self._state.mean, std=self._state.std
+        )
         return mc_dropout_predict(mcd_session, arr, n_passes=n_passes)
 
 

--- a/radiologist-inference/src/radiologist/inference/mc_dropout.py
+++ b/radiologist-inference/src/radiologist/inference/mc_dropout.py
@@ -25,7 +25,8 @@
 from __future__ import annotations
 
 import json
-from typing import List, Union
+from dataclasses import replace
+from typing import TYPE_CHECKING, List, Optional, Union
 
 import numpy as np
 import onnxruntime as ort  # type: ignore[import-untyped]
@@ -35,13 +36,65 @@ from radiologist.inference.base_predictor import (
     BasePredictor,
     _preprocess_image,
     _read_metadata,
+    _resolve_and_pull,
     _softmax,
 )
 from radiologist.inference.models import UncertaintyResult
+from radiologist.registry.wandb_registry import WandbRegistry
+
+if TYPE_CHECKING:
+    from radiologist.registry.interface import ModelRegistry
+    from radiologist.registry.selector import RegistrySelector
 
 
 class MCDropoutPredictor(BasePredictor):
     """Adds MC-Dropout uncertainty estimation to BasePredictor."""
+
+    @classmethod
+    def from_selector(
+        cls,
+        selector: "RegistrySelector",
+        local_dir: str,
+        registry: Optional["ModelRegistry"] = None,
+        mean: Optional[float] = None,
+        std: Optional[float] = None,
+        input_shape: Optional[List[int]] = None,
+    ) -> "MCDropoutPredictor":
+        """Resolve det + MC-Dropout ({run_id}-mcd) artifacts and load via from_path.
+
+        Args:
+            selector: Selector for the deterministic artifact. When
+                selector.run_id is set, the MC-Dropout counterpart is looked
+                up at f"{run_id}-mcd"; otherwise the same selector
+                (tags/groups/metric) is reused for both, matching today's CLI
+                fallback behavior.
+            local_dir: Local directory where both ONNX files will be saved.
+            registry: Registry to resolve/download from. Defaults to a single
+                shared WandbRegistry() instance when omitted.
+            mean: Optional normalization mean, forwarded to from_path.
+            std: Optional normalization std, forwarded to from_path.
+            input_shape: Optional input_shape fallback, forwarded to
+                from_path.
+
+        Returns:
+            Loaded MCDropoutPredictor instance.
+
+        Raises:
+            RuntimeError: When the ``registry`` extra (wandb) is not
+                installed.
+        """
+        reg = registry if registry is not None else WandbRegistry()
+        det_path = _resolve_and_pull(selector, local_dir, reg)
+        mcd_run_id = f"{selector.run_id}-mcd" if selector.run_id else selector.run_id
+        mcd_selector = replace(selector, run_id=mcd_run_id)
+        mcd_path = _resolve_and_pull(mcd_selector, local_dir, reg)
+        return cls.from_path(
+            det_path=det_path,
+            mcd_path=mcd_path,
+            mean=mean,
+            std=std,
+            input_shape=input_shape,
+        )
 
     def predict_with_uncertainty(
         self,

--- a/radiologist-inference/tests/_helpers.py
+++ b/radiologist-inference/tests/_helpers.py
@@ -21,7 +21,7 @@
 # SOFTWARE.
 
 import json
-from typing import Optional
+from typing import List, Optional
 
 import numpy as np
 import onnx
@@ -35,7 +35,9 @@ N_FEATURES = 3 * 224 * 224
 
 
 def _add_metadata(
-    model: onnx.ModelProto, extra: Optional[dict] = None
+    model: onnx.ModelProto,
+    extra: Optional[dict] = None,
+    omit_keys: Optional[List[str]] = None,
 ) -> onnx.ModelProto:
     base = {
         "classes": json.dumps(CLASSES),
@@ -45,6 +47,9 @@ def _add_metadata(
     }
     if extra:
         base.update(extra)
+    if omit_keys:
+        for key in omit_keys:
+            base.pop(key, None)
     del model.metadata_props[:]
     for k, v in base.items():
         e = model.metadata_props.add()
@@ -58,6 +63,7 @@ def build_det_onnx(
     priors: Optional[dict] = None,
     filename: str = "model_det.onnx",
     feat_nonzero: bool = False,
+    omit_keys: Optional[List[str]] = None,
 ) -> str:
     """Build a minimal deterministic 2-class ONNX classifier for tests.
 
@@ -110,7 +116,7 @@ def build_det_onnx(
     extra = {}
     if priors is not None:
         extra["training_prior"] = json.dumps(priors)
-    _add_metadata(model, extra)
+    _add_metadata(model, extra, omit_keys=omit_keys)
 
     path = str(tmp_path / filename)
     onnx.save(model, path)

--- a/radiologist-inference/tests/test_classifier.py
+++ b/radiologist-inference/tests/test_classifier.py
@@ -199,6 +199,68 @@ class TestClassifierFromRegistry:
                 )
 
 
+class TestClassifierMeanStdNormalization:
+    def test_predict_with_mean_and_std_differs_from_default(self, det_onnx_path):
+        """Supplying mean/std must change probabilities relative to the
+        default /255.0-only normalization."""
+        image = np.zeros((224, 224, 3), dtype=np.uint8)
+
+        default_classifier = Classifier.from_path(det_path=det_onnx_path)
+        normalized_classifier = Classifier.from_path(
+            det_path=det_onnx_path, mean=128.0, std=65.0
+        )
+
+        default_result = default_classifier.predict(image=image)
+        normalized_result = normalized_classifier.predict(image=image)
+
+        assert default_result.probabilities != normalized_result.probabilities
+
+    def test_predict_with_only_mean_raises_value_error(self, det_onnx_path):
+        """Supplying mean without std must raise ValueError on predict."""
+        classifier = Classifier.from_path(det_path=det_onnx_path, mean=128.0)
+        image = np.zeros((224, 224, 3), dtype=np.uint8)
+
+        with pytest.raises(ValueError, match="mean and std"):
+            classifier.predict(image=image)
+
+    def test_predict_with_only_std_raises_value_error(self, det_onnx_path):
+        """Supplying std without mean must raise ValueError on predict."""
+        classifier = Classifier.from_path(det_path=det_onnx_path, std=65.0)
+        image = np.zeros((224, 224, 3), dtype=np.uint8)
+
+        with pytest.raises(ValueError, match="mean and std"):
+            classifier.predict(image=image)
+
+
+class TestFromPathInputShapeFallback:
+    def test_from_path_without_input_shape_metadata_raises_clear_error(self, tmp_path):
+        """A model with no input_shape metadata and no default given must
+        raise a clear ValueError."""
+        det_path = build_det_onnx(
+            tmp_path, filename="no_shape.onnx", omit_keys=["input_shape"]
+        )
+
+        with pytest.raises(ValueError, match="input_shape"):
+            Classifier.from_path(det_path=det_path)
+
+    def test_from_path_without_input_shape_metadata_succeeds_with_default(
+        self, tmp_path
+    ):
+        """Passing input_shape explicitly must fill in for missing metadata."""
+        det_path = build_det_onnx(
+            tmp_path, filename="no_shape.onnx", omit_keys=["input_shape"]
+        )
+
+        classifier = Classifier.from_path(
+            det_path=det_path, input_shape=[1, 3, 224, 224]
+        )
+        image = np.zeros((224, 224, 3), dtype=np.uint8)
+        result = classifier.predict(image=image)
+
+        assert isinstance(result, Prediction)
+        assert set(result.probabilities.keys()) == set(CLASSES)
+
+
 class TestClassifierFromSelector:
     def test_from_selector_with_injected_registry_resolves_and_pulls(
         self, det_onnx_path, tmp_path

--- a/radiologist-inference/tests/test_classifier.py
+++ b/radiologist-inference/tests/test_classifier.py
@@ -215,21 +215,19 @@ class TestClassifierMeanStdNormalization:
 
         assert default_result.probabilities != normalized_result.probabilities
 
-    def test_predict_with_only_mean_raises_value_error(self, det_onnx_path):
-        """Supplying mean without std must raise ValueError on predict."""
-        classifier = Classifier.from_path(det_path=det_onnx_path, mean=128.0)
-        image = np.zeros((224, 224, 3), dtype=np.uint8)
-
+    def test_from_path_with_only_mean_raises_value_error(self, det_onnx_path):
+        """Supplying mean without std must raise ValueError eagerly at
+        from_path, before any prediction is requested (fail-fast, bugfix
+        review finding on PR #131)."""
         with pytest.raises(ValueError, match="mean and std"):
-            classifier.predict(image=image)
+            Classifier.from_path(det_path=det_onnx_path, mean=128.0)
 
-    def test_predict_with_only_std_raises_value_error(self, det_onnx_path):
-        """Supplying std without mean must raise ValueError on predict."""
-        classifier = Classifier.from_path(det_path=det_onnx_path, std=65.0)
-        image = np.zeros((224, 224, 3), dtype=np.uint8)
-
+    def test_from_path_with_only_std_raises_value_error(self, det_onnx_path):
+        """Supplying std without mean must raise ValueError eagerly at
+        from_path, before any prediction is requested (fail-fast, bugfix
+        review finding on PR #131)."""
         with pytest.raises(ValueError, match="mean and std"):
-            classifier.predict(image=image)
+            Classifier.from_path(det_path=det_onnx_path, std=65.0)
 
 
 class TestFromPathInputShapeFallback:
@@ -329,3 +327,24 @@ class TestClassifierFromSelector:
 
         assert selector_result.probabilities == path_result.probabilities
         assert selector_result.probabilities != default_result.probabilities
+
+    def test_from_selector_with_mismatched_mean_std_raises_before_any_pull(
+        self, det_onnx_path, tmp_path
+    ):
+        """A mismatched mean/std pair must raise ValueError before the
+        selector is resolved or the artifact pulled — no wasted network I/O
+        on a request that's doomed to fail (bugfix review finding on PR
+        #131)."""
+        fake_registry = _FakeSelectorRegistry(det_onnx_path)
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        with pytest.raises(ValueError, match="mean and std"):
+            Classifier.from_selector(
+                selector,
+                local_dir=str(tmp_path),
+                registry=fake_registry,
+                mean=128.0,
+            )
+
+        assert fake_registry.resolve_calls == []
+        assert fake_registry.pull_calls == []

--- a/radiologist-inference/tests/test_classifier.py
+++ b/radiologist-inference/tests/test_classifier.py
@@ -300,3 +300,32 @@ class TestClassifierFromSelector:
                 RuntimeError, match=r"radiologist-inference\[registry\]"
             ):
                 Classifier.from_selector(selector, local_dir=str(tmp_path))
+
+    def test_from_selector_with_mean_std_matches_from_path_normalization(
+        self, det_onnx_path, tmp_path
+    ):
+        """from_selector must forward mean/std to from_path so a
+        registry-backed load normalizes identically to a local-path load with
+        the same params (bugfix #139)."""
+        fake_registry = _FakeSelectorRegistry(det_onnx_path)
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        selector_classifier = Classifier.from_selector(
+            selector,
+            local_dir=str(tmp_path),
+            registry=fake_registry,
+            mean=128.0,
+            std=65.0,
+        )
+        path_classifier = Classifier.from_path(
+            det_path=det_onnx_path, mean=128.0, std=65.0
+        )
+        default_classifier = Classifier.from_path(det_path=det_onnx_path)
+
+        image = np.zeros((224, 224, 3), dtype=np.uint8)
+        selector_result = selector_classifier.predict(image=image)
+        path_result = path_classifier.predict(image=image)
+        default_result = default_classifier.predict(image=image)
+
+        assert selector_result.probabilities == path_result.probabilities
+        assert selector_result.probabilities != default_result.probabilities

--- a/radiologist-inference/tests/test_cli.py
+++ b/radiologist-inference/tests/test_cli.py
@@ -304,6 +304,79 @@ class TestRegistrySelectorDispatch:
         assert kwargs["filters"]["tags"]["$in"] == ["a", "b"]
         assert det_path is not None
 
+    def test_predict_with_run_id_and_mean_std_input_shape_changes_output(
+        self, tmp_path
+    ):
+        """--mean/--std/--input-shape must not be silently dropped when the
+        predictor is loaded via a registry selector (--run-id) instead of
+        --model (bugfix #139)."""
+        build_det_onnx(tmp_path, filename="det.onnx")
+        image_path = _make_png_path(tmp_path)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        def _invoke(extra_args):
+            mock_wandb, pulled_art = _make_registry_wandb_mock()
+            pulled_art.download.return_value = str(tmp_path)
+            with patch.object(resolver_mod, "_wandb", mock_wandb):
+                return runner.invoke(
+                    app,
+                    [
+                        "predict",
+                        image_path,
+                        "--run-id",
+                        "run1",
+                        "--local-dir",
+                        str(tmp_path),
+                        *extra_args,
+                    ],
+                )
+
+        default_result = _invoke([])
+        normalized_result = _invoke(
+            ["--mean", "128", "--std", "65", "--input-shape", "1,3,224,224"]
+        )
+
+        assert default_result.exit_code == 0, default_result.output
+        assert normalized_result.exit_code == 0, normalized_result.output
+        assert default_result.output != normalized_result.output
+
+    def test_explain_with_run_id_and_mean_std_input_shape_changes_output(
+        self, tmp_path
+    ):
+        """Same as predict: explain must thread --mean/--std/--input-shape
+        through a registry-selector load (bugfix #139)."""
+        build_det_onnx(tmp_path, filename="det.onnx")
+        image_path = _make_png_path(tmp_path)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        def _invoke(extra_args):
+            mock_wandb, pulled_art = _make_registry_wandb_mock()
+            pulled_art.download.return_value = str(tmp_path)
+            with patch.object(resolver_mod, "_wandb", mock_wandb):
+                return runner.invoke(
+                    app,
+                    [
+                        "explain",
+                        image_path,
+                        "--run-id",
+                        "run1",
+                        "--local-dir",
+                        str(tmp_path),
+                        *extra_args,
+                    ],
+                )
+
+        default_result = _invoke([])
+        normalized_result = _invoke(
+            ["--mean", "128", "--std", "65", "--input-shape", "1,3,224,224"]
+        )
+
+        assert default_result.exit_code == 0, default_result.output
+        assert normalized_result.exit_code == 0, normalized_result.output
+        assert default_result.output != normalized_result.output
+
     def test_predict_without_model_or_selector_exits_nonzero(self, tmp_path):
         image_path = _make_png_path(tmp_path)
 

--- a/radiologist-inference/tests/test_cli.py
+++ b/radiologist-inference/tests/test_cli.py
@@ -115,6 +115,37 @@ class TestPredictCommand:
         assert "ABNORMAL" in result.output
 
 
+class TestPredictCommandNormalizationFlags:
+    def test_predict_with_mean_std_input_shape_changes_output(self, tmp_path):
+        """--mean/--std/--input-shape must be accepted and change output vs.
+        the default (no flags) invocation."""
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        image_path = _make_png_path(tmp_path)
+
+        default_result = runner.invoke(
+            app, ["predict", image_path, "--model", det_path]
+        )
+        normalized_result = runner.invoke(
+            app,
+            [
+                "predict",
+                image_path,
+                "--model",
+                det_path,
+                "--mean",
+                "128",
+                "--std",
+                "65",
+                "--input-shape",
+                "1,3,224,224",
+            ],
+        )
+
+        assert default_result.exit_code == 0
+        assert normalized_result.exit_code == 0, normalized_result.output
+        assert default_result.output != normalized_result.output
+
+
 class TestExplainCommand:
     def test_explain_exits_0_and_prints_predicted_class(self, tmp_path):
         det_path = build_det_onnx(tmp_path, filename="det.onnx")
@@ -141,6 +172,29 @@ class TestExplainCommand:
         assert saved.ndim == 2
 
 
+class TestExplainCommandNormalizationFlags:
+    def test_explain_with_mean_std_accepted(self, tmp_path):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        image_path = _make_png_path(tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "explain",
+                image_path,
+                "--model",
+                det_path,
+                "--mean",
+                "128",
+                "--std",
+                "65",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
+        assert "Predicted class:" in result.output
+
+
 class TestUncertaintyCommand:
     def test_uncertainty_exits_0_and_prints_stats(self, tmp_path):
         det_path = build_det_onnx(tmp_path, filename="det.onnx")
@@ -162,6 +216,36 @@ class TestUncertaintyCommand:
         )
 
         assert result.exit_code == 0
+        assert "entropy" in result.output.lower()
+
+
+class TestUncertaintyCommandNormalizationFlags:
+    def test_uncertainty_with_mean_std_input_shape_accepted(self, tmp_path):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
+        image_path = _make_png_path(tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "uncertainty",
+                image_path,
+                "--model",
+                det_path,
+                "--mcd-model",
+                mcd_path,
+                "--n-passes",
+                "5",
+                "--mean",
+                "128",
+                "--std",
+                "65",
+                "--input-shape",
+                "1,3,224,224",
+            ],
+        )
+
+        assert result.exit_code == 0, result.output
         assert "entropy" in result.output.lower()
 
 

--- a/radiologist-inference/tests/test_mc_dropout.py
+++ b/radiologist-inference/tests/test_mc_dropout.py
@@ -274,3 +274,43 @@ class TestMCDropoutFromSelector:
                 RuntimeError, match=r"radiologist-inference\[registry\]"
             ):
                 MCDropoutPredictor.from_selector(selector, local_dir=str(tmp_path))
+
+
+# ---------------------------------------------------------------------------
+# Tests: MCDropoutPredictor.from_path mean/std eager validation
+# ---------------------------------------------------------------------------
+
+
+class TestMCDropoutFromPathMeanStdValidation:
+    def test_from_path_with_only_mean_raises_value_error(
+        self, det_onnx_path, mcd_onnx_path
+    ):
+        """Supplying mean without std must raise ValueError eagerly at
+        from_path, before any prediction is requested (bugfix review finding
+        on PR #131 — MCDropoutPredictor delegates to the shared
+        BasePredictor.from_path code path)."""
+        with pytest.raises(ValueError, match="mean and std"):
+            MCDropoutPredictor.from_path(
+                det_path=det_onnx_path, mcd_path=mcd_onnx_path, mean=128.0
+            )
+
+    def test_from_selector_with_mismatched_mean_std_raises_before_any_pull(
+        self, det_onnx_path, mcd_onnx_path, tmp_path
+    ):
+        """MCDropoutPredictor.from_selector has its own det+mcd resolve/pull
+        sequence (it does not delegate resolution to BasePredictor); a
+        mismatched mean/std pair must raise before either artifact is
+        resolved or pulled (bugfix review finding on PR #131)."""
+        fake_registry = _FakeMcdSelectorRegistry(det_onnx_path, mcd_onnx_path)
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        with pytest.raises(ValueError, match="mean and std"):
+            MCDropoutPredictor.from_selector(
+                selector,
+                local_dir=str(tmp_path),
+                registry=fake_registry,
+                mean=128.0,
+            )
+
+        assert fake_registry.resolve_calls == []
+        assert fake_registry.pull_calls == []

--- a/radiologist-inference/tests/test_mc_dropout.py
+++ b/radiologist-inference/tests/test_mc_dropout.py
@@ -27,10 +27,57 @@ Tests drive through the public API only. Fixtures build real ONNX models so
 no mocks are needed for local code.
 """
 
+from typing import List, Optional, Tuple
+from unittest.mock import patch
+
 import numpy as np
 import pytest
+from _helpers import build_det_onnx, build_mcd_onnx
+
+from radiologist.inference import MCDropoutPredictor
+from radiologist.registry import ArtifactRef, RegistrySelector
 
 CLASSES = ["NORMAL", "ABNORMAL"]
+
+
+class _FakeMcdSelectorRegistry:
+    """Fake registry resolving det (run_id) vs mcd ({run_id}-mcd) artifacts.
+
+    When run_id is None (tags/groups/metric-based selection), the same
+    artifact path is returned for both resolutions, matching today's
+    fallback semantics.
+    """
+
+    def __init__(self, det_path: str, mcd_path: str) -> None:
+        self._det_path = det_path
+        self._mcd_path = mcd_path
+        self.resolve_calls: List[Tuple[str, Optional[str]]] = []
+        self.pull_calls: List[Tuple[str, str]] = []
+
+    def resolve(
+        self,
+        path: str,
+        run_id=None,
+        groups=None,
+        tags=None,
+        metric=None,
+        version=None,
+        include_sweeps: bool = False,
+    ) -> ArtifactRef:
+        self.resolve_calls.append((path, run_id))
+        resolved_run_id = run_id or "resolved-run"
+        return ArtifactRef(
+            qualified_name=f"{path}/model-{resolved_run_id}:best",
+            run_id=resolved_run_id,
+            artifact_name=f"model-{resolved_run_id}",
+            version="best",
+        )
+
+    def pull(self, artifact_path: str, local_dir: str) -> str:
+        self.pull_calls.append((artifact_path, local_dir))
+        if artifact_path.endswith("-mcd:best"):
+            return self._mcd_path
+        return self._det_path
 
 
 # ---------------------------------------------------------------------------
@@ -129,3 +176,101 @@ class TestMcDropoutPredict:
         preprocessed = sample_image.astype(np.float32).transpose(2, 0, 1)[np.newaxis]
         result = mc_dropout_predict(session, preprocessed, n_passes=20)
         assert result.n_passes == 20
+
+
+# ---------------------------------------------------------------------------
+# Tests: MCDropoutPredictor.from_selector
+# ---------------------------------------------------------------------------
+
+
+class TestMCDropoutFromSelector:
+    def test_from_selector_resolves_det_and_mcd_suffixed_run_id(self, tmp_path):
+        """from_selector with a run_id must resolve both the det artifact
+        (run_id) and the mcd artifact ({run_id}-mcd), threading mean/std/
+        input_shape into the loaded predictor (bugfix #139)."""
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
+        fake_registry = _FakeMcdSelectorRegistry(det_path, mcd_path)
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        predictor = MCDropoutPredictor.from_selector(
+            selector,
+            local_dir=str(tmp_path),
+            registry=fake_registry,
+            mean=128.0,
+            std=65.0,
+        )
+
+        image = np.zeros((224, 224, 3), dtype=np.uint8)
+        result = predictor.predict_with_uncertainty(image, n_passes=10)
+
+        assert isinstance(predictor, MCDropoutPredictor)
+        assert set(result.mean_probabilities.keys()) == set(CLASSES)
+        assert abs(sum(result.mean_probabilities.values()) - 1.0) < 1e-5
+        assert fake_registry.resolve_calls == [
+            ("entity/project/model", "run123"),
+            ("entity/project/model", "run123-mcd"),
+        ]
+        assert fake_registry.pull_calls == [
+            ("entity/project/model/model-run123:best", str(tmp_path)),
+            ("entity/project/model/model-run123-mcd:best", str(tmp_path)),
+        ]
+
+    def test_from_selector_mean_std_changes_normalization(self, tmp_path):
+        """mean/std supplied to from_selector must actually change the
+        normalization applied before MC-Dropout inference."""
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
+
+        default_predictor = MCDropoutPredictor.from_selector(
+            RegistrySelector(path="entity/project/model", run_id="run123"),
+            local_dir=str(tmp_path),
+            registry=_FakeMcdSelectorRegistry(det_path, mcd_path),
+        )
+        normalized_predictor = MCDropoutPredictor.from_selector(
+            RegistrySelector(path="entity/project/model", run_id="run123"),
+            local_dir=str(tmp_path),
+            registry=_FakeMcdSelectorRegistry(det_path, mcd_path),
+            mean=128.0,
+            std=65.0,
+        )
+
+        assert default_predictor._state.mean is None
+        assert normalized_predictor._state.mean == 128.0
+        assert normalized_predictor._state.std == 65.0
+
+    def test_from_selector_without_run_id_reuses_same_selector_for_det_and_mcd(
+        self, tmp_path
+    ):
+        """When selector.run_id is None (tags/groups/metric-based selection),
+        the same selector must be reused for both det and mcd resolution —
+        no -mcd suffix — matching today's CLI fallback behavior."""
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
+        fake_registry = _FakeMcdSelectorRegistry(det_path, mcd_path)
+        selector = RegistrySelector(path="entity/project/model", tags=["a", "b"])
+
+        predictor = MCDropoutPredictor.from_selector(
+            selector, local_dir=str(tmp_path), registry=fake_registry
+        )
+
+        assert isinstance(predictor, MCDropoutPredictor)
+        assert fake_registry.resolve_calls == [
+            ("entity/project/model", None),
+            ("entity/project/model", None),
+        ]
+
+    def test_from_selector_raises_runtime_error_naming_inference_extra_when_wandb_absent(
+        self, tmp_path
+    ):
+        """from_selector with no injected registry and wandb absent must
+        raise RuntimeError naming radiologist-inference[registry]."""
+        import radiologist.registry.optional as optional_mod
+
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        with patch.object(optional_mod, "_wandb", None):
+            with pytest.raises(
+                RuntimeError, match=r"radiologist-inference\[registry\]"
+            ):
+                MCDropoutPredictor.from_selector(selector, local_dir=str(tmp_path))


### PR DESCRIPTION
## Summary

- `BasePredictor.from_path`/`from_registry` now accept optional `mean`, `std`, and `input_shape` kwargs so inference-time normalization can match a model's actual training-time preprocessing instead of always doing `/255.0`-only scaling.
- `mean`/`std` must be passed together (raises `ValueError` otherwise); `input_shape` is used only as a fallback when the ONNX file's embedded metadata has no `input_shape` key (raises `ValueError` if neither is available).
- The `radiologist` CLI's `predict`, `explain`, and `uncertainty` commands gain matching `--mean`, `--std`, and `--input-shape` flags, threaded straight through to `from_path`.
- Fully backward compatible: omitting the new args preserves today's default `/255.0`-only preprocessing.

Closes #129.

## Test plan

- [ ] `make test-inference` passes
- [ ] `radiologist predict <img> --model <onnx> --mean <m> --std <s>` produces normalized preprocessing matching training-time stats
- [ ] Omitting `--mean`/`--std`/`--input-shape` preserves prior `/255.0`-only behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)