### PR TITLE
feat(inference): single-session predictors + declarative CLI verb registry

### DIFF
--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -23,5 +23,7 @@
 - [Pytest worktree isolation](feedback_pytest_worktree_isolation.md) — stale `.pth` cross-worktree pointers and cross-package plugin-name collisions; run pytest per-package with `--confcutdir=.`
 - [pyenv activate needs shell init](feedback_pyenv_activate_needs_shell_init.md) — Bash calls need `eval "$(pyenv init -)"; eval "$(pyenv virtualenv-init -)"` before `pyenv activate`, else installs silently land in the shared venv
 - [Worktree branch already checked out](feedback_worktree_branch_already_checked_out.md) — git refuses a 2nd worktree for a branch checked out elsewhere; work in-place instead; also watch for uv.lock revision noise from `make dev-install`
+- [Issue test-scope incomplete](feedback_issue_test_scope_incomplete.md) — an issue's test-update list can omit call sites broken by a signature change; grep the old signature across the whole suite before declaring green
+- [onnxruntime NoSuchFile vs FileNotFoundError](feedback_onnxruntime_no_such_file_vs_file_not_found.md) — onnxruntime raises its own NoSuchFile on a missing path, not FileNotFoundError; check existence explicitly if the AC requires the stdlib type
 
 See also: [[shared/MEMORY.md]] for cross-agent rules (TDD).

--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -25,5 +25,6 @@
 - [Worktree branch already checked out](feedback_worktree_branch_already_checked_out.md) — git refuses a 2nd worktree for a branch checked out elsewhere; work in-place instead; also watch for uv.lock revision noise from `make dev-install`
 - [Issue test-scope incomplete](feedback_issue_test_scope_incomplete.md) — an issue's test-update list can omit call sites broken by a signature change; grep the old signature across the whole suite before declaring green
 - [onnxruntime NoSuchFile vs FileNotFoundError](feedback_onnxruntime_no_such_file_vs_file_not_found.md) — onnxruntime raises its own NoSuchFile on a missing path, not FileNotFoundError; check existence explicitly if the AC requires the stdlib type
+- [Epic seam convention ownership move](feedback_epic_seam_convention_ownership_move.md) — when a new shared seam's contract says a convention "now lives here"/"is no longer done automatically", grep sibling methods for the old inline version and simplify it away, don't double-apply
 
 See also: [[shared/MEMORY.md]] for cross-agent rules (TDD).

--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -27,5 +27,6 @@
 - [onnxruntime NoSuchFile vs FileNotFoundError](feedback_onnxruntime_no_such_file_vs_file_not_found.md) — onnxruntime raises its own NoSuchFile on a missing path, not FileNotFoundError; check existence explicitly if the AC requires the stdlib type
 - [Epic seam convention ownership move](feedback_epic_seam_convention_ownership_move.md) — when a new shared seam's contract says a convention "now lives here"/"is no longer done automatically", grep sibling methods for the old inline version and simplify it away, don't double-apply
 - [Narrowed shared-helper signature drops params](feedback_narrowed_shared_helper_signature_drops_params.md) — a "rewire onto shared helper X" issue's literal call-signature snippet can predate optional kwargs that landed afterward; grep old call sites' full kwargs before deleting any, extend the helper instead of regressing
+- [Review-fix reverts epic seam scope creep](feedback_review_fix_reverts_epic_seam_scope_creep.md) — when a review says an internal seam leaked into `__all__`, revert both the export and the test's expected set atomically; don't just widen the test to match the leak
 
 See also: [[shared/MEMORY.md]] for cross-agent rules (TDD).

--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -26,5 +26,6 @@
 - [Issue test-scope incomplete](feedback_issue_test_scope_incomplete.md) — an issue's test-update list can omit call sites broken by a signature change; grep the old signature across the whole suite before declaring green
 - [onnxruntime NoSuchFile vs FileNotFoundError](feedback_onnxruntime_no_such_file_vs_file_not_found.md) — onnxruntime raises its own NoSuchFile on a missing path, not FileNotFoundError; check existence explicitly if the AC requires the stdlib type
 - [Epic seam convention ownership move](feedback_epic_seam_convention_ownership_move.md) — when a new shared seam's contract says a convention "now lives here"/"is no longer done automatically", grep sibling methods for the old inline version and simplify it away, don't double-apply
+- [Narrowed shared-helper signature drops params](feedback_narrowed_shared_helper_signature_drops_params.md) — a "rewire onto shared helper X" issue's literal call-signature snippet can predate optional kwargs that landed afterward; grep old call sites' full kwargs before deleting any, extend the helper instead of regressing
 
 See also: [[shared/MEMORY.md]] for cross-agent rules (TDD).

--- a/.claude/agent-memory/tdd-developer/feedback_epic_seam_convention_ownership_move.md
+++ b/.claude/agent-memory/tdd-developer/feedback_epic_seam_convention_ownership_move.md
@@ -1,0 +1,31 @@
+---
+name: epic-seam-convention-ownership-move
+description: when a new shared-seam issue's interface contract says a naming/rewrite convention now lives in the new module, check whether an existing sibling method already applies that same convention internally — it must be simplified to stop double-applying it
+metadata:
+  type: feedback
+---
+
+In radiologist#142 (predictor-verb registry `verbs.py`), the interface contract required
+`load_predictor` to rewrite `run_id` via `apply_mcd_convention` (`f"{run_id}-mcd"`) *before*
+building the registry selector, for the `uncertainty` verb. But the pre-existing
+`MCDropoutPredictor.from_selector` (delivered by a prior sibling issue, #141) already applied
+that exact same `{run_id}-mcd` suffixing internally (plus an extra, no-longer-wanted pull of the
+deterministic model) — a design left over from an older CLI-only bugfix (#139). Blindly wiring
+`load_predictor` on top of the untouched `from_selector` double-applied the suffix
+(`run1` → `run1-mcd` → `run1-mcd-mcd`), a bug only surfaced by writing a real registry-backed
+test for the `uncertainty` verb (mocking only the wandb boundary) and reading the resulting
+mock call args.
+
+**Why:** epic specs describe the target end-state of the *new* module's contract, not every
+existing collaborator that also happens to encode the same behavior today. The issue text's own
+phrase "the deterministic model is no longer pulled" was the signal that a sibling method's
+current behavior was slated to change as *part of* this slice's shared seam, not a fact I could
+take as already true.
+
+**How to apply:** when an issue's design notes state a convention "is exactly what `<new
+function>` encodes" or "is no longer done automatically", grep for the old inline version of that
+same logic in the classes/functions the new function will call into. If found, it is a shared
+seam this slice must simplify (per
+[[feedback_shared_base_class_seam_in_decomposition_epics]]) — remove the duplicate rewrite from
+the old location and update its existing tests to reflect the new single-application contract,
+rather than leaving both layers applying the convention.

--- a/.claude/agent-memory/tdd-developer/feedback_issue_test_scope_incomplete.md
+++ b/.claude/agent-memory/tdd-developer/feedback_issue_test_scope_incomplete.md
@@ -1,0 +1,25 @@
+---
+name: issue-test-scope-incomplete
+description: An issue's "Test updates (owned by this slice)" list can omit test call sites that break anyway because of a signature change — grep for the old signature across the whole test suite before trusting the list.
+metadata:
+  type: feedback
+---
+
+When an issue changes a public method's signature (e.g. `from_path(det_path, mcd_path=None)`
+→ `from_path(model_path)`), its "Technical notes" section may enumerate only the test files/line
+ranges the architect explicitly reviewed — not every call site that breaks as a mechanical
+consequence of the signature change. In radiologist#141, `TestMCDropoutFromPathMeanStdValidation`
+in `test_mc_dropout.py` called `MCDropoutPredictor.from_path(det_path=..., mcd_path=...)` directly
+and was not mentioned anywhere in the issue body, yet it broke immediately once the signature
+changed.
+
+**Why:** issue authors write the test-update list from memory/diff-review at spec time; a
+grep-verifiable mechanical break can slip through even in a careful spec. Trusting the list
+literally leaves `pytest` red despite believing you did everything asked.
+
+**How to apply:** after implementing a signature change (rename/drop kwarg, rename method), run
+`grep -rn "<old_signature_pattern>"` across the whole test directory (not just the files the issue
+names) before declaring green. Fix every hit, even ones the issue didn't call out — the AC
+"pytest green" always wins over an incomplete enumeration. See also
+[[feedback_shared_base_class_seam_in_decomposition_epics]] for the same principle applied to
+production code seams.

--- a/.claude/agent-memory/tdd-developer/feedback_narrowed_shared_helper_signature_drops_params.md
+++ b/.claude/agent-memory/tdd-developer/feedback_narrowed_shared_helper_signature_drops_params.md
@@ -1,0 +1,32 @@
+---
+name: narrowed-shared-helper-signature-drops-params
+description: an issue's literal interface-contract code snippet for a shared loading/dispatch helper can omit optional kwargs (mean/std/input_shape-style passthrough) that landed in the repo after the snippet was drafted — grep existing tests for the old call sites before deleting the params
+metadata:
+  type: feedback
+---
+
+In radiologist#143 (CLI rewire onto `verbs.load_predictor`), the issue's interface contract
+showed the exact call `verbs.load_predictor(verb, model, run_id, tags, groups, metric,
+local_dir)` — 7 positional args, no `mean`/`std`/`input_shape`. But `verbs.py` (#142) had been
+drafted before a separate, already-merged bugfix (#139/commits `e30e572`/`9d9ea35`) added
+`mean`/`std`/`input_shape` normalization-override support to `Classifier.from_path` /
+`from_selector` and threaded it through the CLI's old `_load_predictor` /
+`_load_uncertainty_predictor` helpers. `tests/test_cli.py` already had
+`TestPredictCommandNormalizationFlags` etc. asserting `--mean --std --input-shape` change
+CLI output — those tests were not mentioned in #143's "Test updates" list at all, because the
+issue author's snippet simply predated that feature landing.
+
+**Why:** literal interface-contract snippets in an issue are drafted at spec time and can miss
+capabilities that merged into `main`/the epic branch afterward. Deleting the params to match
+the snippet exactly would silently drop working normalization-override support and break
+already-passing tests — "pytest green" as an AC always wins over a narrower literal snippet.
+
+**How to apply:** before implementing a "rewire onto shared helper X" issue, `grep -rn` the
+old call sites the issue is replacing for **all** their kwargs (not just the ones named in the
+issue body), and check whether the shared helper's current signature already supports them. If
+not, extend the shared helper with the same optional kwargs (default `None`), forwarded
+verbatim to the underlying constructor — this keeps the literal positional-arg contract intact
+(callers using only the 7 named args are unaffected) while not regressing capability. Related:
+[[feedback_shared_base_class_seam_in_decomposition_epics]] (implement the seam your own
+GREEN-real bar needs) and [[feedback_issue_test_scope_incomplete]] (grep the whole test suite,
+not just the issue's named line ranges).

--- a/.claude/agent-memory/tdd-developer/feedback_onnxruntime_no_such_file_vs_file_not_found.md
+++ b/.claude/agent-memory/tdd-developer/feedback_onnxruntime_no_such_file_vs_file_not_found.md
@@ -1,0 +1,22 @@
+---
+name: onnxruntime-no-such-file-vs-file-not-found
+description: onnxruntime.InferenceSession raises its own NoSuchFile error for a missing model path, not Python's FileNotFoundError — check existence explicitly before constructing the session if the AC requires FileNotFoundError.
+metadata:
+  type: feedback
+---
+
+`onnxruntime.InferenceSession(path)` on a nonexistent path raises
+`onnxruntime.capi.onnxruntime_pybind11_state.NoSuchFile`, not the stdlib `FileNotFoundError`. If an
+acceptance criterion says "loading from a missing path raises FileNotFoundError," you must add an
+explicit `os.path.exists(path)` check (or catch-and-reraise) before/around the `InferenceSession(...)`
+call — the library's own exception type won't satisfy a `pytest.raises(FileNotFoundError)`
+assertion.
+
+**Why:** third-party inference/IO libraries typically wrap missing-file errors in their own
+exception hierarchy for cross-platform/backend consistency; they do not subclass the stdlib
+exception callers usually expect.
+
+**How to apply:** whenever a spec asks for a standard Python exception type (`FileNotFoundError`,
+`ValueError`, etc.) on a path/IO operation delegated to a third-party library, verify what that
+library actually raises (a quick `python -c` repro) before assuming it matches — add the explicit
+check/wrap in the wrapping code if it doesn't.

--- a/.claude/agent-memory/tdd-developer/feedback_review_fix_reverts_epic_seam_scope_creep.md
+++ b/.claude/agent-memory/tdd-developer/feedback_review_fix_reverts_epic_seam_scope_creep.md
@@ -1,0 +1,40 @@
+---
+name: feedback-review-fix-reverts-epic-seam-scope-creep
+description: when a code-review finding says a helper module's names leaked into a package __init__/__all__, the fix is a straight revert (remove import + names), not a re-negotiation of the seam
+metadata:
+  type: feedback
+---
+
+On PR #144 (predictor-verb-registry epic), review flagged that
+`radiologist-inference`'s `__init__.py` had re-exported `verbs.py`'s
+`PredictorVerb`/`get_verb`/`apply_mcd_convention`/`load_predictor` into
+`__all__`, directly contradicting the epic issue's own explicit instruction
+("Do not edit `__init__.py` — verbs stays internal"). This is the same class
+of thing as [[feedback_shared_base_class_seam_in_decomposition_epics]] and
+[[feedback_skeleton_issue_repoints_old_tests]]: an internal CLI-support seam
+had scope-crept into the public API surface during implementation, and the
+review caught it after merge.
+
+**Why:** `cli.py` already imported `verbs` directly
+(`from radiologist.inference import verbs`) — nothing needed the re-export.
+Once one file re-exports an internal seam, the package's exact-equality
+`__all__` test (`test_public_api.py::test_all_public_names_present`) has to
+grow with it, silently normalizing the leak for future reviewers/agents who
+just diff against the "current" expected set instead of the epic's original
+intent.
+
+**How to apply:** when a finding says "X leaked into `__all__`", revert both
+sides atomically in one commit: remove the import block + the names from
+`__all__` in `__init__.py`, AND shrink the test's expected `set` literal back
+to what it was before the leaking commit (check `git log -p` on the test file
+if unsure what "before" means) — don't just make the test pass by keeping the
+leaked names in both places. A second finding on the same PR (redundant
+`MCDropoutPredictor.from_selector` override that had become byte-for-byte
+identical to the inherited `BasePredictor.from_selector` after
+`_resolve_and_pull` absorbed the registry-fallback logic) is the same root
+cause in miniature: a decomposition epic's shared-seam code drifting out of
+sync between sibling/slice issues. Also: this PR's `TestServeCommand` mocked
+`create_app` (owned code) — reviewed fix was to let the real `create_app`
+run (it's side-effect-free once `_uvicorn.run` is mocked as the actual
+process boundary) and assert through FastAPI's `TestClient`, mirroring the
+pattern already established in `test_app.py`.

--- a/radiologist-inference/README.md
+++ b/radiologist-inference/README.md
@@ -133,7 +133,7 @@ radiologist predict chest_xray.png --model model.onnx
 radiologist explain chest_xray.png --model model.onnx --out saliency.npy
 
 # MC-Dropout uncertainty
-radiologist uncertainty chest_xray.png --model model.onnx --mcd-model model_mcd.onnx
+radiologist uncertainty chest_xray.png --model model_mcd.onnx
 ```
 
 `predict`, `explain`, and `uncertainty` all accept optional `--mean`,
@@ -144,6 +144,14 @@ Omitting all three keeps today's default `/255.0`-only preprocessing:
 ```bash
 radiologist predict chest_xray.png --model model.onnx \
     --mean 128 --std 65 --input-shape 1,3,224,224
+```
+
+```bash
+# Serve — picks the verb to serve via --predict/--explain/--uncertainty
+# (default: explain, preserving today's behavior)
+radiologist serve --model model.onnx
+radiologist serve --uncertainty --model model_mcd.onnx
+radiologist serve --predict --run-id abc123
 ```
 
 ## Public API reference

--- a/radiologist-inference/README.md
+++ b/radiologist-inference/README.md
@@ -38,20 +38,18 @@ matching the capabilities you need.
 from radiologist.inference import Classifier, Explainer, MCDropoutPredictor
 
 # Deterministic prediction only
-classifier = Classifier.from_path(det_path="model.onnx")
+classifier = Classifier.from_path(model_path="model.onnx")
 result = classifier.predict("chest_xray.png")
 print(result.predicted_class)          # "NORMAL"
 print(result.probabilities)            # {"NORMAL": 0.93, "PNEUMONIA": 0.07}
 
 # Score-CAM explanation (Explainer inherits predict from Classifier)
-explainer = Explainer.from_path(det_path="model.onnx")
+explainer = Explainer.from_path(model_path="model.onnx")
 explanation = explainer.explain("chest_xray.png")
 print(explanation.saliency_map.shape)  # (H, W)
 
-# MC-Dropout uncertainty (requires mcd_path)
-mcd_predictor = MCDropoutPredictor.from_path(
-    det_path="model.onnx", mcd_path="model_mcd.onnx"
-)
+# MC-Dropout uncertainty (loaded from a stochastic MC-Dropout ONNX model)
+mcd_predictor = MCDropoutPredictor.from_path(model_path="model_mcd.onnx")
 uncertainty = mcd_predictor.predict_with_uncertainty("chest_xray.png", n_passes=30)
 print(uncertainty.predictive_entropy)
 print(uncertainty.std_per_class)
@@ -79,7 +77,7 @@ train/serve-consistent preprocessing:
 
 ```python
 classifier = Classifier.from_path(
-    det_path="model.onnx", mean=128.0, std=65.0,
+    model_path="model.onnx", mean=128.0, std=65.0,
 )
 ```
 
@@ -93,7 +91,7 @@ ONNX file's embedded metadata has no `input_shape` key; if metadata has no
 
 ```python
 classifier = Classifier.from_path(
-    det_path="model_without_shape_metadata.onnx", input_shape=[1, 3, 224, 224],
+    model_path="model_without_shape_metadata.onnx", input_shape=[1, 3, 224, 224],
 )
 ```
 
@@ -156,7 +154,7 @@ Common loading surface shared by every predictor class.
 
 | Method | Signature | Description |
 |---|---|---|
-| `from_path` | `(det_path: str, mcd_path: Optional[str] = None, mean: Optional[float] = None, std: Optional[float] = None, input_shape: Optional[List[int]] = None) -> BasePredictor` | Load from local ONNX files |
+| `from_path` | `(model_path: str, mean: Optional[float] = None, std: Optional[float] = None, input_shape: Optional[List[int]] = None) -> BasePredictor` | Load from a local ONNX file |
 | `from_registry` | `(artifact_path: str, local_dir: str, registry=None, mean: Optional[float] = None, std: Optional[float] = None, input_shape: Optional[List[int]] = None) -> BasePredictor` | Download from W&B Registry and load; requires `registry` extra |
 
 ### `Classifier(BasePredictor)`
@@ -175,7 +173,7 @@ Common loading surface shared by every predictor class.
 
 | Method | Signature | Description |
 |---|---|---|
-| `predict_with_uncertainty` | `(image, n_passes: int = 30) -> UncertaintyResult` | MC-Dropout stochastic inference; requires `mcd_path` at load time |
+| `predict_with_uncertainty` | `(image, n_passes: int = 30) -> UncertaintyResult` | MC-Dropout stochastic inference |
 
 ### `score_cam`
 
@@ -214,7 +212,7 @@ above). Requires the `serve` extra.
 | `Prediction` | `probabilities: Dict[str, float]`, `predicted_class: str` |
 | `Explanation` | `saliency_map: np.ndarray`, `predicted_class: str` |
 | `UncertaintyResult` | `mean_probabilities: Dict[str, float]`, `std_per_class: Dict[str, float]`, `predictive_entropy: float`, `n_passes: int` |
-| `ModelMetadata` | `classes: List[str]`, `input_shape: List[int]`, `cam_target_layer: str`, `output_names: List[str]`, `mc_dropout: bool` |
+| `ModelMetadata` | `classes: List[str]`, `input_shape: List[int]`, `cam_target_layer: str`, `output_names: List[str]` |
 
 ## Development setup
 

--- a/radiologist-inference/src/radiologist/inference/__init__.py
+++ b/radiologist-inference/src/radiologist/inference/__init__.py
@@ -32,6 +32,12 @@ from radiologist.inference.models import (
     Prediction,
     UncertaintyResult,
 )
+from radiologist.inference.verbs import (
+    PredictorVerb,
+    apply_mcd_convention,
+    get_verb,
+    load_predictor,
+)
 
 __all__ = [
     "BasePredictor",
@@ -45,4 +51,8 @@ __all__ = [
     "score_cam",
     "mc_dropout_predict",
     "create_app",
+    "PredictorVerb",
+    "get_verb",
+    "apply_mcd_convention",
+    "load_predictor",
 ]

--- a/radiologist-inference/src/radiologist/inference/__init__.py
+++ b/radiologist-inference/src/radiologist/inference/__init__.py
@@ -32,12 +32,6 @@ from radiologist.inference.models import (
     Prediction,
     UncertaintyResult,
 )
-from radiologist.inference.verbs import (
-    PredictorVerb,
-    apply_mcd_convention,
-    get_verb,
-    load_predictor,
-)
 
 __all__ = [
     "BasePredictor",
@@ -51,8 +45,4 @@ __all__ = [
     "score_cam",
     "mc_dropout_predict",
     "create_app",
-    "PredictorVerb",
-    "get_verb",
-    "apply_mcd_convention",
-    "load_predictor",
 ]

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -29,6 +29,7 @@ in the subclasses defined in classifier.py, explainer.py, and mc_dropout.py.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Dict, List, Optional, Union
 
@@ -52,10 +53,9 @@ _INFERENCE_WANDB_MISSING_MSG = (
 
 @dataclass
 class _PredictorState:
-    det_session: ort.InferenceSession
+    session: ort.InferenceSession
     metadata: Dict[str, str]
     model_metadata: ModelMetadata
-    mcd_session: Optional[ort.InferenceSession] = field(default=None)
     mean: Optional[float] = field(default=None)
     std: Optional[float] = field(default=None)
 
@@ -68,17 +68,18 @@ class BasePredictor:
     @classmethod
     def from_path(
         cls,
-        det_path: str,
-        mcd_path: Optional[str] = None,
+        model_path: str,
         mean: Optional[float] = None,
         std: Optional[float] = None,
         input_shape: Optional[List[int]] = None,
     ) -> "BasePredictor":
-        """Load a predictor instance from local ONNX file paths.
+        """Load a predictor instance from a local ONNX file path.
 
         Args:
-            det_path: Path to the deterministic ONNX model file.
-            mcd_path: Optional path to the MC-Dropout ONNX model file.
+            model_path: Path to the ONNX model file. For an MCDropoutPredictor
+                this must be the stochastic (MC-Dropout) model — the single
+                session state is verb-agnostic and holds whichever model was
+                loaded.
             mean: Optional normalization mean. When omitted (with std also
                 omitted), preprocessing keeps today's /255.0-only scaling.
             std: Optional normalization std. Must be provided together with
@@ -90,30 +91,26 @@ class BasePredictor:
             Loaded instance of the calling subclass.
 
         Raises:
-            FileNotFoundError: If det_path does not exist.
+            FileNotFoundError: If model_path does not exist.
             ValueError: If exactly one of mean/std is provided, or if no
                 input_shape can be resolved from metadata or the argument.
         """
         _validate_mean_std(mean, std)
-        det_session = ort.InferenceSession(det_path)
-        metadata = _read_metadata(det_session)
-
-        mcd_session: Optional[ort.InferenceSession] = None
-        if mcd_path is not None:
-            mcd_session = ort.InferenceSession(mcd_path)
+        if not os.path.exists(model_path):
+            raise FileNotFoundError(f"No such ONNX model file: {model_path}")
+        session = ort.InferenceSession(model_path)
+        metadata = _read_metadata(session)
 
         model_metadata = _parse_model_metadata(
             metadata,
-            mc_dropout=mcd_session is not None,
             default_input_shape=input_shape,
         )
 
         instance = cls.__new__(cls)
         instance._state = _PredictorState(
-            det_session=det_session,
+            session=session,
             metadata=metadata,
             model_metadata=model_metadata,
-            mcd_session=mcd_session,
             mean=mean,
             std=std,
         )
@@ -151,11 +148,11 @@ class BasePredictor:
         _validate_mean_std(mean, std)
         reg = registry if registry is not None else WandbRegistry()
         try:
-            det_path = reg.pull(artifact_path=artifact_path, local_dir=local_dir)
+            model_path = reg.pull(artifact_path=artifact_path, local_dir=local_dir)
         except RuntimeError as exc:
             raise RuntimeError(_INFERENCE_WANDB_MISSING_MSG) from exc
         return cls.from_path(
-            det_path=det_path, mean=mean, std=std, input_shape=input_shape
+            model_path=model_path, mean=mean, std=std, input_shape=input_shape
         )
 
     @classmethod
@@ -188,9 +185,9 @@ class BasePredictor:
             ValueError: If exactly one of mean/std is provided.
         """
         _validate_mean_std(mean, std)
-        det_path = _resolve_and_pull(selector, local_dir, registry)
+        model_path = _resolve_and_pull(selector, local_dir, registry)
         return cls.from_path(
-            det_path=det_path, mean=mean, std=std, input_shape=input_shape
+            model_path=model_path, mean=mean, std=std, input_shape=input_shape
         )
 
 
@@ -229,14 +226,12 @@ def _read_metadata(session: "ort.InferenceSession") -> Dict[str, str]:
 
 def _parse_model_metadata(
     metadata: Dict[str, str],
-    mc_dropout: bool,
     default_input_shape: Optional[List[int]] = None,
 ) -> ModelMetadata:
     """Parse the raw ONNX metadata dict into a typed ModelMetadata.
 
     Args:
-        metadata: Raw custom_metadata_map from the deterministic session.
-        mc_dropout: Whether a stochastic (MC-Dropout) session was also loaded.
+        metadata: Raw custom_metadata_map from the loaded session.
         default_input_shape: Fallback [N, C, H, W] used when the metadata has
             no input_shape key.
 
@@ -260,7 +255,6 @@ def _parse_model_metadata(
         input_shape=input_shape,
         cam_target_layer=metadata["cam_target_layer"],
         output_names=json.loads(metadata["output_names"]),
-        mc_dropout=mc_dropout,
     )
 
 

--- a/radiologist-inference/src/radiologist/inference/classifier.py
+++ b/radiologist-inference/src/radiologist/inference/classifier.py
@@ -67,7 +67,7 @@ class Classifier(BasePredictor):
             image, input_shape, mean=self._state.mean, std=self._state.std
         )
 
-        session = self._state.det_session
+        session = self._state.session
         input_name = session.get_inputs()[0].name
         outputs = session.run(["logits"], {input_name: arr})
         logits: np.ndarray = outputs[0][0]

--- a/radiologist-inference/src/radiologist/inference/cli.py
+++ b/radiologist-inference/src/radiologist/inference/cli.py
@@ -24,7 +24,7 @@
 
 Entry points: predict <image> --model <det_path>
               explain <image> --model <det_path>
-              uncertainty <image> --model <det_path> --mcd-model <mcd_path>
+              uncertainty <image> --model <mcd_path>
 """
 
 import functools
@@ -32,19 +32,11 @@ from typing import Any, Callable, List, Optional, TypeVar
 
 import numpy as np
 
+from radiologist.inference import verbs
 from radiologist.inference.app import create_app
-from radiologist.inference.classifier import Classifier
-from radiologist.inference.explainer import Explainer
-from radiologist.inference.mc_dropout import MCDropoutPredictor
 from radiologist.inference.optional import _typer, _uvicorn
-from radiologist.registry import selector_from_flags
 
 F = TypeVar("F", bound=Callable[..., None])
-
-_SELECTOR_REQUIRED_MSG = (
-    "Provide either --model or a registry selector "
-    "(--run-id/--tags/--groups/--metric)."
-)
 
 
 def _parse_int_list(value: Optional[str]) -> Optional[List[int]]:
@@ -52,73 +44,6 @@ def _parse_int_list(value: Optional[str]) -> Optional[List[int]]:
     if value is None:
         return None
     return [int(part) for part in value.split(",")]
-
-
-def _load_predictor(
-    predictor_cls: Any,
-    model: Optional[str],
-    run_id: Optional[str],
-    tags: Optional[List[str]],
-    groups: Optional[List[str]],
-    metric: Optional[str],
-    local_dir: str,
-    mean: Optional[float] = None,
-    std: Optional[float] = None,
-    input_shape: Optional[str] = None,
-) -> Any:
-    """Dispatch to a registry selector or a local path, per predictor_cls."""
-    selector = selector_from_flags(
-        path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
-    )
-    parsed_input_shape = _parse_int_list(input_shape)
-    if selector.is_registry_backed():
-        return predictor_cls.from_selector(
-            selector,
-            local_dir=local_dir,
-            mean=mean,
-            std=std,
-            input_shape=parsed_input_shape,
-        )
-    if model is not None:
-        return predictor_cls.from_path(
-            model_path=model, mean=mean, std=std, input_shape=parsed_input_shape
-        )
-    raise ValueError(_SELECTOR_REQUIRED_MSG)
-
-
-def _load_uncertainty_predictor(
-    model: Optional[str],
-    run_id: Optional[str],
-    tags: Optional[List[str]],
-    groups: Optional[List[str]],
-    metric: Optional[str],
-    local_dir: str,
-    mcd_model: Optional[str],
-    mean: Optional[float] = None,
-    std: Optional[float] = None,
-    input_shape: Optional[str] = None,
-) -> "MCDropoutPredictor":
-    """Load det+mcd models: registry pair (run_id / {run_id}-mcd) or local paths."""
-    selector = selector_from_flags(
-        path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
-    )
-    parsed_input_shape = _parse_int_list(input_shape)
-    if selector.is_registry_backed():
-        return MCDropoutPredictor.from_selector(
-            selector,
-            local_dir=local_dir,
-            mean=mean,
-            std=std,
-            input_shape=parsed_input_shape,
-        )
-    if model is not None:
-        return MCDropoutPredictor.from_path(
-            model_path=mcd_model if mcd_model is not None else model,
-            mean=mean,
-            std=std,
-            input_shape=parsed_input_shape,
-        )
-    raise ValueError(_SELECTOR_REQUIRED_MSG)
 
 
 if _typer is not None:
@@ -166,8 +91,8 @@ if _typer is not None:
         ),
     ) -> None:
         """Run classification inference on a chest X-ray image."""
-        classifier = _load_predictor(
-            Classifier,
+        classifier = verbs.load_predictor(
+            verbs.get_verb("predict"),
             model,
             run_id,
             tags,
@@ -176,7 +101,7 @@ if _typer is not None:
             local_dir,
             mean=mean,
             std=std,
-            input_shape=input_shape,
+            input_shape=_parse_int_list(input_shape),
         )
         result = classifier.predict(image=image_path)
         typer.echo(f"Predicted class: {result.predicted_class}")
@@ -213,8 +138,8 @@ if _typer is not None:
         ),
     ) -> None:
         """Produce a Score-CAM explanation for a chest X-ray image."""
-        explainer = _load_predictor(
-            Explainer,
+        explainer = verbs.load_predictor(
+            verbs.get_verb("explain"),
             model,
             run_id,
             tags,
@@ -223,7 +148,7 @@ if _typer is not None:
             local_dir,
             mean=mean,
             std=std,
-            input_shape=input_shape,
+            input_shape=_parse_int_list(input_shape),
         )
         result = explainer.explain(image=image_path)
         typer.echo(f"Predicted class: {result.predicted_class}")
@@ -240,16 +165,13 @@ if _typer is not None:
             ..., help="Path to the input chest X-ray image."
         ),
         model: Optional[str] = typer.Option(
-            None, "--model", help="Path to the deterministic ONNX model."
+            None, "--model", help="Path to the MC-Dropout ONNX model."
         ),
         run_id: Optional[str] = typer.Option(None, "--run-id"),
         tags: Optional[List[str]] = typer.Option(None, "--tags"),
         groups: Optional[List[str]] = typer.Option(None, "--groups"),
         metric: Optional[str] = typer.Option(None, "--metric"),
         local_dir: str = typer.Option(".", "--local-dir"),
-        mcd_model: Optional[str] = typer.Option(
-            None, "--mcd-model", help="Path to the MC-Dropout ONNX model."
-        ),
         n_passes: int = typer.Option(
             30, "--n-passes", help="Number of stochastic forward passes."
         ),
@@ -266,17 +188,17 @@ if _typer is not None:
         ),
     ) -> None:
         """Estimate MC-Dropout uncertainty for a chest X-ray image."""
-        predictor = _load_uncertainty_predictor(
+        predictor = verbs.load_predictor(
+            verbs.get_verb("uncertainty"),
             model,
             run_id,
             tags,
             groups,
             metric,
             local_dir,
-            mcd_model,
             mean=mean,
             std=std,
-            input_shape=input_shape,
+            input_shape=_parse_int_list(input_shape),
         )
         result = predictor.predict_with_uncertainty(image=image_path, n_passes=n_passes)
         typer.echo("Mean probabilities:")
@@ -296,6 +218,17 @@ if _typer is not None:
         local_dir: str = typer.Option(".", "--local-dir"),
         host: str = typer.Option("127.0.0.1", "--host"),
         port: int = typer.Option(8000, "--port"),
+        predict: bool = typer.Option(
+            False, "--predict", help="Serve a Classifier (predict verb)."
+        ),
+        explain: bool = typer.Option(
+            False, "--explain", help="Serve an Explainer (explain verb, default)."
+        ),
+        uncertainty: bool = typer.Option(
+            False,
+            "--uncertainty",
+            help="Serve an MCDropoutPredictor (uncertainty verb).",
+        ),
     ) -> None:
         """Launch the FastAPI inference server via uvicorn."""
         if _uvicorn is None:
@@ -303,17 +236,25 @@ if _typer is not None:
                 "The 'serve' extra is required to use the serve command. "
                 "Install it with: pip install radiologist-inference[serve]"
             )
-        selector = selector_from_flags(
-            path=model or "", run_id=run_id, tags=tags, groups=groups, metric=metric
+        if sum([predict, explain, uncertainty]) > 1:
+            raise ValueError("Choose at most one of --predict/--explain/--uncertainty.")
+        verb_name = (
+            "predict" if predict else "uncertainty" if uncertainty else "explain"
         )
-        if selector.is_registry_backed():
-            predictor: Optional[Explainer] = Explainer.from_selector(
-                selector, local_dir=local_dir
+        has_source = model is not None or any([run_id, tags, groups, metric])
+        predictor = (
+            verbs.load_predictor(
+                verbs.get_verb(verb_name),
+                model,
+                run_id,
+                tags,
+                groups,
+                metric,
+                local_dir,
             )
-        elif model is not None:
-            predictor = Explainer.from_path(model_path=model)
-        else:
-            predictor = None
+            if has_source
+            else None
+        )
         fastapi_app = create_app(predictor)
         _uvicorn.run(fastapi_app, host=host, port=port)
 

--- a/radiologist-inference/src/radiologist/inference/cli.py
+++ b/radiologist-inference/src/radiologist/inference/cli.py
@@ -81,7 +81,7 @@ def _load_predictor(
         )
     if model is not None:
         return predictor_cls.from_path(
-            det_path=model, mean=mean, std=std, input_shape=parsed_input_shape
+            model_path=model, mean=mean, std=std, input_shape=parsed_input_shape
         )
     raise ValueError(_SELECTOR_REQUIRED_MSG)
 
@@ -113,8 +113,7 @@ def _load_uncertainty_predictor(
         )
     if model is not None:
         return MCDropoutPredictor.from_path(
-            det_path=model,
-            mcd_path=mcd_model,
+            model_path=mcd_model if mcd_model is not None else model,
             mean=mean,
             std=std,
             input_shape=parsed_input_shape,
@@ -312,7 +311,7 @@ if _typer is not None:
                 selector, local_dir=local_dir
             )
         elif model is not None:
-            predictor = Explainer.from_path(det_path=model)
+            predictor = Explainer.from_path(model_path=model)
         else:
             predictor = None
         fastapi_app = create_app(predictor)

--- a/radiologist-inference/src/radiologist/inference/explainer.py
+++ b/radiologist-inference/src/radiologist/inference/explainer.py
@@ -65,7 +65,7 @@ class Explainer(Classifier):
             pil_orig, input_shape, mean=self._state.mean, std=self._state.std
         )
 
-        session = self._state.det_session
+        session = self._state.session
         input_name = session.get_inputs()[0].name
         outputs = session.run(["logits", "feature_maps"], {input_name: preprocessed})
         logits: np.ndarray = outputs[0][0]

--- a/radiologist-inference/src/radiologist/inference/mc_dropout.py
+++ b/radiologist-inference/src/radiologist/inference/mc_dropout.py
@@ -61,15 +61,17 @@ class MCDropoutPredictor(BasePredictor):
         std: Optional[float] = None,
         input_shape: Optional[List[int]] = None,
     ) -> "MCDropoutPredictor":
-        """Resolve det + MC-Dropout ({run_id}-mcd) artifacts and load via from_path.
+        """Resolve the MC-Dropout ({run_id}-mcd) artifact and load via from_path.
 
         Args:
-            selector: Selector for the deterministic artifact. When
-                selector.run_id is set, the MC-Dropout counterpart is looked
-                up at f"{run_id}-mcd"; otherwise the same selector
-                (tags/groups/metric) is reused for both, matching today's CLI
-                fallback behavior.
-            local_dir: Local directory where both ONNX files will be saved.
+            selector: Selector for the deterministic counterpart run. When
+                selector.run_id is set, the MC-Dropout artifact is looked up
+                at f"{run_id}-mcd"; otherwise the same selector
+                (tags/groups/metric) is reused, matching today's CLI fallback
+                behavior. Only the resolved MC-Dropout artifact is loaded —
+                the single session state for an MCDropoutPredictor is the
+                stochastic model.
+            local_dir: Local directory where the ONNX file will be saved.
             registry: Registry to resolve/download from. Defaults to a single
                 shared WandbRegistry() instance when omitted.
             mean: Optional normalization mean, forwarded to from_path.
@@ -87,13 +89,12 @@ class MCDropoutPredictor(BasePredictor):
         """
         _validate_mean_std(mean, std)
         reg = registry if registry is not None else WandbRegistry()
-        det_path = _resolve_and_pull(selector, local_dir, reg)
+        _resolve_and_pull(selector, local_dir, reg)
         mcd_run_id = f"{selector.run_id}-mcd" if selector.run_id else selector.run_id
         mcd_selector = replace(selector, run_id=mcd_run_id)
         mcd_path = _resolve_and_pull(mcd_selector, local_dir, reg)
         return cls.from_path(
-            det_path=det_path,
-            mcd_path=mcd_path,
+            model_path=mcd_path,
             mean=mean,
             std=std,
             input_shape=input_shape,
@@ -104,22 +105,13 @@ class MCDropoutPredictor(BasePredictor):
         image: Union[str, "np.ndarray", "PILImage.Image"],
         n_passes: int = 30,
     ) -> UncertaintyResult:
-        """Run MC-Dropout inference and return uncertainty estimates.
-
-        Raises:
-            RuntimeError: When no stochastic (MC-Dropout) session was loaded.
-        """
-        mcd_session = self._state.mcd_session
-        if mcd_session is None:
-            raise RuntimeError(
-                "MC-Dropout inference requires mcd_path to be supplied when"
-                " loading the predictor via from_path()."
-            )
+        """Run MC-Dropout inference and return uncertainty estimates."""
+        session = self._state.session
         input_shape = self._state.model_metadata.input_shape
         arr = _preprocess_image(
             image, input_shape, mean=self._state.mean, std=self._state.std
         )
-        return mc_dropout_predict(mcd_session, arr, n_passes=n_passes)
+        return mc_dropout_predict(session, arr, n_passes=n_passes)
 
 
 def mc_dropout_predict(

--- a/radiologist-inference/src/radiologist/inference/mc_dropout.py
+++ b/radiologist-inference/src/radiologist/inference/mc_dropout.py
@@ -25,7 +25,6 @@
 from __future__ import annotations
 
 import json
-from dataclasses import replace
 from typing import TYPE_CHECKING, List, Optional, Union
 
 import numpy as np
@@ -61,16 +60,17 @@ class MCDropoutPredictor(BasePredictor):
         std: Optional[float] = None,
         input_shape: Optional[List[int]] = None,
     ) -> "MCDropoutPredictor":
-        """Resolve the MC-Dropout ({run_id}-mcd) artifact and load via from_path.
+        """Resolve the selector and load the single MC-Dropout artifact.
+
+        The caller (``radiologist.inference.verbs.load_predictor``) is
+        responsible for applying the repo-wide ``{run_id}-mcd`` naming
+        convention to ``selector`` before calling this method — this method
+        performs a single resolve/pull against whatever selector it is
+        given; the deterministic model is no longer pulled here.
 
         Args:
-            selector: Selector for the deterministic counterpart run. When
-                selector.run_id is set, the MC-Dropout artifact is looked up
-                at f"{run_id}-mcd"; otherwise the same selector
-                (tags/groups/metric) is reused, matching today's CLI fallback
-                behavior. Only the resolved MC-Dropout artifact is loaded —
-                the single session state for an MCDropoutPredictor is the
-                stochastic model.
+            selector: Selector already naming the MC-Dropout artifact to
+                resolve.
             local_dir: Local directory where the ONNX file will be saved.
             registry: Registry to resolve/download from. Defaults to a single
                 shared WandbRegistry() instance when omitted.
@@ -89,10 +89,7 @@ class MCDropoutPredictor(BasePredictor):
         """
         _validate_mean_std(mean, std)
         reg = registry if registry is not None else WandbRegistry()
-        _resolve_and_pull(selector, local_dir, reg)
-        mcd_run_id = f"{selector.run_id}-mcd" if selector.run_id else selector.run_id
-        mcd_selector = replace(selector, run_id=mcd_run_id)
-        mcd_path = _resolve_and_pull(mcd_selector, local_dir, reg)
+        mcd_path = _resolve_and_pull(selector, local_dir, reg)
         return cls.from_path(
             model_path=mcd_path,
             mean=mean,

--- a/radiologist-inference/src/radiologist/inference/mc_dropout.py
+++ b/radiologist-inference/src/radiologist/inference/mc_dropout.py
@@ -25,7 +25,7 @@
 from __future__ import annotations
 
 import json
-from typing import TYPE_CHECKING, List, Optional, Union
+from typing import List, Union
 
 import numpy as np
 import onnxruntime as ort  # type: ignore[import-untyped]
@@ -35,67 +35,20 @@ from radiologist.inference.base_predictor import (
     BasePredictor,
     _preprocess_image,
     _read_metadata,
-    _resolve_and_pull,
     _softmax,
-    _validate_mean_std,
 )
 from radiologist.inference.models import UncertaintyResult
-from radiologist.registry.wandb_registry import WandbRegistry
-
-if TYPE_CHECKING:
-    from radiologist.registry.interface import ModelRegistry
-    from radiologist.registry.selector import RegistrySelector
 
 
 class MCDropoutPredictor(BasePredictor):
-    """Adds MC-Dropout uncertainty estimation to BasePredictor."""
+    """Adds MC-Dropout uncertainty estimation to BasePredictor.
 
-    @classmethod
-    def from_selector(
-        cls,
-        selector: "RegistrySelector",
-        local_dir: str,
-        registry: Optional["ModelRegistry"] = None,
-        mean: Optional[float] = None,
-        std: Optional[float] = None,
-        input_shape: Optional[List[int]] = None,
-    ) -> "MCDropoutPredictor":
-        """Resolve the selector and load the single MC-Dropout artifact.
-
-        The caller (``radiologist.inference.verbs.load_predictor``) is
-        responsible for applying the repo-wide ``{run_id}-mcd`` naming
-        convention to ``selector`` before calling this method — this method
-        performs a single resolve/pull against whatever selector it is
-        given; the deterministic model is no longer pulled here.
-
-        Args:
-            selector: Selector already naming the MC-Dropout artifact to
-                resolve.
-            local_dir: Local directory where the ONNX file will be saved.
-            registry: Registry to resolve/download from. Defaults to a single
-                shared WandbRegistry() instance when omitted.
-            mean: Optional normalization mean, forwarded to from_path.
-            std: Optional normalization std, forwarded to from_path.
-            input_shape: Optional input_shape fallback, forwarded to
-                from_path.
-
-        Returns:
-            Loaded MCDropoutPredictor instance.
-
-        Raises:
-            RuntimeError: When the ``registry`` extra (wandb) is not
-                installed.
-            ValueError: If exactly one of mean/std is provided.
-        """
-        _validate_mean_std(mean, std)
-        reg = registry if registry is not None else WandbRegistry()
-        mcd_path = _resolve_and_pull(selector, local_dir, reg)
-        return cls.from_path(
-            model_path=mcd_path,
-            mean=mean,
-            std=std,
-            input_shape=input_shape,
-        )
+    Inherits ``BasePredictor.from_selector`` unchanged: the caller
+    (``radiologist.inference.verbs.load_predictor``) is responsible for
+    applying the repo-wide ``{run_id}-mcd`` naming convention to the
+    selector before calling ``from_selector`` — the base implementation
+    performs a single resolve/pull against whatever selector it is given.
+    """
 
     def predict_with_uncertainty(
         self,

--- a/radiologist-inference/src/radiologist/inference/models.py
+++ b/radiologist-inference/src/radiologist/inference/models.py
@@ -62,4 +62,3 @@ class ModelMetadata:
     input_shape: List[int]
     cam_target_layer: str
     output_names: List[str]
-    mc_dropout: bool

--- a/radiologist-inference/src/radiologist/inference/verbs.py
+++ b/radiologist-inference/src/radiologist/inference/verbs.py
@@ -81,6 +81,9 @@ def load_predictor(
     groups: Optional[List[str]],
     metric: Optional[str],
     local_dir: str,
+    mean: Optional[float] = None,
+    std: Optional[float] = None,
+    input_shape: Optional[List[int]] = None,
 ) -> BasePredictor:
     """Single loading path for every verb.
 
@@ -89,7 +92,9 @@ def load_predictor(
     path, ``verb.predictor_cls.from_path(model_path=model)``; else raises
     ``ValueError`` naming ``--model`` and the registry selector flags. When
     ``verb.mcd_convention`` is ``True``, ``run_id`` is rewritten via
-    ``apply_mcd_convention`` before building the selector.
+    ``apply_mcd_convention`` before building the selector. ``mean``/``std``/
+    ``input_shape`` are forwarded unchanged to the predictor's
+    ``from_selector``/``from_path`` constructor for preprocessing overrides.
     """
     effective_run_id = apply_mcd_convention(run_id) if verb.mcd_convention else run_id
     selector = selector_from_flags(
@@ -100,7 +105,15 @@ def load_predictor(
         metric=metric,
     )
     if selector.is_registry_backed():
-        return verb.predictor_cls.from_selector(selector, local_dir=local_dir)
+        return verb.predictor_cls.from_selector(
+            selector,
+            local_dir=local_dir,
+            mean=mean,
+            std=std,
+            input_shape=input_shape,
+        )
     if model is not None:
-        return verb.predictor_cls.from_path(model_path=model)
+        return verb.predictor_cls.from_path(
+            model_path=model, mean=mean, std=std, input_shape=input_shape
+        )
     raise ValueError(_SELECTOR_REQUIRED_MSG)

--- a/radiologist-inference/src/radiologist/inference/verbs.py
+++ b/radiologist-inference/src/radiologist/inference/verbs.py
@@ -1,0 +1,75 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+from dataclasses import dataclass
+from typing import List, Optional, Type
+
+from radiologist.inference.base_predictor import BasePredictor
+
+
+@dataclass(frozen=True)
+class PredictorVerb:
+    """Immutable descriptor binding a CLI verb name to the predictor class it
+    constructs and whether registry resolution applies the ``{run_id}-mcd``
+    convention."""
+
+    name: str
+    predictor_cls: Type[BasePredictor]
+    mcd_convention: bool
+
+
+def get_verb(name: str) -> PredictorVerb:
+    """Return the registered ``PredictorVerb`` for ``name``.
+
+    Raises ``KeyError`` for an unknown name.
+    """
+    raise NotImplementedError
+
+
+def apply_mcd_convention(run_id: Optional[str]) -> Optional[str]:
+    """Return ``f"{run_id}-mcd"`` when ``run_id`` is truthy, else ``None``.
+
+    Encodes the repo-wide det/mcd registry pairing used by the uncertainty
+    verb.
+    """
+    raise NotImplementedError
+
+
+def load_predictor(
+    verb: PredictorVerb,
+    model: Optional[str],
+    run_id: Optional[str],
+    tags: Optional[List[str]],
+    groups: Optional[List[str]],
+    metric: Optional[str],
+    local_dir: str,
+) -> BasePredictor:
+    """Single loading path for every verb.
+
+    When the (verb-adjusted) flags are registry-backed, resolves via
+    ``verb.predictor_cls.from_selector(...)``; else when ``model`` is a local
+    path, ``verb.predictor_cls.from_path(model_path=model)``; else raises
+    ``ValueError`` naming ``--model`` and the registry selector flags. When
+    ``verb.mcd_convention`` is ``True``, ``run_id`` is rewritten via
+    ``apply_mcd_convention`` before building the selector.
+    """
+    raise NotImplementedError

--- a/radiologist-inference/src/radiologist/inference/verbs.py
+++ b/radiologist-inference/src/radiologist/inference/verbs.py
@@ -21,9 +21,18 @@
 # SOFTWARE.
 
 from dataclasses import dataclass
-from typing import List, Optional, Type
+from typing import Dict, List, Optional, Type
 
 from radiologist.inference.base_predictor import BasePredictor
+from radiologist.inference.classifier import Classifier
+from radiologist.inference.explainer import Explainer
+from radiologist.inference.mc_dropout import MCDropoutPredictor
+from radiologist.registry import selector_from_flags
+
+_SELECTOR_REQUIRED_MSG = (
+    "Provide either --model or a registry selector "
+    "(--run-id/--tags/--groups/--metric)."
+)
 
 
 @dataclass(frozen=True)
@@ -37,12 +46,22 @@ class PredictorVerb:
     mcd_convention: bool
 
 
+_VERBS: Dict[str, PredictorVerb] = {
+    v.name: v
+    for v in (
+        PredictorVerb("predict", Classifier, False),
+        PredictorVerb("explain", Explainer, False),
+        PredictorVerb("uncertainty", MCDropoutPredictor, True),
+    )
+}
+
+
 def get_verb(name: str) -> PredictorVerb:
     """Return the registered ``PredictorVerb`` for ``name``.
 
     Raises ``KeyError`` for an unknown name.
     """
-    raise NotImplementedError
+    return _VERBS[name]
 
 
 def apply_mcd_convention(run_id: Optional[str]) -> Optional[str]:
@@ -51,7 +70,7 @@ def apply_mcd_convention(run_id: Optional[str]) -> Optional[str]:
     Encodes the repo-wide det/mcd registry pairing used by the uncertainty
     verb.
     """
-    raise NotImplementedError
+    return f"{run_id}-mcd" if run_id else None
 
 
 def load_predictor(
@@ -72,4 +91,16 @@ def load_predictor(
     ``verb.mcd_convention`` is ``True``, ``run_id`` is rewritten via
     ``apply_mcd_convention`` before building the selector.
     """
-    raise NotImplementedError
+    effective_run_id = apply_mcd_convention(run_id) if verb.mcd_convention else run_id
+    selector = selector_from_flags(
+        path=model or "",
+        run_id=effective_run_id,
+        tags=tags,
+        groups=groups,
+        metric=metric,
+    )
+    if selector.is_registry_backed():
+        return verb.predictor_cls.from_selector(selector, local_dir=local_dir)
+    if model is not None:
+        return verb.predictor_cls.from_path(model_path=model)
+    raise ValueError(_SELECTOR_REQUIRED_MSG)

--- a/radiologist-inference/src/radiologist/inference/verbs.py
+++ b/radiologist-inference/src/radiologist/inference/verbs.py
@@ -20,6 +20,8 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+"""Predictor-verb registry binding CLI verb names to predictor classes."""
+
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Type
 
@@ -59,16 +61,27 @@ _VERBS: Dict[str, PredictorVerb] = {
 def get_verb(name: str) -> PredictorVerb:
     """Return the registered ``PredictorVerb`` for ``name``.
 
-    Raises ``KeyError`` for an unknown name.
+    Args:
+        name: Verb name to look up (e.g. ``"predict"``, ``"explain"``,
+            ``"uncertainty"``).
+
+    Returns:
+        The registered ``PredictorVerb`` for ``name``.
+
+    Raises:
+        KeyError: If ``name`` is not a registered verb.
     """
     return _VERBS[name]
 
 
 def apply_mcd_convention(run_id: Optional[str]) -> Optional[str]:
-    """Return ``f"{run_id}-mcd"`` when ``run_id`` is truthy, else ``None``.
+    """Encode the repo-wide det/mcd registry naming convention.
 
-    Encodes the repo-wide det/mcd registry pairing used by the uncertainty
-    verb.
+    Args:
+        run_id: Deterministic model's run id, or ``None``.
+
+    Returns:
+        ``f"{run_id}-mcd"`` when ``run_id`` is truthy, else ``None``.
     """
     return f"{run_id}-mcd" if run_id else None
 
@@ -92,9 +105,33 @@ def load_predictor(
     path, ``verb.predictor_cls.from_path(model_path=model)``; else raises
     ``ValueError`` naming ``--model`` and the registry selector flags. When
     ``verb.mcd_convention`` is ``True``, ``run_id`` is rewritten via
-    ``apply_mcd_convention`` before building the selector. ``mean``/``std``/
-    ``input_shape`` are forwarded unchanged to the predictor's
-    ``from_selector``/``from_path`` constructor for preprocessing overrides.
+    ``apply_mcd_convention`` before building the selector.
+
+    Args:
+        verb: Registered verb descriptor naming the predictor class to
+            construct and whether the ``{run_id}-mcd`` convention applies.
+        model: Local ONNX file path. Mutually exclusive with the registry
+            selector flags (``run_id``/``tags``/``groups``/``metric``).
+        run_id: Registry selector run id. Rewritten via
+            ``apply_mcd_convention`` when ``verb.mcd_convention`` is ``True``.
+        tags: Registry selector tags.
+        groups: Registry selector groups.
+        metric: Registry selector metric name.
+        local_dir: Local directory where a registry-resolved ONNX file will
+            be saved.
+        mean: Optional normalization mean, forwarded unchanged to the
+            predictor's ``from_selector``/``from_path`` constructor.
+        std: Optional normalization std, forwarded unchanged to the
+            predictor's ``from_selector``/``from_path`` constructor.
+        input_shape: Optional input_shape fallback, forwarded unchanged to
+            the predictor's ``from_selector``/``from_path`` constructor.
+
+    Returns:
+        Loaded predictor instance of ``verb.predictor_cls``.
+
+    Raises:
+        ValueError: If neither ``model`` nor a registry selector flag
+            (``run_id``/``tags``/``groups``/``metric``) is provided.
     """
     effective_run_id = apply_mcd_convention(run_id) if verb.mcd_convention else run_id
     selector = selector_from_flags(

--- a/radiologist-inference/tests/conftest.py
+++ b/radiologist-inference/tests/conftest.py
@@ -47,20 +47,11 @@ def mcd_onnx_path(tmp_path):
 
 
 @pytest.fixture()
-def predictor_with_mcd(tmp_path):
+def predictor(tmp_path):
     from radiologist.inference.mc_dropout import MCDropoutPredictor
 
-    det = build_det_onnx(tmp_path, filename="det.onnx")
     mcd = build_mcd_onnx(tmp_path, filename="mcd.onnx")
-    return MCDropoutPredictor.from_path(det_path=det, mcd_path=mcd)
-
-
-@pytest.fixture()
-def predictor_without_mcd(tmp_path):
-    from radiologist.inference.mc_dropout import MCDropoutPredictor
-
-    det = build_det_onnx(tmp_path, filename="det_only.onnx")
-    return MCDropoutPredictor.from_path(det_path=det)
+    return MCDropoutPredictor.from_path(model_path=mcd)
 
 
 @pytest.fixture()

--- a/radiologist-inference/tests/test_app.py
+++ b/radiologist-inference/tests/test_app.py
@@ -45,20 +45,19 @@ def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
 @pytest.fixture()
 def classifier(tmp_path) -> Classifier:
     det_path = build_det_onnx(tmp_path, filename="det.onnx")
-    return Classifier.from_path(det_path=det_path)
+    return Classifier.from_path(model_path=det_path)
 
 
 @pytest.fixture()
 def explainer(tmp_path) -> Explainer:
     det_path = build_det_onnx(tmp_path, filename="det.onnx")
-    return Explainer.from_path(det_path=det_path)
+    return Explainer.from_path(model_path=det_path)
 
 
 @pytest.fixture()
 def mcd_predictor(tmp_path) -> MCDropoutPredictor:
-    det_path = build_det_onnx(tmp_path, filename="det.onnx")
     mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
-    return MCDropoutPredictor.from_path(det_path=det_path, mcd_path=mcd_path)
+    return MCDropoutPredictor.from_path(model_path=mcd_path)
 
 
 # ---------------------------------------------------------------------------

--- a/radiologist-inference/tests/test_classifier.py
+++ b/radiologist-inference/tests/test_classifier.py
@@ -85,16 +85,35 @@ class _FakeSelectorRegistry:
 class TestClassifierFromPath:
     def test_from_path_returns_classifier_instance(self, det_onnx_path):
         """from_path called on Classifier must return a Classifier instance."""
-        classifier = Classifier.from_path(det_path=det_onnx_path)
+        classifier = Classifier.from_path(model_path=det_onnx_path)
         assert isinstance(classifier, Classifier)
         assert isinstance(classifier, BasePredictor)
+
+    def test_from_path_missing_file_raises_file_not_found_error(self, tmp_path):
+        """Loading from a path that does not exist must raise FileNotFoundError."""
+        missing_path = str(tmp_path / "does_not_exist.onnx")
+        with pytest.raises(FileNotFoundError):
+            Classifier.from_path(model_path=missing_path)
+
+    def test_from_path_constructs_exactly_one_onnx_session(self, det_onnx_path):
+        """Loading any predictor from a valid path must construct exactly one
+        ONNX session, regardless of predictor type (spy on the true process
+        boundary: onnxruntime.InferenceSession)."""
+        import onnxruntime as ort
+
+        with patch(
+            "radiologist.inference.base_predictor.ort.InferenceSession",
+            wraps=ort.InferenceSession,
+        ) as spy:
+            Classifier.from_path(model_path=det_onnx_path)
+            assert spy.call_count == 1
 
 
 class TestClassifierPredict:
     def test_predict_returns_prediction_with_class_keys_and_argmax(self, det_onnx_path):
         """predict must return a Prediction whose probability keys equal the
         model classes and whose predicted_class is the argmax."""
-        classifier = Classifier.from_path(det_path=det_onnx_path)
+        classifier = Classifier.from_path(model_path=det_onnx_path)
 
         image = np.zeros((224, 224, 3), dtype=np.uint8)
         result = classifier.predict(image=image)
@@ -112,7 +131,7 @@ class TestClassifierDeploymentPrior:
     ):
         """Supplying deployment_prior must change probabilities while the
         result still sums to ~1."""
-        classifier = Classifier.from_path(det_path=det_onnx_path)
+        classifier = Classifier.from_path(model_path=det_onnx_path)
         image = np.zeros((224, 224, 3), dtype=np.uint8)
 
         no_prior = classifier.predict(image=image)
@@ -136,10 +155,12 @@ class TestClassifierEmbeddedPrior:
         onnx_no_prior = build_det_onnx(tmp_path, priors=None, filename="no_prior.onnx")
         image = np.zeros((224, 224, 3), dtype=np.uint8)
 
-        with_embedded = Classifier.from_path(det_path=onnx_with_prior).predict(
+        with_embedded = Classifier.from_path(model_path=onnx_with_prior).predict(
             image=image
         )
-        no_embedded = Classifier.from_path(det_path=onnx_no_prior).predict(image=image)
+        no_embedded = Classifier.from_path(model_path=onnx_no_prior).predict(
+            image=image
+        )
 
         assert with_embedded.probabilities != no_embedded.probabilities
 
@@ -157,7 +178,7 @@ class TestClassifierFromRegistry:
             local_dir=str(tmp_path),
             registry=fake_registry,
         )
-        path_classifier = Classifier.from_path(det_path=det_onnx_path)
+        path_classifier = Classifier.from_path(model_path=det_onnx_path)
 
         image = np.zeros((224, 224, 3), dtype=np.uint8)
         registry_result = registry_classifier.predict(image=image)
@@ -205,9 +226,9 @@ class TestClassifierMeanStdNormalization:
         default /255.0-only normalization."""
         image = np.zeros((224, 224, 3), dtype=np.uint8)
 
-        default_classifier = Classifier.from_path(det_path=det_onnx_path)
+        default_classifier = Classifier.from_path(model_path=det_onnx_path)
         normalized_classifier = Classifier.from_path(
-            det_path=det_onnx_path, mean=128.0, std=65.0
+            model_path=det_onnx_path, mean=128.0, std=65.0
         )
 
         default_result = default_classifier.predict(image=image)
@@ -220,14 +241,14 @@ class TestClassifierMeanStdNormalization:
         from_path, before any prediction is requested (fail-fast, bugfix
         review finding on PR #131)."""
         with pytest.raises(ValueError, match="mean and std"):
-            Classifier.from_path(det_path=det_onnx_path, mean=128.0)
+            Classifier.from_path(model_path=det_onnx_path, mean=128.0)
 
     def test_from_path_with_only_std_raises_value_error(self, det_onnx_path):
         """Supplying std without mean must raise ValueError eagerly at
         from_path, before any prediction is requested (fail-fast, bugfix
         review finding on PR #131)."""
         with pytest.raises(ValueError, match="mean and std"):
-            Classifier.from_path(det_path=det_onnx_path, std=65.0)
+            Classifier.from_path(model_path=det_onnx_path, std=65.0)
 
 
 class TestFromPathInputShapeFallback:
@@ -239,7 +260,7 @@ class TestFromPathInputShapeFallback:
         )
 
         with pytest.raises(ValueError, match="input_shape"):
-            Classifier.from_path(det_path=det_path)
+            Classifier.from_path(model_path=det_path)
 
     def test_from_path_without_input_shape_metadata_succeeds_with_default(
         self, tmp_path
@@ -250,7 +271,7 @@ class TestFromPathInputShapeFallback:
         )
 
         classifier = Classifier.from_path(
-            det_path=det_path, input_shape=[1, 3, 224, 224]
+            model_path=det_path, input_shape=[1, 3, 224, 224]
         )
         image = np.zeros((224, 224, 3), dtype=np.uint8)
         result = classifier.predict(image=image)
@@ -271,7 +292,7 @@ class TestClassifierFromSelector:
         classifier = Classifier.from_selector(
             selector, local_dir=str(tmp_path), registry=fake_registry
         )
-        path_classifier = Classifier.from_path(det_path=det_onnx_path)
+        path_classifier = Classifier.from_path(model_path=det_onnx_path)
 
         image = np.zeros((224, 224, 3), dtype=np.uint8)
         selector_result = classifier.predict(image=image)
@@ -316,9 +337,9 @@ class TestClassifierFromSelector:
             std=65.0,
         )
         path_classifier = Classifier.from_path(
-            det_path=det_onnx_path, mean=128.0, std=65.0
+            model_path=det_onnx_path, mean=128.0, std=65.0
         )
-        default_classifier = Classifier.from_path(det_path=det_onnx_path)
+        default_classifier = Classifier.from_path(model_path=det_onnx_path)
 
         image = np.zeros((224, 224, 3), dtype=np.uint8)
         selector_result = selector_classifier.predict(image=image)

--- a/radiologist-inference/tests/test_cli.py
+++ b/radiologist-inference/tests/test_cli.py
@@ -32,6 +32,7 @@ from unittest.mock import MagicMock, patch
 import numpy as np
 import pytest
 from _helpers import build_det_onnx, build_mcd_onnx
+from fastapi.testclient import TestClient
 from PIL import Image as PILImage
 from typer.testing import CliRunner
 
@@ -496,30 +497,44 @@ class TestServeCommand:
         assert "serve" in result.output
 
     def test_serve_with_predict_flag_serves_a_classifier(self, tmp_path):
+        """--predict must wire a Classifier into the served app: /predict
+        works and /explain, /uncertainty are absent (mirrors test_app.py's
+        TestClassifierApp, driven end-to-end through the serve command)."""
         det_path = build_det_onnx(tmp_path, filename="det.onnx")
         import radiologist.inference.cli as cli_mod
-        from radiologist.inference import Classifier
 
         mock_uvicorn = MagicMock()
         with patch.object(cli_mod, "_uvicorn", mock_uvicorn):
-            with patch.object(cli_mod, "create_app") as mock_create_app:
-                mock_create_app.return_value = MagicMock()
-                result = runner.invoke(app, ["serve", "--predict", "--model", det_path])
+            result = runner.invoke(app, ["serve", "--predict", "--model", det_path])
 
         assert result.exit_code == 0, result.output
         mock_uvicorn.run.assert_called_once()
-        (predictor,), _ = mock_create_app.call_args
-        assert isinstance(predictor, Classifier)
+        (fastapi_app,), _ = mock_uvicorn.run.call_args
+        client = TestClient(fastapi_app)
+        image_path = _make_png_path(tmp_path)
+        with open(image_path, "rb") as f:
+            predict_response = client.post(
+                "/predict", files={"image": ("input.png", f, "image/png")}
+            )
+        assert predict_response.status_code == 200
+        with open(image_path, "rb") as f:
+            explain_response = client.post(
+                "/explain", files={"image": ("input.png", f, "image/png")}
+            )
+        assert explain_response.status_code == 404
 
     def test_serve_with_uncertainty_and_run_id_resolves_via_mcd_convention(
         self, tmp_path
     ):
+        """--uncertainty --run-id must wire an MCDropoutPredictor into the
+        served app via the {run_id}-mcd convention: /uncertainty works and
+        /predict is absent (mirrors test_app.py's TestMCDropoutApp, driven
+        end-to-end through the serve command)."""
         mcd_dir = tmp_path / "mcd"
         mcd_dir.mkdir()
         build_mcd_onnx(mcd_dir, filename="mcd.onnx")
 
         import radiologist.inference.cli as cli_mod
-        from radiologist.inference import MCDropoutPredictor
 
         mock_wandb, pulled_art = _make_registry_wandb_mock()
         pulled_art.download.return_value = str(mcd_dir)
@@ -529,25 +544,34 @@ class TestServeCommand:
         mock_uvicorn = MagicMock()
         with patch.object(resolver_mod, "_wandb", mock_wandb):
             with patch.object(cli_mod, "_uvicorn", mock_uvicorn):
-                with patch.object(cli_mod, "create_app") as mock_create_app:
-                    mock_create_app.return_value = MagicMock()
-                    result = runner.invoke(
-                        app,
-                        [
-                            "serve",
-                            "--uncertainty",
-                            "--run-id",
-                            "run1",
-                            "--local-dir",
-                            str(tmp_path),
-                        ],
-                    )
+                result = runner.invoke(
+                    app,
+                    [
+                        "serve",
+                        "--uncertainty",
+                        "--run-id",
+                        "run1",
+                        "--local-dir",
+                        str(tmp_path),
+                    ],
+                )
 
         assert result.exit_code == 0, result.output
         mock_uvicorn.run.assert_called_once()
-        (predictor,), _ = mock_create_app.call_args
-        assert isinstance(predictor, MCDropoutPredictor)
         assert pulled_art.download.call_count == 1
+        (fastapi_app,), _ = mock_uvicorn.run.call_args
+        client = TestClient(fastapi_app)
+        image_path = _make_png_path(tmp_path)
+        with open(image_path, "rb") as f:
+            uncertainty_response = client.post(
+                "/uncertainty", files={"image": ("input.png", f, "image/png")}
+            )
+        assert uncertainty_response.status_code == 200
+        with open(image_path, "rb") as f:
+            predict_response = client.post(
+                "/predict", files={"image": ("input.png", f, "image/png")}
+            )
+        assert predict_response.status_code == 404
 
     def test_serve_with_two_verb_flags_exits_nonzero(self, tmp_path):
         det_path = build_det_onnx(tmp_path, filename="det.onnx")
@@ -562,15 +586,23 @@ class TestServeCommand:
         assert result.exit_code != 0
 
     def test_serve_with_no_source_starts_with_no_predictor(self, tmp_path):
+        """No --model/registry selector must start the app with no predictor
+        injected: every predictor route 503s (mirrors test_app.py's
+        TestNoPredictorInjected, driven end-to-end through the serve
+        command)."""
         import radiologist.inference.cli as cli_mod
 
         mock_uvicorn = MagicMock()
         with patch.object(cli_mod, "_uvicorn", mock_uvicorn):
-            with patch.object(cli_mod, "create_app") as mock_create_app:
-                mock_create_app.return_value = MagicMock()
-                result = runner.invoke(app, ["serve"])
+            result = runner.invoke(app, ["serve"])
 
         assert result.exit_code == 0, result.output
         mock_uvicorn.run.assert_called_once()
-        (predictor,), _ = mock_create_app.call_args
-        assert predictor is None
+        (fastapi_app,), _ = mock_uvicorn.run.call_args
+        client = TestClient(fastapi_app)
+        image_path = _make_png_path(tmp_path)
+        with open(image_path, "rb") as f:
+            predict_response = client.post(
+                "/predict", files={"image": ("input.png", f, "image/png")}
+            )
+        assert predict_response.status_code == 503

--- a/radiologist-inference/tests/test_cli.py
+++ b/radiologist-inference/tests/test_cli.py
@@ -197,7 +197,6 @@ class TestExplainCommandNormalizationFlags:
 
 class TestUncertaintyCommand:
     def test_uncertainty_exits_0_and_prints_stats(self, tmp_path):
-        det_path = build_det_onnx(tmp_path, filename="det.onnx")
         mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
         image_path = _make_png_path(tmp_path)
 
@@ -207,8 +206,6 @@ class TestUncertaintyCommand:
                 "uncertainty",
                 image_path,
                 "--model",
-                det_path,
-                "--mcd-model",
                 mcd_path,
                 "--n-passes",
                 "5",
@@ -218,10 +215,7 @@ class TestUncertaintyCommand:
         assert result.exit_code == 0
         assert "entropy" in result.output.lower()
 
-
-class TestUncertaintyCommandNormalizationFlags:
-    def test_uncertainty_with_mean_std_input_shape_accepted(self, tmp_path):
-        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+    def test_uncertainty_exposes_no_mcd_model_option(self, tmp_path):
         mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
         image_path = _make_png_path(tmp_path)
 
@@ -231,8 +225,29 @@ class TestUncertaintyCommandNormalizationFlags:
                 "uncertainty",
                 image_path,
                 "--model",
-                det_path,
+                mcd_path,
                 "--mcd-model",
+                mcd_path,
+            ],
+        )
+
+        assert result.exit_code != 0
+        assert "--mcd-model" in result.output or "no such option" in (
+            result.output.lower()
+        )
+
+
+class TestUncertaintyCommandNormalizationFlags:
+    def test_uncertainty_with_mean_std_input_shape_accepted(self, tmp_path):
+        mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
+        image_path = _make_png_path(tmp_path)
+
+        result = runner.invoke(
+            app,
+            [
+                "uncertainty",
+                image_path,
+                "--model",
                 mcd_path,
                 "--n-passes",
                 "5",
@@ -396,17 +411,17 @@ class TestRegistrySelectorDispatch:
 
         assert result.exit_code != 0
 
-    def test_uncertainty_with_run_id_resolves_det_and_mcd_models(self, tmp_path):
-        det_dir = tmp_path / "det"
+    def test_uncertainty_with_run_id_resolves_mcd_model_via_convention(self, tmp_path):
+        """uncertainty --run-id must resolve a single model via the
+        ``{run_id}-mcd`` convention — exactly one registry pull, no
+        deterministic-model pull (bugfix landed in the verb registry, #142)."""
         mcd_dir = tmp_path / "mcd"
-        det_dir.mkdir()
         mcd_dir.mkdir()
-        build_det_onnx(det_dir, filename="det.onnx")
         build_mcd_onnx(mcd_dir, filename="mcd.onnx")
         image_path = _make_png_path(tmp_path)
 
         mock_wandb, pulled_art = _make_registry_wandb_mock()
-        pulled_art.download.side_effect = [str(det_dir), str(mcd_dir)]
+        pulled_art.download.return_value = str(mcd_dir)
 
         import radiologist.registry.resolver as resolver_mod
 
@@ -427,6 +442,7 @@ class TestRegistrySelectorDispatch:
 
         assert result.exit_code == 0, result.output
         assert "entropy" in result.output.lower()
+        assert pulled_art.download.call_count == 1
 
     def test_predict_with_run_id_fails_naming_inference_extra_when_wandb_absent(
         self, tmp_path
@@ -478,3 +494,83 @@ class TestServeCommand:
 
         assert result.exit_code != 0
         assert "serve" in result.output
+
+    def test_serve_with_predict_flag_serves_a_classifier(self, tmp_path):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        import radiologist.inference.cli as cli_mod
+        from radiologist.inference import Classifier
+
+        mock_uvicorn = MagicMock()
+        with patch.object(cli_mod, "_uvicorn", mock_uvicorn):
+            with patch.object(cli_mod, "create_app") as mock_create_app:
+                mock_create_app.return_value = MagicMock()
+                result = runner.invoke(app, ["serve", "--predict", "--model", det_path])
+
+        assert result.exit_code == 0, result.output
+        mock_uvicorn.run.assert_called_once()
+        (predictor,), _ = mock_create_app.call_args
+        assert isinstance(predictor, Classifier)
+
+    def test_serve_with_uncertainty_and_run_id_resolves_via_mcd_convention(
+        self, tmp_path
+    ):
+        mcd_dir = tmp_path / "mcd"
+        mcd_dir.mkdir()
+        build_mcd_onnx(mcd_dir, filename="mcd.onnx")
+
+        import radiologist.inference.cli as cli_mod
+        from radiologist.inference import MCDropoutPredictor
+
+        mock_wandb, pulled_art = _make_registry_wandb_mock()
+        pulled_art.download.return_value = str(mcd_dir)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        mock_uvicorn = MagicMock()
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            with patch.object(cli_mod, "_uvicorn", mock_uvicorn):
+                with patch.object(cli_mod, "create_app") as mock_create_app:
+                    mock_create_app.return_value = MagicMock()
+                    result = runner.invoke(
+                        app,
+                        [
+                            "serve",
+                            "--uncertainty",
+                            "--run-id",
+                            "run1",
+                            "--local-dir",
+                            str(tmp_path),
+                        ],
+                    )
+
+        assert result.exit_code == 0, result.output
+        mock_uvicorn.run.assert_called_once()
+        (predictor,), _ = mock_create_app.call_args
+        assert isinstance(predictor, MCDropoutPredictor)
+        assert pulled_art.download.call_count == 1
+
+    def test_serve_with_two_verb_flags_exits_nonzero(self, tmp_path):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        import radiologist.inference.cli as cli_mod
+
+        mock_uvicorn = MagicMock()
+        with patch.object(cli_mod, "_uvicorn", mock_uvicorn):
+            result = runner.invoke(
+                app, ["serve", "--predict", "--explain", "--model", det_path]
+            )
+
+        assert result.exit_code != 0
+
+    def test_serve_with_no_source_starts_with_no_predictor(self, tmp_path):
+        import radiologist.inference.cli as cli_mod
+
+        mock_uvicorn = MagicMock()
+        with patch.object(cli_mod, "_uvicorn", mock_uvicorn):
+            with patch.object(cli_mod, "create_app") as mock_create_app:
+                mock_create_app.return_value = MagicMock()
+                result = runner.invoke(app, ["serve"])
+
+        assert result.exit_code == 0, result.output
+        mock_uvicorn.run.assert_called_once()
+        (predictor,), _ = mock_create_app.call_args
+        assert predictor is None

--- a/radiologist-inference/tests/test_explainer.py
+++ b/radiologist-inference/tests/test_explainer.py
@@ -39,7 +39,7 @@ CLASSES = ["NORMAL", "ABNORMAL"]
 class TestExplainerFromPath:
     def test_from_path_returns_explainer_instance(self, det_onnx_path_nonzero):
         """from_path called on Explainer must return an Explainer instance."""
-        explainer = Explainer.from_path(det_path=det_onnx_path_nonzero)
+        explainer = Explainer.from_path(model_path=det_onnx_path_nonzero)
         assert isinstance(explainer, Explainer)
         assert isinstance(explainer, Classifier)
 
@@ -47,7 +47,7 @@ class TestExplainerFromPath:
 class TestExplainSpatialDimensions:
     def test_saliency_map_matches_input_image_spatial_dims(self, det_onnx_path_nonzero):
         """saliency_map must have H x W dimensions matching the original image."""
-        explainer = Explainer.from_path(det_path=det_onnx_path_nonzero)
+        explainer = Explainer.from_path(model_path=det_onnx_path_nonzero)
 
         h, w = 128, 96
         image = np.zeros((h, w, 3), dtype=np.uint8)
@@ -57,7 +57,7 @@ class TestExplainSpatialDimensions:
 
     def test_saliency_map_matches_pil_image_spatial_dims(self, det_onnx_path_nonzero):
         """saliency_map dims must match a PIL Image input, not the model input shape."""
-        explainer = Explainer.from_path(det_path=det_onnx_path_nonzero)
+        explainer = Explainer.from_path(model_path=det_onnx_path_nonzero)
 
         h, w = 200, 150
         pil_img = PILImage.fromarray(np.zeros((h, w, 3), dtype=np.uint8), mode="RGB")
@@ -68,7 +68,7 @@ class TestExplainSpatialDimensions:
 class TestExplainPredictedClass:
     def test_explain_predicted_class_matches_predict(self, det_onnx_path_nonzero):
         """Explanation.predicted_class must agree with predict() for the same image."""
-        explainer = Explainer.from_path(det_path=det_onnx_path_nonzero)
+        explainer = Explainer.from_path(model_path=det_onnx_path_nonzero)
         image = np.zeros((224, 224, 3), dtype=np.uint8)
 
         explanation = explainer.explain(image=image)
@@ -86,7 +86,9 @@ class TestExplainRespectsEmbeddedPrior:
         raw_path = build_det_onnx(tmp_path, priors=None, filename="raw.onnx")
         image = np.zeros((224, 224, 3), dtype=np.uint8)
         raw_predicted = (
-            Classifier.from_path(det_path=raw_path).predict(image=image).predicted_class
+            Classifier.from_path(model_path=raw_path)
+            .predict(image=image)
+            .predicted_class
         )
         other_class = next(c for c in CLASSES if c != raw_predicted)
 
@@ -95,7 +97,7 @@ class TestExplainRespectsEmbeddedPrior:
             priors={raw_predicted: 0.01, other_class: 0.99},
             filename="skewed.onnx",
         )
-        explainer = Explainer.from_path(det_path=skewed_path)
+        explainer = Explainer.from_path(model_path=skewed_path)
 
         explanation = explainer.explain(image=image)
         prediction = explainer.predict(image=image)
@@ -107,7 +109,7 @@ class TestExplainRespectsEmbeddedPrior:
 class TestExplainSaliencyValues:
     def test_all_saliency_values_in_0_1(self, det_onnx_path_nonzero):
         """Every value in saliency_map must lie in [0, 1]."""
-        explainer = Explainer.from_path(det_path=det_onnx_path_nonzero)
+        explainer = Explainer.from_path(model_path=det_onnx_path_nonzero)
         image = np.zeros((224, 224, 3), dtype=np.uint8)
 
         result = explainer.explain(image=image)
@@ -119,7 +121,7 @@ class TestExplainSaliencyValues:
 class TestExplainerInheritsPredict:
     def test_explainer_also_serves_predict(self, det_onnx_path_nonzero):
         """An Explainer instance must also answer predict() and return a Prediction."""
-        explainer = Explainer.from_path(det_path=det_onnx_path_nonzero)
+        explainer = Explainer.from_path(model_path=det_onnx_path_nonzero)
         image = np.zeros((224, 224, 3), dtype=np.uint8)
 
         result = explainer.predict(image=image)

--- a/radiologist-inference/tests/test_mc_dropout.py
+++ b/radiologist-inference/tests/test_mc_dropout.py
@@ -295,11 +295,10 @@ class TestMCDropoutFromPathMeanStdValidation:
     def test_from_selector_with_mismatched_mean_std_raises_before_any_pull(
         self, det_onnx_path, mcd_onnx_path, tmp_path
     ):
-        """MCDropoutPredictor.from_selector validates mean/std itself before
-        resolving or pulling anything (it does not delegate to
-        BasePredictor.from_selector); a mismatched mean/std pair must raise
-        before the artifact is resolved or pulled (bugfix review finding on
-        PR #131)."""
+        """MCDropoutPredictor.from_selector inherits BasePredictor.from_selector
+        unchanged, which validates mean/std before resolving or pulling
+        anything; a mismatched mean/std pair must raise before the artifact
+        is resolved or pulled (bugfix review finding on PR #131)."""
         fake_registry = _FakeMcdSelectorRegistry(det_onnx_path, mcd_onnx_path)
         selector = RegistrySelector(path="entity/project/model", run_id="run123")
 

--- a/radiologist-inference/tests/test_mc_dropout.py
+++ b/radiologist-inference/tests/test_mc_dropout.py
@@ -86,54 +86,57 @@ class _FakeMcdSelectorRegistry:
 
 
 class TestPredictWithUncertainty:
-    def test_returns_uncertainty_result_type(self, predictor_with_mcd, sample_image):
+    def test_returns_uncertainty_result_type(self, predictor, sample_image):
         """predict_with_uncertainty must return an UncertaintyResult."""
         from radiologist.inference.models import UncertaintyResult
 
-        result = predictor_with_mcd.predict_with_uncertainty(sample_image, n_passes=10)
+        result = predictor.predict_with_uncertainty(sample_image, n_passes=10)
         assert isinstance(result, UncertaintyResult)
 
-    def test_mean_probabilities_sum_to_one(self, predictor_with_mcd, sample_image):
+    def test_mean_probabilities_sum_to_one(self, predictor, sample_image):
         """mean_probabilities must sum to 1.0 within floating tolerance."""
-        result = predictor_with_mcd.predict_with_uncertainty(sample_image, n_passes=10)
+        result = predictor.predict_with_uncertainty(sample_image, n_passes=10)
         total = sum(result.mean_probabilities.values())
         assert abs(total - 1.0) < 1e-5
 
-    def test_mean_probabilities_keyed_by_class_names(
-        self, predictor_with_mcd, sample_image
-    ):
+    def test_mean_probabilities_keyed_by_class_names(self, predictor, sample_image):
         """mean_probabilities keys must match class names from model metadata."""
-        result = predictor_with_mcd.predict_with_uncertainty(sample_image, n_passes=10)
+        result = predictor.predict_with_uncertainty(sample_image, n_passes=10)
         assert set(result.mean_probabilities.keys()) == set(CLASSES)
 
-    def test_std_per_class_is_nonzero(self, predictor_with_mcd, sample_image):
+    def test_std_per_class_is_nonzero(self, predictor, sample_image):
         """std_per_class must be non-zero across stochastic passes."""
-        result = predictor_with_mcd.predict_with_uncertainty(sample_image, n_passes=30)
+        result = predictor.predict_with_uncertainty(sample_image, n_passes=30)
         assert any(v > 0 for v in result.std_per_class.values())
 
-    def test_predictive_entropy_is_nonnegative(self, predictor_with_mcd, sample_image):
+    def test_predictive_entropy_is_nonnegative(self, predictor, sample_image):
         """predictive_entropy must be >= 0."""
-        result = predictor_with_mcd.predict_with_uncertainty(sample_image, n_passes=10)
+        result = predictor.predict_with_uncertainty(sample_image, n_passes=10)
         assert result.predictive_entropy >= 0.0
 
-    def test_n_passes_reflects_requested_count(self, predictor_with_mcd, sample_image):
+    def test_n_passes_reflects_requested_count(self, predictor, sample_image):
         """UncertaintyResult.n_passes must equal the requested number of passes."""
-        result = predictor_with_mcd.predict_with_uncertainty(sample_image, n_passes=15)
+        result = predictor.predict_with_uncertainty(sample_image, n_passes=15)
         assert result.n_passes == 15
 
-    def test_larger_n_passes_reflected_in_result(
-        self, predictor_with_mcd, sample_image
-    ):
+    def test_larger_n_passes_reflected_in_result(self, predictor, sample_image):
         """Calling with n_passes=50 must report n_passes=50."""
-        result = predictor_with_mcd.predict_with_uncertainty(sample_image, n_passes=50)
+        result = predictor.predict_with_uncertainty(sample_image, n_passes=50)
         assert result.n_passes == 50
 
-    def test_raises_runtime_error_when_no_mcd_model(
-        self, predictor_without_mcd, sample_image
-    ):
-        """predict_with_uncertainty on a predictor loaded without mcd_path must raise RuntimeError."""
-        with pytest.raises(RuntimeError, match="MC-Dropout"):
-            predictor_without_mcd.predict_with_uncertainty(sample_image)
+    def test_from_path_constructs_exactly_one_onnx_session(self, mcd_onnx_path):
+        """Loading an MCDropoutPredictor must construct exactly one ONNX
+        session (spy on the true process boundary:
+        onnxruntime.InferenceSession) — the load-time requirement of a
+        second (deterministic) model is gone."""
+        import onnxruntime as ort
+
+        with patch(
+            "radiologist.inference.base_predictor.ort.InferenceSession",
+            wraps=ort.InferenceSession,
+        ) as spy:
+            MCDropoutPredictor.from_path(model_path=mcd_onnx_path)
+            assert spy.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -282,17 +285,13 @@ class TestMCDropoutFromSelector:
 
 
 class TestMCDropoutFromPathMeanStdValidation:
-    def test_from_path_with_only_mean_raises_value_error(
-        self, det_onnx_path, mcd_onnx_path
-    ):
+    def test_from_path_with_only_mean_raises_value_error(self, mcd_onnx_path):
         """Supplying mean without std must raise ValueError eagerly at
         from_path, before any prediction is requested (bugfix review finding
         on PR #131 — MCDropoutPredictor delegates to the shared
         BasePredictor.from_path code path)."""
         with pytest.raises(ValueError, match="mean and std"):
-            MCDropoutPredictor.from_path(
-                det_path=det_onnx_path, mcd_path=mcd_onnx_path, mean=128.0
-            )
+            MCDropoutPredictor.from_path(model_path=mcd_onnx_path, mean=128.0)
 
     def test_from_selector_with_mismatched_mean_std_raises_before_any_pull(
         self, det_onnx_path, mcd_onnx_path, tmp_path

--- a/radiologist-inference/tests/test_mc_dropout.py
+++ b/radiologist-inference/tests/test_mc_dropout.py
@@ -187,14 +187,16 @@ class TestMcDropoutPredict:
 
 
 class TestMCDropoutFromSelector:
-    def test_from_selector_resolves_det_and_mcd_suffixed_run_id(self, tmp_path):
-        """from_selector with a run_id must resolve both the det artifact
-        (run_id) and the mcd artifact ({run_id}-mcd), threading mean/std/
-        input_shape into the loaded predictor (bugfix #139)."""
+    def test_from_selector_resolves_single_artifact_for_given_selector(self, tmp_path):
+        """from_selector performs a single resolve/pull against whatever
+        selector it is given, threading mean/std/input_shape into the loaded
+        predictor. The {run_id}-mcd naming convention is applied by the
+        caller (radiologist.inference.verbs.load_predictor), not here — the
+        deterministic model is no longer pulled by this method."""
         det_path = build_det_onnx(tmp_path, filename="det.onnx")
         mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
         fake_registry = _FakeMcdSelectorRegistry(det_path, mcd_path)
-        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+        selector = RegistrySelector(path="entity/project/model", run_id="run123-mcd")
 
         predictor = MCDropoutPredictor.from_selector(
             selector,
@@ -211,11 +213,9 @@ class TestMCDropoutFromSelector:
         assert set(result.mean_probabilities.keys()) == set(CLASSES)
         assert abs(sum(result.mean_probabilities.values()) - 1.0) < 1e-5
         assert fake_registry.resolve_calls == [
-            ("entity/project/model", "run123"),
             ("entity/project/model", "run123-mcd"),
         ]
         assert fake_registry.pull_calls == [
-            ("entity/project/model/model-run123:best", str(tmp_path)),
             ("entity/project/model/model-run123-mcd:best", str(tmp_path)),
         ]
 
@@ -226,12 +226,12 @@ class TestMCDropoutFromSelector:
         mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
 
         default_predictor = MCDropoutPredictor.from_selector(
-            RegistrySelector(path="entity/project/model", run_id="run123"),
+            RegistrySelector(path="entity/project/model", run_id="run123-mcd"),
             local_dir=str(tmp_path),
             registry=_FakeMcdSelectorRegistry(det_path, mcd_path),
         )
         normalized_predictor = MCDropoutPredictor.from_selector(
-            RegistrySelector(path="entity/project/model", run_id="run123"),
+            RegistrySelector(path="entity/project/model", run_id="run123-mcd"),
             local_dir=str(tmp_path),
             registry=_FakeMcdSelectorRegistry(det_path, mcd_path),
             mean=128.0,
@@ -242,12 +242,12 @@ class TestMCDropoutFromSelector:
         assert normalized_predictor._state.mean == 128.0
         assert normalized_predictor._state.std == 65.0
 
-    def test_from_selector_without_run_id_reuses_same_selector_for_det_and_mcd(
+    def test_from_selector_without_run_id_resolves_once_with_tags_selector(
         self, tmp_path
     ):
         """When selector.run_id is None (tags/groups/metric-based selection),
-        the same selector must be reused for both det and mcd resolution —
-        no -mcd suffix — matching today's CLI fallback behavior."""
+        the selector is resolved exactly once — no -mcd suffix is applied
+        here."""
         det_path = build_det_onnx(tmp_path, filename="det.onnx")
         mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
         fake_registry = _FakeMcdSelectorRegistry(det_path, mcd_path)
@@ -259,7 +259,6 @@ class TestMCDropoutFromSelector:
 
         assert isinstance(predictor, MCDropoutPredictor)
         assert fake_registry.resolve_calls == [
-            ("entity/project/model", None),
             ("entity/project/model", None),
         ]
 
@@ -296,10 +295,11 @@ class TestMCDropoutFromPathMeanStdValidation:
     def test_from_selector_with_mismatched_mean_std_raises_before_any_pull(
         self, det_onnx_path, mcd_onnx_path, tmp_path
     ):
-        """MCDropoutPredictor.from_selector has its own det+mcd resolve/pull
-        sequence (it does not delegate resolution to BasePredictor); a
-        mismatched mean/std pair must raise before either artifact is
-        resolved or pulled (bugfix review finding on PR #131)."""
+        """MCDropoutPredictor.from_selector validates mean/std itself before
+        resolving or pulling anything (it does not delegate to
+        BasePredictor.from_selector); a mismatched mean/std pair must raise
+        before the artifact is resolved or pulled (bugfix review finding on
+        PR #131)."""
         fake_registry = _FakeMcdSelectorRegistry(det_onnx_path, mcd_onnx_path)
         selector = RegistrySelector(path="entity/project/model", run_id="run123")
 

--- a/radiologist-inference/tests/test_public_api.py
+++ b/radiologist-inference/tests/test_public_api.py
@@ -116,9 +116,22 @@ def test_result_dataclasses_are_importable():
         input_shape=[1, 3, 224, 224],
         cam_target_layer="features",
         output_names=["output"],
-        mc_dropout=False,
     )
     assert meta.classes == ["a", "b"]
+
+
+def test_model_metadata_rejects_mc_dropout_kwarg():
+    """ModelMetadata must have no mc_dropout field; passing it raises TypeError."""
+    from radiologist.inference import ModelMetadata
+
+    with pytest.raises(TypeError):
+        ModelMetadata(
+            classes=["a", "b"],
+            input_shape=[1, 3, 224, 224],
+            cam_target_layer="features",
+            output_names=["output"],
+            mc_dropout=False,
+        )
 
 
 def test_predictor_subclass_relationships_hold():

--- a/radiologist-inference/tests/test_public_api.py
+++ b/radiologist-inference/tests/test_public_api.py
@@ -54,6 +54,10 @@ def test_all_public_names_present():
         "score_cam",
         "mc_dropout_predict",
         "create_app",
+        "PredictorVerb",
+        "get_verb",
+        "apply_mcd_convention",
+        "load_predictor",
     }
     assert set(pkg.__all__) == expected
     for name in expected:

--- a/radiologist-inference/tests/test_public_api.py
+++ b/radiologist-inference/tests/test_public_api.py
@@ -54,10 +54,6 @@ def test_all_public_names_present():
         "score_cam",
         "mc_dropout_predict",
         "create_app",
-        "PredictorVerb",
-        "get_verb",
-        "apply_mcd_convention",
-        "load_predictor",
     }
     assert set(pkg.__all__) == expected
     for name in expected:

--- a/radiologist-inference/tests/test_verbs.py
+++ b/radiologist-inference/tests/test_verbs.py
@@ -1,0 +1,223 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Tests for the predictor-verb registry (verbs.py).
+
+Registry-backed cases mock the wandb/registry process boundary only
+(patch radiologist.registry.resolver._wandb); from_path/from_selector run
+for real against ONNX models built by build_det_onnx/build_mcd_onnx.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from _helpers import build_det_onnx, build_mcd_onnx
+
+from radiologist.inference import Classifier, Explainer, MCDropoutPredictor
+from radiologist.inference.verbs import apply_mcd_convention, get_verb, load_predictor
+
+
+def _make_registry_wandb_mock(qualified_name: str = "entity/project/model-run1:best"):
+    """A wandb mock distinguishing resolve()'s kwargs artifact() call from
+    pull()'s positional artifact() call, per _WandbResolver's two call shapes.
+    """
+    mock_wandb = MagicMock()
+
+    resolved_art = MagicMock()
+    resolved_art.qualified_name = qualified_name
+    resolved_art.version = "best"
+
+    pulled_art = MagicMock()
+
+    best_run = MagicMock()
+    best_run.id = "run1"
+
+    api_instance = MagicMock()
+    api_instance.runs.return_value = [best_run]
+
+    def _artifact(*args, **kwargs):
+        return resolved_art if kwargs else pulled_art
+
+    api_instance.artifact.side_effect = _artifact
+    mock_wandb.Api.return_value = api_instance
+    return mock_wandb, pulled_art
+
+
+class TestGetVerb:
+    def test_uncertainty_verb_constructs_mcdropout_predictor_with_mcd_convention(self):
+        verb = get_verb("uncertainty")
+        assert verb.predictor_cls is MCDropoutPredictor
+        assert verb.mcd_convention is True
+
+    def test_predict_verb_constructs_classifier_without_mcd_convention(self):
+        verb = get_verb("predict")
+        assert verb.predictor_cls is Classifier
+        assert verb.mcd_convention is False
+
+    def test_explain_verb_constructs_explainer_without_mcd_convention(self):
+        verb = get_verb("explain")
+        assert verb.predictor_cls is Explainer
+        assert verb.mcd_convention is False
+
+    def test_unregistered_verb_name_raises_key_error(self):
+        with pytest.raises(KeyError):
+            get_verb("nonexistent-verb")
+
+
+class TestApplyMcdConvention:
+    def test_truthy_run_id_maps_to_run_id_dash_mcd_suffix(self):
+        assert apply_mcd_convention("run1") == "run1-mcd"
+
+    def test_none_run_id_maps_to_none(self):
+        assert apply_mcd_convention(None) is None
+
+    def test_empty_string_run_id_maps_to_none(self):
+        assert apply_mcd_convention("") is None
+
+
+class TestLoadPredictorFromLocalPath:
+    def test_predict_verb_with_local_model_path_returns_classifier(self, tmp_path):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        verb = get_verb("predict")
+
+        predictor = load_predictor(
+            verb,
+            model=det_path,
+            run_id=None,
+            tags=None,
+            groups=None,
+            metric=None,
+            local_dir=str(tmp_path),
+        )
+
+        assert isinstance(predictor, Classifier)
+
+    def test_explain_verb_with_local_model_path_returns_explainer(self, tmp_path):
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        verb = get_verb("explain")
+
+        predictor = load_predictor(
+            verb,
+            model=det_path,
+            run_id=None,
+            tags=None,
+            groups=None,
+            metric=None,
+            local_dir=str(tmp_path),
+        )
+
+        assert isinstance(predictor, Explainer)
+
+    def test_uncertainty_verb_with_local_model_path_returns_mcdropout_predictor(
+        self, tmp_path
+    ):
+        mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
+        verb = get_verb("uncertainty")
+
+        predictor = load_predictor(
+            verb,
+            model=mcd_path,
+            run_id=None,
+            tags=None,
+            groups=None,
+            metric=None,
+            local_dir=str(tmp_path),
+        )
+
+        assert isinstance(predictor, MCDropoutPredictor)
+
+
+class TestLoadPredictorFromRegistry:
+    def test_predict_verb_with_run_id_resolves_classifier_from_registry(self, tmp_path):
+        build_det_onnx(tmp_path, filename="det.onnx")
+        verb = get_verb("predict")
+        mock_wandb, pulled_art = _make_registry_wandb_mock()
+        pulled_art.download.return_value = str(tmp_path)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            predictor = load_predictor(
+                verb,
+                model=None,
+                run_id="run1",
+                tags=None,
+                groups=None,
+                metric=None,
+                local_dir=str(tmp_path),
+            )
+
+        assert isinstance(predictor, Classifier)
+
+    def test_uncertainty_verb_with_run_id_resolves_against_mcd_suffixed_run_id(
+        self, tmp_path
+    ):
+        build_mcd_onnx(tmp_path, filename="mcd.onnx")
+        verb = get_verb("uncertainty")
+        mock_wandb, pulled_art = _make_registry_wandb_mock(
+            qualified_name="entity/project/model-run1-mcd:best"
+        )
+        pulled_art.download.return_value = str(tmp_path)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            predictor = load_predictor(
+                verb,
+                model=None,
+                run_id="run1",
+                tags=None,
+                groups=None,
+                metric=None,
+                local_dir=str(tmp_path),
+            )
+
+        assert isinstance(predictor, MCDropoutPredictor)
+        api_instance = mock_wandb.Api.return_value
+        resolve_calls = [
+            call for call in api_instance.artifact.call_args_list if call.kwargs
+        ]
+        assert len(resolve_calls) == 1
+        assert "run1-mcd" in resolve_calls[0].kwargs["name"]
+
+
+class TestLoadPredictorRaisesWhenNoSourceGiven:
+    def test_no_model_and_no_registry_selector_raises_value_error(self, tmp_path):
+        verb = get_verb("predict")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_predictor(
+                verb,
+                model=None,
+                run_id=None,
+                tags=None,
+                groups=None,
+                metric=None,
+                local_dir=str(tmp_path),
+            )
+
+        message = str(exc_info.value)
+        assert "--model" in message
+        assert "--run-id" in message
+        assert "--tags" in message
+        assert "--groups" in message
+        assert "--metric" in message


### PR DESCRIPTION
## Summary

Implements the epic milestone "Single-session predictors + declarative CLI verb registry" across four sequential slices:

- **#140** — Skeleton: lands `verbs.py` as typed `NotImplementedError` stubs, publishing the target contract with no behavioral change.
- **#141** — Single-session predictor core: collapses `_PredictorState.det_session`/`mcd_session` into a single required `session`; `MCDropoutPredictor` no longer loads an unused deterministic model; drops the vestigial `ModelMetadata.mc_dropout` field and the structurally-impossible "no mcd session" `RuntimeError`.
- **#142** — Predictor-verb registry (`verbs.py`): implements `PredictorVerb`, `get_verb`, `apply_mcd_convention`, and `load_predictor` — one declarative `verb → (predictor class, registry convention)` table replacing duplicated CLI loading logic.
- **#143** — CLI rewire: `predict`/`explain`/`uncertainty`/`serve` now go through `verbs.load_predictor`; deletes `_load_predictor`/`_load_uncertainty_predictor`; drops `--mcd-model`; adds mutually-exclusive `--predict`/`--explain`/`--uncertainty` flags to `serve` (default: `explain`).

Every predictor now constructs exactly one ONNX session regardless of type, verified by spying `onnxruntime.InferenceSession` at the true process boundary.

Closes #140, closes #141, closes #142, closes #143.

## Test plan

- [x] `make test-inference` — 119 passed
- [x] `make test-registry` — 70 passed (unaffected, sanity check)
- [x] `mypy radiologist-inference/src` — clean
- [x] Confirmed `radiologist-etl` pre-existing failures are unrelated (branch touches nothing under `radiologist-etl/`)
- [x] Quality review (3 parallel code-reviewer passes) — pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)