### PR TITLE
Epic — Prometheus metrics instrumentation for the inference serving app

### DIFF
--- a/radiologist-inference/README.md
+++ b/radiologist-inference/README.md
@@ -17,7 +17,7 @@ Installs: `numpy`, `Pillow`, `onnxruntime`.
 | Extra | Installs | Enables |
 |---|---|---|
 | `registry` | `wandb` | `BasePredictor.from_registry` |
-| `serve` | `fastapi`, `uvicorn`, `python-multipart` | `create_app`, HTTP server |
+| `serve` | `fastapi`, `uvicorn`, `python-multipart`, `prometheus-client` | `create_app`, HTTP server, `GET /metrics` |
 | `cli` | `typer` | `radiologist` CLI entry point |
 | `all` | all of the above | everything |
 
@@ -119,9 +119,60 @@ Routes:
 | Method | Path | Description |
 |---|---|---|
 | `GET` | `/healthz` | Liveness check |
+| `GET` | `/readyz` | Readiness check; 503 until a predictor is loaded |
 | `POST` | `/predict` | Classify a chest X-ray image (multipart upload) |
 | `POST` | `/explain` | Return Score-CAM saliency map |
 | `POST` | `/uncertainty` | MC-Dropout uncertainty estimation |
+| `GET` | `/metrics` | Prometheus exposition of the metric catalogue below |
+
+### Metrics (`GET /metrics`, requires `serve` extra)
+
+Instrumentation is always-on whenever `prometheus-client` is importable — no
+CLI flag, no configuration. `GET /metrics` returns a
+`text/plain; version=0.0.4; charset=utf-8` Prometheus exposition payload of
+this application's own `CollectorRegistry`. When `prometheus-client` is not
+installed, `GET /metrics` is not wired at all and the route 404s cleanly;
+every `Metrics` recording method silently no-ops instead of raising, so
+request handling is unaffected either way.
+
+The registry is **per-application and per-process**: each call to
+`create_app` builds a fresh `CollectorRegistry`, so only these ten families
+are exposed — there are no `process_*` / `python_gc_*` collectors. The
+deployment model is assumed **single-worker**;
+`prometheus_client.multiprocess` (multi-process/multi-worker aggregation) is
+not supported. Scrape traffic against `/metrics` itself is excluded from all
+counters, histograms and gauges below — it is not counted, timed, or tracked
+in flight.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `inference_requests_total` | Counter | `route`, `status` | Total inference API requests |
+| `inference_request_duration_seconds` | Histogram | `route` | Wall-clock request duration, in seconds |
+| `inference_requests_in_progress` | Gauge | `route` | Requests currently being served |
+| `inference_errors_total` | Counter | `route`, `error_type` | Request-level errors |
+| `inference_input_image_size_bytes` | Histogram | — | Uploaded input image size, in bytes |
+| `inference_input_image_width_pixels` | Histogram | — | Pre-resize input image width, in pixels |
+| `inference_input_image_height_pixels` | Histogram | — | Pre-resize input image height, in pixels |
+| `inference_predicted_class_total` | Counter | `class` | Predictions per predicted class |
+| `inference_confidence` | Histogram | — | Maximum predicted class probability |
+| `inference_predictive_entropy` | Histogram | — | Predictive entropy of the mean MC-Dropout prediction |
+| `inference_uncertainty_std_max` | Histogram | — | Maximum per-class std across MC-Dropout passes |
+
+`route` and `error_type` are closed, bounded-cardinality label sets — never
+caller-controlled text:
+
+- `route` is one of `/predict`, `/explain`, `/uncertainty`, `/healthz`,
+  `/readyz`, `/metrics`, or the fallback value `unmatched` for any other
+  path.
+- `error_type` is one of `invalid_image`, `empty_file`, `no_model_loaded`,
+  `validation_error`.
+
+Two scope reconciliations, recorded here so they are not re-litigated:
+
+- `/explain` does not observe `inference_confidence` — `Explanation` carries
+  no probability vector to derive a confidence value from.
+- `/uncertainty` does not increment `inference_predicted_class_total` —
+  `UncertaintyResult` has no `predicted_class` field.
 
 ### CLI (requires `cli` extra)
 

--- a/radiologist-inference/pyproject.toml
+++ b/radiologist-inference/pyproject.toml
@@ -22,6 +22,7 @@ all = [
     "uvicorn>=0.23.0",
     "python-multipart>=0.0.9",
     "typer>=0.9.0",
+    "prometheus-client>=0.20.0",
 ]
 cli = ["typer>=0.9.0"]
 registry = ["wandb>=0.27.0"]
@@ -29,6 +30,7 @@ serve = [
     "fastapi>=0.100.0",
     "uvicorn>=0.23.0",
     "python-multipart>=0.0.9",
+    "prometheus-client>=0.20.0",
 ]
 
 [project.scripts]

--- a/radiologist-inference/radiologist_inference_tests/_helpers.py
+++ b/radiologist-inference/radiologist_inference_tests/_helpers.py
@@ -20,13 +20,16 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
+import io
 import json
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import numpy as np
 import onnx
 import onnx.helper as oh
 import onnx.numpy_helper as onh
+from fastapi.testclient import TestClient
+from PIL import Image as PILImage
 
 CLASSES = ["NORMAL", "ABNORMAL"]
 INPUT_SHAPE = [1, 3, 224, 224]
@@ -121,6 +124,33 @@ def build_det_onnx(
     path = str(tmp_path / filename)
     onnx.save(model, path)
     return path
+
+
+def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    img = PILImage.fromarray(arr, mode="RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _sample(body: str, name: str, **labels: str) -> float:
+    """Value of one sample line in a Prometheus exposition body, or 0.0."""
+    if labels:
+        rendered = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
+        prefix = f"{name}{{{rendered}}} "
+    else:
+        prefix = f"{name} "
+    for line in body.splitlines():
+        if line.startswith(prefix):
+            return float(line[len(prefix) :])
+    return 0.0
+
+
+def _hist(client: TestClient, name: str) -> Tuple[float, float]:
+    """Return (count, sum) for an unlabelled histogram at the current scrape."""
+    body = client.get("/metrics").text
+    return _sample(body, f"{name}_count"), _sample(body, f"{name}_sum")
 
 
 def build_mcd_onnx(tmp_path, filename: str = "model_mcd.onnx") -> str:

--- a/radiologist-inference/radiologist_inference_tests/test_app.py
+++ b/radiologist-inference/radiologist_inference_tests/test_app.py
@@ -22,24 +22,13 @@
 
 """Behavioural tests for the isinstance-driven create_app() factory."""
 
-import io
 from typing import Any
 
-import numpy as np
 import pytest
-from _helpers import build_det_onnx, build_mcd_onnx
+from _helpers import _make_png_bytes, build_det_onnx, build_mcd_onnx
 from fastapi.testclient import TestClient
-from PIL import Image as PILImage
 
 from radiologist.inference import Classifier, Explainer, MCDropoutPredictor, create_app
-
-
-def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
-    arr = np.zeros((height, width, 3), dtype=np.uint8)
-    img = PILImage.fromarray(arr, mode="RGB")
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    return buf.getvalue()
 
 
 @pytest.fixture()

--- a/radiologist-inference/radiologist_inference_tests/test_input_and_error_metrics.py
+++ b/radiologist-inference/radiologist_inference_tests/test_input_and_error_metrics.py
@@ -30,37 +30,13 @@ Assertions compare scrape deltas (scrape -> act -> scrape -> compare), never
 absolute values.
 """
 
-import io
-from typing import Any, Tuple
+from typing import Any
 
-import numpy as np
 import pytest
-from _helpers import build_det_onnx, build_mcd_onnx
+from _helpers import _hist, _make_png_bytes, _sample, build_det_onnx, build_mcd_onnx
 from fastapi.testclient import TestClient
-from PIL import Image as PILImage
 
 from radiologist.inference import Classifier, Explainer, MCDropoutPredictor, create_app
-
-
-def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
-    arr = np.zeros((height, width, 3), dtype=np.uint8)
-    img = PILImage.fromarray(arr, mode="RGB")
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    return buf.getvalue()
-
-
-def _sample(body: str, name: str, **labels: str) -> float:
-    """Value of one sample line in a Prometheus exposition body, or 0.0."""
-    if labels:
-        rendered = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
-        prefix = f"{name}{{{rendered}}} "
-    else:
-        prefix = f"{name} "
-    for line in body.splitlines():
-        if line.startswith(prefix):
-            return float(line[len(prefix) :])
-    return 0.0
 
 
 def _errors(client: TestClient, route: str, error_type: str) -> float:
@@ -70,12 +46,6 @@ def _errors(client: TestClient, route: str, error_type: str) -> float:
         route=route,
         error_type=error_type,
     )
-
-
-def _hist(client: TestClient, name: str) -> Tuple[float, float]:
-    """Return (count, sum) for an unlabelled histogram at the current scrape."""
-    body = client.get("/metrics").text
-    return _sample(body, f"{name}_count"), _sample(body, f"{name}_sum")
 
 
 @pytest.fixture()

--- a/radiologist-inference/radiologist_inference_tests/test_input_and_error_metrics.py
+++ b/radiologist-inference/radiologist_inference_tests/test_input_and_error_metrics.py
@@ -1,0 +1,233 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Behavioural tests for the error taxonomy metric (4) and input-image
+metrics (5, 6a, 6b).
+
+Covers ``inference_errors_total``, driven exclusively through real HTTP
+traffic against a real ``TestClient``. Assertions compare scrape deltas
+(scrape -> act -> scrape -> compare), never absolute values.
+"""
+
+import io
+from typing import Any
+
+import numpy as np
+import pytest
+from _helpers import build_det_onnx, build_mcd_onnx
+from fastapi.testclient import TestClient
+from PIL import Image as PILImage
+
+from radiologist.inference import Classifier, Explainer, MCDropoutPredictor, create_app
+
+
+def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    img = PILImage.fromarray(arr, mode="RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _sample(body: str, name: str, **labels: str) -> float:
+    """Value of one sample line in a Prometheus exposition body, or 0.0."""
+    if labels:
+        rendered = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
+        prefix = f"{name}{{{rendered}}} "
+    else:
+        prefix = f"{name} "
+    for line in body.splitlines():
+        if line.startswith(prefix):
+            return float(line[len(prefix) :])
+    return 0.0
+
+
+def _errors(client: TestClient, route: str, error_type: str) -> float:
+    return _sample(
+        client.get("/metrics").text,
+        "inference_errors_total",
+        route=route,
+        error_type=error_type,
+    )
+
+
+@pytest.fixture()
+def classifier(tmp_path: Any) -> Classifier:
+    det_path = build_det_onnx(tmp_path, filename="det.onnx")
+    return Classifier.from_path(model_path=det_path)
+
+
+@pytest.fixture()
+def explainer(tmp_path: Any) -> Explainer:
+    det_path = build_det_onnx(tmp_path, filename="det.onnx")
+    return Explainer.from_path(model_path=det_path)
+
+
+@pytest.fixture()
+def mcd_predictor(tmp_path: Any) -> MCDropoutPredictor:
+    mcd_path = build_mcd_onnx(tmp_path)
+    return MCDropoutPredictor.from_path(model_path=mcd_path)
+
+
+@pytest.fixture()
+def client(classifier: Classifier) -> TestClient:
+    return TestClient(create_app(predictor=classifier))
+
+
+class TestErrorTaxonomyOnPredict:
+    def test_undecodable_upload_is_counted_as_invalid_image(
+        self, client: TestClient
+    ) -> None:
+        before = _errors(client, "/predict", "invalid_image")
+        client.post(
+            "/predict", files={"image": ("bad.png", b"not an image", "image/png")}
+        )
+        assert _errors(client, "/predict", "invalid_image") - before == 1.0
+
+    def test_empty_upload_is_counted_as_empty_file_only(
+        self, client: TestClient
+    ) -> None:
+        before_empty = _errors(client, "/predict", "empty_file")
+        before_invalid = _errors(client, "/predict", "invalid_image")
+        client.post("/predict", files={"image": ("e.png", b"", "image/png")})
+        assert _errors(client, "/predict", "empty_file") - before_empty == 1.0
+        assert _errors(client, "/predict", "invalid_image") - before_invalid == 0.0
+
+    def test_missing_file_field_is_counted_as_validation_error(
+        self, client: TestClient
+    ) -> None:
+        before = _errors(client, "/predict", "validation_error")
+        assert client.post("/predict").status_code == 400
+        assert _errors(client, "/predict", "validation_error") - before == 1.0
+
+    def test_no_predictor_is_counted_as_no_model_loaded(self) -> None:
+        client = TestClient(create_app(predictor=None))
+        before = _errors(client, "/predict", "no_model_loaded")
+        client.post(
+            "/predict", files={"image": ("t.png", _make_png_bytes(), "image/png")}
+        )
+        assert _errors(client, "/predict", "no_model_loaded") - before == 1.0
+
+    def test_successful_upload_records_no_error(self, client: TestClient) -> None:
+        client.post(
+            "/predict", files={"image": ("t.png", _make_png_bytes(), "image/png")}
+        )
+        body = client.get("/metrics").text
+        for error_type in (
+            "invalid_image",
+            "empty_file",
+            "no_model_loaded",
+            "validation_error",
+        ):
+            assert (
+                _sample(
+                    body,
+                    "inference_errors_total",
+                    route="/predict",
+                    error_type=error_type,
+                )
+                == 0.0
+            )
+
+
+class TestErrorTaxonomyOnExplain:
+    @pytest.fixture()
+    def client(self, explainer: Explainer) -> TestClient:
+        return TestClient(create_app(predictor=explainer))
+
+    def test_undecodable_upload_is_counted_as_invalid_image(
+        self, client: TestClient
+    ) -> None:
+        before = _errors(client, "/explain", "invalid_image")
+        client.post(
+            "/explain", files={"image": ("bad.png", b"not an image", "image/png")}
+        )
+        assert _errors(client, "/explain", "invalid_image") - before == 1.0
+
+    def test_empty_upload_is_counted_as_empty_file(self, client: TestClient) -> None:
+        before = _errors(client, "/explain", "empty_file")
+        client.post("/explain", files={"image": ("e.png", b"", "image/png")})
+        assert _errors(client, "/explain", "empty_file") - before == 1.0
+
+    def test_missing_file_field_is_counted_as_validation_error(
+        self, client: TestClient
+    ) -> None:
+        before = _errors(client, "/explain", "validation_error")
+        assert client.post("/explain").status_code == 400
+        assert _errors(client, "/explain", "validation_error") - before == 1.0
+
+
+class TestErrorTaxonomyOnUncertainty:
+    @pytest.fixture()
+    def client(self, mcd_predictor: MCDropoutPredictor) -> TestClient:
+        return TestClient(create_app(predictor=mcd_predictor))
+
+    def test_undecodable_upload_is_counted_as_invalid_image(
+        self, client: TestClient
+    ) -> None:
+        before = _errors(client, "/uncertainty", "invalid_image")
+        client.post(
+            "/uncertainty", files={"image": ("bad.png", b"not an image", "image/png")}
+        )
+        assert _errors(client, "/uncertainty", "invalid_image") - before == 1.0
+
+    def test_empty_upload_is_counted_as_empty_file(self, client: TestClient) -> None:
+        before = _errors(client, "/uncertainty", "empty_file")
+        client.post("/uncertainty", files={"image": ("e.png", b"", "image/png")})
+        assert _errors(client, "/uncertainty", "empty_file") - before == 1.0
+
+    def test_missing_file_field_is_counted_as_validation_error(
+        self, client: TestClient
+    ) -> None:
+        before = _errors(client, "/uncertainty", "validation_error")
+        assert client.post("/uncertainty").status_code == 400
+        assert _errors(client, "/uncertainty", "validation_error") - before == 1.0
+
+    def test_no_predictor_is_counted_as_no_model_loaded(self) -> None:
+        client = TestClient(create_app(predictor=None))
+        before = _errors(client, "/uncertainty", "no_model_loaded")
+        client.post(
+            "/uncertainty", files={"image": ("t.png", _make_png_bytes(), "image/png")}
+        )
+        assert _errors(client, "/uncertainty", "no_model_loaded") - before == 1.0
+
+
+class TestReadinessProbeDoesNotInflateErrorBudget:
+    def test_readiness_probe_records_no_error(self) -> None:
+        client = TestClient(create_app(predictor=None))
+        assert client.get("/readyz").status_code == 503
+        body = client.get("/metrics").text
+        for error_type in (
+            "invalid_image",
+            "empty_file",
+            "no_model_loaded",
+            "validation_error",
+        ):
+            assert (
+                _sample(
+                    body,
+                    "inference_errors_total",
+                    route="/readyz",
+                    error_type=error_type,
+                )
+                == 0.0
+            )

--- a/radiologist-inference/radiologist_inference_tests/test_input_and_error_metrics.py
+++ b/radiologist-inference/radiologist_inference_tests/test_input_and_error_metrics.py
@@ -23,13 +23,15 @@
 """Behavioural tests for the error taxonomy metric (4) and input-image
 metrics (5, 6a, 6b).
 
-Covers ``inference_errors_total``, driven exclusively through real HTTP
-traffic against a real ``TestClient``. Assertions compare scrape deltas
-(scrape -> act -> scrape -> compare), never absolute values.
+Covers ``inference_errors_total``, ``inference_input_image_size_bytes``,
+``inference_input_image_width_pixels`` and ``inference_input_image_height_pixels``,
+driven exclusively through real HTTP traffic against a real ``TestClient``.
+Assertions compare scrape deltas (scrape -> act -> scrape -> compare), never
+absolute values.
 """
 
 import io
-from typing import Any
+from typing import Any, Tuple
 
 import numpy as np
 import pytest
@@ -70,6 +72,12 @@ def _errors(client: TestClient, route: str, error_type: str) -> float:
     )
 
 
+def _hist(client: TestClient, name: str) -> Tuple[float, float]:
+    """Return (count, sum) for an unlabelled histogram at the current scrape."""
+    body = client.get("/metrics").text
+    return _sample(body, f"{name}_count"), _sample(body, f"{name}_sum")
+
+
 @pytest.fixture()
 def classifier(tmp_path: Any) -> Classifier:
     det_path = build_det_onnx(tmp_path, filename="det.onnx")
@@ -84,7 +92,7 @@ def explainer(tmp_path: Any) -> Explainer:
 
 @pytest.fixture()
 def mcd_predictor(tmp_path: Any) -> MCDropoutPredictor:
-    mcd_path = build_mcd_onnx(tmp_path)
+    mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
     return MCDropoutPredictor.from_path(model_path=mcd_path)
 
 
@@ -149,6 +157,64 @@ class TestErrorTaxonomyOnPredict:
             )
 
 
+class TestInputImageMetricsOnPredict:
+    def test_successful_upload_records_size_width_and_height(
+        self, client: TestClient
+    ) -> None:
+        png = _make_png_bytes(width=96, height=48)
+
+        c0, s0 = _hist(client, "inference_input_image_size_bytes")
+        w0, ws0 = _hist(client, "inference_input_image_width_pixels")
+        h0, hs0 = _hist(client, "inference_input_image_height_pixels")
+
+        client.post("/predict", files={"image": ("t.png", png, "image/png")})
+
+        c1, s1 = _hist(client, "inference_input_image_size_bytes")
+        w1, ws1 = _hist(client, "inference_input_image_width_pixels")
+        h1, hs1 = _hist(client, "inference_input_image_height_pixels")
+
+        assert c1 - c0 == 1.0
+        assert s1 - s0 == pytest.approx(float(len(png)))
+        assert w1 - w0 == 1.0
+        assert ws1 - ws0 == pytest.approx(96.0)  # not 48 -- width is not transposed
+        assert h1 - h0 == 1.0
+        assert hs1 - hs0 == pytest.approx(48.0)
+
+    def test_undecodable_upload_records_no_input_observation(
+        self, client: TestClient
+    ) -> None:
+        c0, _ = _hist(client, "inference_input_image_size_bytes")
+        w0, _ = _hist(client, "inference_input_image_width_pixels")
+        h0, _ = _hist(client, "inference_input_image_height_pixels")
+        client.post(
+            "/predict", files={"image": ("bad.png", b"not an image", "image/png")}
+        )
+        c1, _ = _hist(client, "inference_input_image_size_bytes")
+        w1, _ = _hist(client, "inference_input_image_width_pixels")
+        h1, _ = _hist(client, "inference_input_image_height_pixels")
+        assert c1 == c0
+        assert w1 == w0
+        assert h1 == h0
+
+    def test_empty_upload_records_no_input_observation(
+        self, client: TestClient
+    ) -> None:
+        c0, _ = _hist(client, "inference_input_image_size_bytes")
+        client.post("/predict", files={"image": ("e.png", b"", "image/png")})
+        c1, _ = _hist(client, "inference_input_image_size_bytes")
+        assert c1 == c0
+
+    def test_missing_model_still_records_the_input(self) -> None:
+        client = TestClient(create_app(predictor=None))
+        png = _make_png_bytes(width=96, height=48)
+        c0, s0 = _hist(client, "inference_input_image_size_bytes")
+        response = client.post("/predict", files={"image": ("t.png", png, "image/png")})
+        assert response.status_code == 503
+        c1, s1 = _hist(client, "inference_input_image_size_bytes")
+        assert c1 - c0 == 1.0
+        assert s1 - s0 == pytest.approx(float(len(png)))
+
+
 class TestErrorTaxonomyOnExplain:
     @pytest.fixture()
     def client(self, explainer: Explainer) -> TestClient:
@@ -174,6 +240,34 @@ class TestErrorTaxonomyOnExplain:
         before = _errors(client, "/explain", "validation_error")
         assert client.post("/explain").status_code == 400
         assert _errors(client, "/explain", "validation_error") - before == 1.0
+
+
+class TestInputImageMetricsOnExplain:
+    @pytest.fixture()
+    def client(self, explainer: Explainer) -> TestClient:
+        return TestClient(create_app(predictor=explainer))
+
+    def test_successful_upload_records_size_width_and_height(
+        self, client: TestClient
+    ) -> None:
+        png = _make_png_bytes(width=96, height=48)
+
+        c0, s0 = _hist(client, "inference_input_image_size_bytes")
+        w0, ws0 = _hist(client, "inference_input_image_width_pixels")
+        h0, hs0 = _hist(client, "inference_input_image_height_pixels")
+
+        client.post("/explain", files={"image": ("t.png", png, "image/png")})
+
+        c1, s1 = _hist(client, "inference_input_image_size_bytes")
+        w1, ws1 = _hist(client, "inference_input_image_width_pixels")
+        h1, hs1 = _hist(client, "inference_input_image_height_pixels")
+
+        assert c1 - c0 == 1.0
+        assert s1 - s0 == pytest.approx(float(len(png)))
+        assert w1 - w0 == 1.0
+        assert ws1 - ws0 == pytest.approx(96.0)
+        assert h1 - h0 == 1.0
+        assert hs1 - hs0 == pytest.approx(48.0)
 
 
 class TestErrorTaxonomyOnUncertainty:
@@ -209,6 +303,34 @@ class TestErrorTaxonomyOnUncertainty:
             "/uncertainty", files={"image": ("t.png", _make_png_bytes(), "image/png")}
         )
         assert _errors(client, "/uncertainty", "no_model_loaded") - before == 1.0
+
+
+class TestInputImageMetricsOnUncertainty:
+    @pytest.fixture()
+    def client(self, mcd_predictor: MCDropoutPredictor) -> TestClient:
+        return TestClient(create_app(predictor=mcd_predictor))
+
+    def test_successful_upload_records_size_width_and_height(
+        self, client: TestClient
+    ) -> None:
+        png = _make_png_bytes(width=96, height=48)
+
+        c0, s0 = _hist(client, "inference_input_image_size_bytes")
+        w0, ws0 = _hist(client, "inference_input_image_width_pixels")
+        h0, hs0 = _hist(client, "inference_input_image_height_pixels")
+
+        client.post("/uncertainty", files={"image": ("t.png", png, "image/png")})
+
+        c1, s1 = _hist(client, "inference_input_image_size_bytes")
+        w1, ws1 = _hist(client, "inference_input_image_width_pixels")
+        h1, hs1 = _hist(client, "inference_input_image_height_pixels")
+
+        assert c1 - c0 == 1.0
+        assert s1 - s0 == pytest.approx(float(len(png)))
+        assert w1 - w0 == 1.0
+        assert ws1 - ws0 == pytest.approx(96.0)
+        assert h1 - h0 == 1.0
+        assert hs1 - hs0 == pytest.approx(48.0)
 
 
 class TestReadinessProbeDoesNotInflateErrorBudget:

--- a/radiologist-inference/radiologist_inference_tests/test_metrics_exposition.py
+++ b/radiologist-inference/radiologist_inference_tests/test_metrics_exposition.py
@@ -27,37 +27,13 @@ the underlying registry, and graceful degradation (404) when the optional
 ``prometheus_client`` dependency is absent.
 """
 
-import io
 from typing import Any
 
-import numpy as np
 import pytest
-from _helpers import build_det_onnx
+from _helpers import _make_png_bytes, _sample, build_det_onnx
 from fastapi.testclient import TestClient
-from PIL import Image as PILImage
 
 from radiologist.inference import Classifier, create_app
-
-
-def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
-    arr = np.zeros((height, width, 3), dtype=np.uint8)
-    img = PILImage.fromarray(arr, mode="RGB")
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    return buf.getvalue()
-
-
-def _sample(body: str, name: str, **labels: str) -> float:
-    """Value of one sample line in a Prometheus exposition body, or 0.0."""
-    if labels:
-        rendered = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
-        prefix = f"{name}{{{rendered}}} "
-    else:
-        prefix = f"{name} "
-    for line in body.splitlines():
-        if line.startswith(prefix):
-            return float(line[len(prefix) :])
-    return 0.0
 
 
 @pytest.fixture()

--- a/radiologist-inference/radiologist_inference_tests/test_metrics_exposition.py
+++ b/radiologist-inference/radiologist_inference_tests/test_metrics_exposition.py
@@ -1,0 +1,144 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Behavioural tests for the GET /metrics scrape endpoint.
+
+Covers scraping the Prometheus text exposition, per-application isolation of
+the underlying registry, and graceful degradation (404) when the optional
+``prometheus_client`` dependency is absent.
+"""
+
+import io
+from typing import Any
+
+import numpy as np
+import pytest
+from _helpers import build_det_onnx
+from fastapi.testclient import TestClient
+from PIL import Image as PILImage
+
+from radiologist.inference import Classifier, create_app
+
+
+def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    img = PILImage.fromarray(arr, mode="RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _sample(body: str, name: str, **labels: str) -> float:
+    """Value of one sample line in a Prometheus exposition body, or 0.0."""
+    if labels:
+        rendered = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
+        prefix = f"{name}{{{rendered}}} "
+    else:
+        prefix = f"{name} "
+    for line in body.splitlines():
+        if line.startswith(prefix):
+            return float(line[len(prefix) :])
+    return 0.0
+
+
+@pytest.fixture()
+def classifier(tmp_path: Any) -> Classifier:
+    det_path = build_det_onnx(tmp_path, filename="det.onnx")
+    return Classifier.from_path(model_path=det_path)
+
+
+@pytest.fixture()
+def client(classifier: Classifier) -> TestClient:
+    return TestClient(create_app(predictor=classifier))
+
+
+class TestScrapeExposition:
+    def test_scrape_returns_prometheus_exposition(self, client: TestClient) -> None:
+        import prometheus_client
+
+        response = client.get("/metrics")
+        assert response.status_code == 200
+        assert response.headers["content-type"] == prometheus_client.CONTENT_TYPE_LATEST
+        assert "# TYPE inference_requests_total counter" in response.text
+
+    def test_all_ten_families_declared_before_any_traffic(
+        self, client: TestClient
+    ) -> None:
+        body = client.get("/metrics").text
+        expected = (
+            "inference_requests_total",
+            "inference_request_duration_seconds",
+            "inference_requests_in_progress",
+            "inference_errors_total",
+            "inference_input_image_size_bytes",
+            "inference_input_image_width_pixels",
+            "inference_input_image_height_pixels",
+            "inference_predicted_class_total",
+            "inference_confidence",
+            "inference_predictive_entropy",
+            "inference_uncertainty_std_max",
+        )
+        for name in expected:
+            assert f"# TYPE {name}" in body, f"missing declaration for {name}"
+
+
+class TestPerApplicationIsolation:
+    def test_two_apps_report_independently(self, classifier: Classifier) -> None:
+        a = TestClient(create_app(predictor=classifier))
+        b = TestClient(create_app(predictor=classifier))
+        a.post(
+            "/predict",
+            files={"image": ("t.png", _make_png_bytes(), "image/png")},
+        )
+        counted = _sample(
+            b.get("/metrics").text,
+            "inference_requests_total",
+            route="/predict",
+            status="200",
+        )
+        assert counted == 0.0
+
+    def test_many_apps_can_be_built_without_duplicate_timeseries_error(
+        self, classifier: Classifier
+    ) -> None:
+        for _ in range(5):
+            c = TestClient(create_app(predictor=classifier))
+            response = c.get("/metrics")
+            assert response.status_code == 200
+
+
+class TestMetricsAbsentWhenExtraMissing:
+    def test_metrics_route_404_and_other_routes_unaffected(
+        self, monkeypatch: Any, classifier: Classifier
+    ) -> None:
+        import radiologist.inference.metrics as metrics_module
+
+        monkeypatch.setattr(metrics_module, "_prometheus_client", None)
+        client = TestClient(create_app(predictor=classifier))
+        assert client.get("/metrics").status_code == 404
+        ok = client.post(
+            "/predict",
+            files={"image": ("t.png", _make_png_bytes(), "image/png")},
+        )
+        assert ok.status_code == 200
+        assert client.get("/healthz").status_code == 200
+        assert client.get("/readyz").status_code == 200

--- a/radiologist-inference/radiologist_inference_tests/test_prediction_metrics.py
+++ b/radiologist-inference/radiologist_inference_tests/test_prediction_metrics.py
@@ -31,42 +31,13 @@ request rather than hard-coded, since the tiny ONNX fixtures (and MC-Dropout
 in particular) do not produce deterministic outputs.
 """
 
-import io
 from typing import Any
 
-import numpy as np
 import pytest
-from _helpers import build_det_onnx, build_mcd_onnx
+from _helpers import _hist, _make_png_bytes, _sample, build_det_onnx, build_mcd_onnx
 from fastapi.testclient import TestClient
-from PIL import Image as PILImage
 
 from radiologist.inference import Classifier, Explainer, MCDropoutPredictor, create_app
-
-
-def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
-    arr = np.zeros((height, width, 3), dtype=np.uint8)
-    img = PILImage.fromarray(arr, mode="RGB")
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    return buf.getvalue()
-
-
-def _sample(body: str, name: str, **labels: str) -> float:
-    """Value of one sample line in a Prometheus exposition body, or 0.0."""
-    if labels:
-        rendered = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
-        prefix = f"{name}{{{rendered}}} "
-    else:
-        prefix = f"{name} "
-    for line in body.splitlines():
-        if line.startswith(prefix):
-            return float(line[len(prefix) :])
-    return 0.0
-
-
-def _hist(client: TestClient, name: str) -> Any:
-    body = client.get("/metrics").text
-    return _sample(body, f"{name}_count"), _sample(body, f"{name}_sum")
 
 
 @pytest.fixture()

--- a/radiologist-inference/radiologist_inference_tests/test_prediction_metrics.py
+++ b/radiologist-inference/radiologist_inference_tests/test_prediction_metrics.py
@@ -1,0 +1,216 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Behavioural tests for the prediction, confidence and uncertainty metrics.
+
+Covers ``inference_predicted_class_total``, ``inference_confidence``,
+``inference_predictive_entropy`` and ``inference_uncertainty_std_max``, driven
+exclusively through real HTTP traffic against a real ``TestClient``.
+Assertions compare scrape deltas (scrape -> act -> scrape -> compare), and
+values are always read from the JSON response body of the triggering
+request rather than hard-coded, since the tiny ONNX fixtures (and MC-Dropout
+in particular) do not produce deterministic outputs.
+"""
+
+import io
+from typing import Any
+
+import numpy as np
+import pytest
+from _helpers import build_det_onnx, build_mcd_onnx
+from fastapi.testclient import TestClient
+from PIL import Image as PILImage
+
+from radiologist.inference import Classifier, Explainer, MCDropoutPredictor, create_app
+
+
+def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    img = PILImage.fromarray(arr, mode="RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _sample(body: str, name: str, **labels: str) -> float:
+    """Value of one sample line in a Prometheus exposition body, or 0.0."""
+    if labels:
+        rendered = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
+        prefix = f"{name}{{{rendered}}} "
+    else:
+        prefix = f"{name} "
+    for line in body.splitlines():
+        if line.startswith(prefix):
+            return float(line[len(prefix) :])
+    return 0.0
+
+
+def _hist(client: TestClient, name: str) -> Any:
+    body = client.get("/metrics").text
+    return _sample(body, f"{name}_count"), _sample(body, f"{name}_sum")
+
+
+@pytest.fixture()
+def classifier(tmp_path: Any) -> Classifier:
+    det_path = build_det_onnx(tmp_path, filename="det.onnx")
+    return Classifier.from_path(model_path=det_path)
+
+
+@pytest.fixture()
+def explainer(tmp_path: Any) -> Explainer:
+    det_path = build_det_onnx(tmp_path, filename="det.onnx")
+    return Explainer.from_path(model_path=det_path)
+
+
+@pytest.fixture()
+def mcd_predictor(tmp_path: Any) -> MCDropoutPredictor:
+    mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
+    return MCDropoutPredictor.from_path(model_path=mcd_path)
+
+
+@pytest.fixture()
+def client(classifier: Classifier) -> TestClient:
+    return TestClient(create_app(predictor=classifier))
+
+
+def test_prediction_records_its_class_and_confidence(client: TestClient) -> None:
+    c0, s0 = _hist(client, "inference_confidence")
+    response = client.post(
+        "/predict", files={"image": ("t.png", _make_png_bytes(), "image/png")}
+    )
+    body = response.json()
+    expected_class = body["predicted_class"]
+    expected_conf = max(body["probabilities"].values())
+
+    exposition = client.get("/metrics").text
+    counted = _sample(
+        exposition, "inference_predicted_class_total", **{"class": expected_class}
+    )
+    c1, s1 = _hist(client, "inference_confidence")
+
+    assert counted == 1.0
+    assert c1 - c0 == 1.0
+    assert s1 - s0 == pytest.approx(expected_conf)
+
+
+def test_repeated_predictions_of_the_same_class_accumulate(
+    client: TestClient,
+) -> None:
+    body = client.post(
+        "/predict", files={"image": ("t.png", _make_png_bytes(), "image/png")}
+    ).json()
+    expected_class = body["predicted_class"]
+    before = _sample(
+        client.get("/metrics").text,
+        "inference_predicted_class_total",
+        **{"class": expected_class},
+    )
+    client.post("/predict", files={"image": ("t.png", _make_png_bytes(), "image/png")})
+    after = _sample(
+        client.get("/metrics").text,
+        "inference_predicted_class_total",
+        **{"class": expected_class},
+    )
+    assert after - before == 1.0
+
+
+def test_explanation_records_its_class_but_no_confidence(
+    explainer: Explainer,
+) -> None:
+    client = TestClient(create_app(predictor=explainer))
+    c0, _ = _hist(client, "inference_confidence")
+    body = client.post(
+        "/explain", files={"image": ("t.png", _make_png_bytes(), "image/png")}
+    ).json()
+
+    exposition = client.get("/metrics").text
+    counted = _sample(
+        exposition,
+        "inference_predicted_class_total",
+        **{"class": body["predicted_class"]},
+    )
+    c1, _ = _hist(client, "inference_confidence")
+
+    assert counted == 1.0
+    assert c1 == c0  # explanation carries no probabilities
+
+
+def test_uncertainty_records_entropy_and_max_std(
+    mcd_predictor: MCDropoutPredictor,
+) -> None:
+    client = TestClient(create_app(predictor=mcd_predictor))
+    e0, es0 = _hist(client, "inference_predictive_entropy")
+    d0, ds0 = _hist(client, "inference_uncertainty_std_max")
+
+    body = client.post(
+        "/uncertainty", files={"image": ("t.png", _make_png_bytes(), "image/png")}
+    ).json()
+    expected_entropy = body["predictive_entropy"]
+    expected_std_max = max(body["std_per_class"].values())
+
+    e1, es1 = _hist(client, "inference_predictive_entropy")
+    d1, ds1 = _hist(client, "inference_uncertainty_std_max")
+
+    assert e1 - e0 == 1.0
+    assert es1 - es0 == pytest.approx(expected_entropy)
+    assert d1 - d0 == 1.0
+    assert ds1 - ds0 == pytest.approx(expected_std_max)
+    # max, not sum: a differing per-class spread records only the largest
+    assert ds1 - ds0 != pytest.approx(sum(body["std_per_class"].values()))
+
+
+def test_uncertainty_records_no_class_and_no_confidence(
+    mcd_predictor: MCDropoutPredictor,
+) -> None:
+    client = TestClient(create_app(predictor=mcd_predictor))
+    c0, _ = _hist(client, "inference_confidence")
+    client.post(
+        "/uncertainty", files={"image": ("t.png", _make_png_bytes(), "image/png")}
+    )
+    exposition = client.get("/metrics").text
+    c1, _ = _hist(client, "inference_confidence")
+
+    assert c1 == c0
+    assert "inference_predicted_class_total{" not in exposition
+
+
+def test_predict_and_explain_add_no_entropy_or_std_observation(
+    client: TestClient,
+) -> None:
+    e0, _ = _hist(client, "inference_predictive_entropy")
+    d0, _ = _hist(client, "inference_uncertainty_std_max")
+    client.post("/predict", files={"image": ("t.png", _make_png_bytes(), "image/png")})
+    e1, _ = _hist(client, "inference_predictive_entropy")
+    d1, _ = _hist(client, "inference_uncertainty_std_max")
+    assert e1 == e0
+    assert d1 == d0
+
+
+def test_rejected_request_records_nothing(client: TestClient) -> None:
+    c0, _ = _hist(client, "inference_confidence")
+    client.post("/predict", files={"image": ("bad.png", b"nope", "image/png")})
+    client.post("/predict", files={"image": ("e.png", b"", "image/png")})
+    exposition = client.get("/metrics").text
+    c1, _ = _hist(client, "inference_confidence")
+
+    assert c1 == c0
+    assert "inference_predicted_class_total{" not in exposition

--- a/radiologist-inference/radiologist_inference_tests/test_request_metrics.py
+++ b/radiologist-inference/radiologist_inference_tests/test_request_metrics.py
@@ -28,37 +28,13 @@ traffic against a real ``TestClient``. Assertions compare scrape deltas
 (scrape -> act -> scrape -> compare), never absolute values.
 """
 
-import io
 from typing import Any
 
-import numpy as np
 import pytest
-from _helpers import build_det_onnx
+from _helpers import _make_png_bytes, _sample, build_det_onnx
 from fastapi.testclient import TestClient
-from PIL import Image as PILImage
 
 from radiologist.inference import Classifier, create_app
-
-
-def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
-    arr = np.zeros((height, width, 3), dtype=np.uint8)
-    img = PILImage.fromarray(arr, mode="RGB")
-    buf = io.BytesIO()
-    img.save(buf, format="PNG")
-    return buf.getvalue()
-
-
-def _sample(body: str, name: str, **labels: str) -> float:
-    """Value of one sample line in a Prometheus exposition body, or 0.0."""
-    if labels:
-        rendered = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
-        prefix = f"{name}{{{rendered}}} "
-    else:
-        prefix = f"{name} "
-    for line in body.splitlines():
-        if line.startswith(prefix):
-            return float(line[len(prefix) :])
-    return 0.0
 
 
 @pytest.fixture()

--- a/radiologist-inference/radiologist_inference_tests/test_request_metrics.py
+++ b/radiologist-inference/radiologist_inference_tests/test_request_metrics.py
@@ -1,0 +1,237 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Behavioural tests for the RED request metrics (1-3).
+
+Covers ``inference_requests_total``, ``inference_request_duration_seconds``
+and ``inference_requests_in_progress``, driven exclusively through real HTTP
+traffic against a real ``TestClient``. Assertions compare scrape deltas
+(scrape -> act -> scrape -> compare), never absolute values.
+"""
+
+import io
+from typing import Any
+
+import numpy as np
+import pytest
+from _helpers import build_det_onnx
+from fastapi.testclient import TestClient
+from PIL import Image as PILImage
+
+from radiologist.inference import Classifier, create_app
+
+
+def _make_png_bytes(width: int = 64, height: int = 64) -> bytes:
+    arr = np.zeros((height, width, 3), dtype=np.uint8)
+    img = PILImage.fromarray(arr, mode="RGB")
+    buf = io.BytesIO()
+    img.save(buf, format="PNG")
+    return buf.getvalue()
+
+
+def _sample(body: str, name: str, **labels: str) -> float:
+    """Value of one sample line in a Prometheus exposition body, or 0.0."""
+    if labels:
+        rendered = ",".join(f'{k}="{v}"' for k, v in sorted(labels.items()))
+        prefix = f"{name}{{{rendered}}} "
+    else:
+        prefix = f"{name} "
+    for line in body.splitlines():
+        if line.startswith(prefix):
+            return float(line[len(prefix) :])
+    return 0.0
+
+
+@pytest.fixture()
+def classifier(tmp_path: Any) -> Classifier:
+    det_path = build_det_onnx(tmp_path, filename="det.onnx")
+    return Classifier.from_path(model_path=det_path)
+
+
+@pytest.fixture()
+def client(classifier: Classifier) -> TestClient:
+    return TestClient(create_app(predictor=classifier))
+
+
+class TestRequestsTotal:
+    def test_successful_prediction_is_counted_for_its_route(
+        self, client: TestClient
+    ) -> None:
+        before = _sample(
+            client.get("/metrics").text,
+            "inference_requests_total",
+            route="/predict",
+            status="200",
+        )
+        client.post(
+            "/predict",
+            files={"image": ("t.png", _make_png_bytes(), "image/png")},
+        )
+        after = _sample(
+            client.get("/metrics").text,
+            "inference_requests_total",
+            route="/predict",
+            status="200",
+        )
+        assert after - before == 1.0
+
+    def test_failed_prediction_with_no_model_is_counted_as_503(self) -> None:
+        client = TestClient(create_app(predictor=None))
+        before = _sample(
+            client.get("/metrics").text,
+            "inference_requests_total",
+            route="/predict",
+            status="503",
+        )
+        client.post(
+            "/predict",
+            files={"image": ("t.png", _make_png_bytes(), "image/png")},
+        )
+        after = _sample(
+            client.get("/metrics").text,
+            "inference_requests_total",
+            route="/predict",
+            status="503",
+        )
+        assert after - before == 1.0
+
+    def test_unknown_path_is_counted_as_unmatched(self, client: TestClient) -> None:
+        client.get("/this-route-does-not-exist")
+        body = client.get("/metrics").text
+        assert (
+            _sample(body, "inference_requests_total", route="unmatched", status="404")
+            >= 1.0
+        )
+
+    def test_healthz_and_readyz_are_counted_like_any_other_route(
+        self, client: TestClient
+    ) -> None:
+        before_health = _sample(
+            client.get("/metrics").text,
+            "inference_requests_total",
+            route="/healthz",
+            status="200",
+        )
+        before_ready = _sample(
+            client.get("/metrics").text,
+            "inference_requests_total",
+            route="/readyz",
+            status="200",
+        )
+        client.get("/healthz")
+        client.get("/readyz")
+        body = client.get("/metrics").text
+        after_health = _sample(
+            body, "inference_requests_total", route="/healthz", status="200"
+        )
+        after_ready = _sample(
+            body, "inference_requests_total", route="/readyz", status="200"
+        )
+        assert after_health - before_health == 1.0
+        assert after_ready - before_ready == 1.0
+
+
+class TestScrapeDoesNotCountItself:
+    def test_scraping_does_not_count_itself(self, client: TestClient) -> None:
+        client.get("/metrics")
+        first = client.get("/metrics").text
+        second = client.get("/metrics").text
+        for status in ("200", "404", "503"):
+            assert (
+                _sample(
+                    first, "inference_requests_total", route="/metrics", status=status
+                )
+                == 0.0
+            )
+            assert (
+                _sample(
+                    second,
+                    "inference_requests_total",
+                    route="/metrics",
+                    status=status,
+                )
+                == 0.0
+            )
+
+    def test_repeated_scrapes_do_not_move_duration_or_in_progress(
+        self, client: TestClient
+    ) -> None:
+        client.get("/metrics")
+        first = client.get("/metrics").text
+        second = client.get("/metrics").text
+        for body in (first, second):
+            assert (
+                _sample(
+                    body,
+                    "inference_request_duration_seconds_count",
+                    route="/metrics",
+                )
+                == 0.0
+            )
+            assert (
+                _sample(body, "inference_requests_in_progress", route="/metrics") == 0.0
+            )
+
+
+class TestRequestDuration:
+    def test_successful_prediction_adds_one_observation_with_positive_duration(
+        self, client: TestClient
+    ) -> None:
+        before_count = _sample(
+            client.get("/metrics").text,
+            "inference_request_duration_seconds_count",
+            route="/predict",
+        )
+        before_sum = _sample(
+            client.get("/metrics").text,
+            "inference_request_duration_seconds_sum",
+            route="/predict",
+        )
+        client.post(
+            "/predict",
+            files={"image": ("t.png", _make_png_bytes(), "image/png")},
+        )
+        body = client.get("/metrics").text
+        after_count = _sample(
+            body, "inference_request_duration_seconds_count", route="/predict"
+        )
+        after_sum = _sample(
+            body, "inference_request_duration_seconds_sum", route="/predict"
+        )
+        assert after_count - before_count == 1.0
+        assert after_sum - before_sum > 0.0
+
+
+class TestRequestsInProgress:
+    def test_gauge_is_zero_between_requests(self, client: TestClient) -> None:
+        body = client.get("/metrics").text
+        for route in ("/predict", "/healthz", "/readyz", "/explain", "/uncertainty"):
+            assert _sample(body, "inference_requests_in_progress", route=route) == 0.0
+
+    def test_gauge_is_released_after_a_failed_request(self) -> None:
+        client = TestClient(create_app(predictor=None))
+        client.post(
+            "/predict",
+            files={"image": ("t.png", _make_png_bytes(), "image/png")},
+        )
+        body = client.get("/metrics").text
+        assert _sample(body, "inference_requests_in_progress", route="/predict") == 0.0

--- a/radiologist-inference/src/radiologist/inference/app.py
+++ b/radiologist-inference/src/radiologist/inference/app.py
@@ -105,6 +105,8 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
     async def validation_exception_handler(
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
+        metrics = state_holder["metrics"]
+        metrics.observe_error(metrics.route_label(request.url.path), "validation_error")
         return JSONResponse(status_code=400, content={"detail": exc.errors()})
 
     if state_holder["metrics"].enabled:
@@ -133,6 +135,8 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
     def _get_predictor(route: Optional[str] = None) -> Any:
         p = state_holder["predictor"]
         if p is None:
+            if route is not None:
+                state_holder["metrics"].observe_error(route, "no_model_loaded")
             raise HTTPException(
                 status_code=503,
                 detail="No model loaded. Supply a predictor instance at startup.",
@@ -143,6 +147,8 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
         try:
             return PILImage.open(io.BytesIO(data)).convert("RGB")
         except UnidentifiedImageError as exc:
+            if route is not None:
+                state_holder["metrics"].observe_error(route, "invalid_image")
             raise HTTPException(
                 status_code=400, detail=f"Invalid image: {exc}"
             ) from exc
@@ -150,6 +156,7 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
     async def _handle(image: Any, method_name: str, route: str) -> Any:
         raw = await image.read()
         if not raw:
+            state_holder["metrics"].observe_error(route, "empty_file")
             raise HTTPException(status_code=400, detail="Empty image file.")
         pil_img = _load_pil(raw, route)
         p = _get_predictor(route)

--- a/radiologist-inference/src/radiologist/inference/app.py
+++ b/radiologist-inference/src/radiologist/inference/app.py
@@ -172,6 +172,8 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
             image: fastapi.UploadFile = fastapi.File(...),
         ) -> Dict[str, Any]:
             result = await _handle(image, "predict", "/predict")
+            state_holder["metrics"].observe_predicted_class(result.predicted_class)
+            state_holder["metrics"].observe_confidence(result.probabilities)
             return {
                 "probabilities": result.probabilities,
                 "predicted_class": result.predicted_class,
@@ -184,6 +186,7 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
             image: fastapi.UploadFile = fastapi.File(...),
         ) -> Dict[str, Any]:
             result = await _handle(image, "explain", "/explain")
+            state_holder["metrics"].observe_predicted_class(result.predicted_class)
             saliency: List[List[float]] = result.saliency_map.tolist()
             return {
                 "saliency_map": saliency,
@@ -197,6 +200,9 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
             image: fastapi.UploadFile = fastapi.File(...),
         ) -> Dict[str, Any]:
             result = await _handle(image, "predict_with_uncertainty", "/uncertainty")
+            state_holder["metrics"].observe_uncertainty(
+                result.predictive_entropy, result.std_per_class
+            )
             return {
                 "mean_probabilities": result.mean_probabilities,
                 "std_per_class": result.std_per_class,

--- a/radiologist-inference/src/radiologist/inference/app.py
+++ b/radiologist-inference/src/radiologist/inference/app.py
@@ -23,11 +23,13 @@
 """FastAPI application factory for the radiologist inference serving layer."""
 
 import io
+import time
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from PIL import Image as PILImage
 from PIL import UnidentifiedImageError
 
+from radiologist.inference.metrics import build_metrics
 from radiologist.inference.optional import _fastapi
 
 if TYPE_CHECKING:
@@ -78,14 +80,20 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
         RequestValidationError,  # type: ignore[import-untyped]
     )
     from starlette.requests import Request  # type: ignore[import-untyped]
-    from starlette.responses import JSONResponse  # type: ignore[import-untyped]
+    from starlette.responses import (  # type: ignore[import-untyped]
+        JSONResponse,
+        Response,
+    )
 
     from radiologist.inference.classifier import Classifier
     from radiologist.inference.explainer import Explainer
     from radiologist.inference.mc_dropout import MCDropoutPredictor
 
     app = fastapi_mod.FastAPI(title="Radiologist Inference API")
-    state_holder: Dict[str, Any] = {"predictor": predictor}
+    state_holder: Dict[str, Any] = {
+        "predictor": predictor,
+        "metrics": build_metrics(),
+    }
 
     HTTPException = fastapi_mod.HTTPException
 
@@ -98,6 +106,29 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
         request: Request, exc: RequestValidationError
     ) -> JSONResponse:
         return JSONResponse(status_code=400, content={"detail": exc.errors()})
+
+    if state_holder["metrics"].enabled:
+
+        @app.middleware("http")
+        async def _metrics_middleware(request: Request, call_next: Any) -> Any:
+            metrics = state_holder["metrics"]
+            route = metrics.route_label(request.url.path)
+            if route == "/metrics":
+                return await call_next(request)
+            metrics.track_request_start(route)
+            t0 = time.perf_counter()
+            status = 500
+            try:
+                response = await call_next(request)
+                status = response.status_code
+                return response
+            finally:
+                metrics.track_request_end(route, status, time.perf_counter() - t0)
+
+        @app.get("/metrics")
+        def metrics_endpoint() -> Any:
+            payload, content_type = state_holder["metrics"].render_latest()
+            return Response(content=payload, media_type=content_type)
 
     def _get_predictor(route: Optional[str] = None) -> Any:
         p = state_holder["predictor"]

--- a/radiologist-inference/src/radiologist/inference/app.py
+++ b/radiologist-inference/src/radiologist/inference/app.py
@@ -99,7 +99,7 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
     ) -> JSONResponse:
         return JSONResponse(status_code=400, content={"detail": exc.errors()})
 
-    def _get_predictor() -> Any:
+    def _get_predictor(route: Optional[str] = None) -> Any:
         p = state_holder["predictor"]
         if p is None:
             raise HTTPException(
@@ -108,7 +108,7 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
             )
         return p
 
-    def _load_pil(data: bytes) -> PILImage.Image:
+    def _load_pil(data: bytes, route: Optional[str] = None) -> PILImage.Image:
         try:
             return PILImage.open(io.BytesIO(data)).convert("RGB")
         except UnidentifiedImageError as exc:
@@ -116,12 +116,12 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
                 status_code=400, detail=f"Invalid image: {exc}"
             ) from exc
 
-    async def _handle(image: Any, method_name: str) -> Any:
+    async def _handle(image: Any, method_name: str, route: str) -> Any:
         raw = await image.read()
         if not raw:
             raise HTTPException(status_code=400, detail="Empty image file.")
-        pil_img = _load_pil(raw)
-        p = _get_predictor()
+        pil_img = _load_pil(raw, route)
+        p = _get_predictor(route)
         return getattr(p, method_name)(pil_img)
 
     if wire_predict:
@@ -130,7 +130,7 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
         async def predict(
             image: fastapi.UploadFile = fastapi.File(...),
         ) -> Dict[str, Any]:
-            result = await _handle(image, "predict")
+            result = await _handle(image, "predict", "/predict")
             return {
                 "probabilities": result.probabilities,
                 "predicted_class": result.predicted_class,
@@ -142,7 +142,7 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
         async def explain(
             image: fastapi.UploadFile = fastapi.File(...),
         ) -> Dict[str, Any]:
-            result = await _handle(image, "explain")
+            result = await _handle(image, "explain", "/explain")
             saliency: List[List[float]] = result.saliency_map.tolist()
             return {
                 "saliency_map": saliency,
@@ -155,7 +155,7 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
         async def uncertainty(
             image: fastapi.UploadFile = fastapi.File(...),
         ) -> Dict[str, Any]:
-            result = await _handle(image, "predict_with_uncertainty")
+            result = await _handle(image, "predict_with_uncertainty", "/uncertainty")
             return {
                 "mean_probabilities": result.mean_probabilities,
                 "std_per_class": result.std_per_class,

--- a/radiologist-inference/src/radiologist/inference/app.py
+++ b/radiologist-inference/src/radiologist/inference/app.py
@@ -159,6 +159,9 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
             state_holder["metrics"].observe_error(route, "empty_file")
             raise HTTPException(status_code=400, detail="Empty image file.")
         pil_img = _load_pil(raw, route)
+        state_holder["metrics"].observe_input_image(
+            len(raw), pil_img.width, pil_img.height
+        )
         p = _get_predictor(route)
         return getattr(p, method_name)(pil_img)
 

--- a/radiologist-inference/src/radiologist/inference/app.py
+++ b/radiologist-inference/src/radiologist/inference/app.py
@@ -117,7 +117,7 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
             route = metrics.route_label(request.url.path)
             if route == "/metrics":
                 return await call_next(request)
-            metrics.track_request_start(route)
+            metrics.observe_request_start(route)
             t0 = time.perf_counter()
             status = 500
             try:
@@ -125,7 +125,7 @@ def _build_app(fastapi_mod: Any, predictor: Optional[Any]) -> Any:  # noqa: C901
                 status = response.status_code
                 return response
             finally:
-                metrics.track_request_end(route, status, time.perf_counter() - t0)
+                metrics.observe_request_end(route, status, time.perf_counter() - t0)
 
         @app.get("/metrics")
         def metrics_endpoint() -> Any:

--- a/radiologist-inference/src/radiologist/inference/metrics.py
+++ b/radiologist-inference/src/radiologist/inference/metrics.py
@@ -158,7 +158,81 @@ class Metrics:
         Args:
             client: The imported ``prometheus_client`` module, or ``None``.
         """
-        raise NotImplementedError
+        if client is None:
+            self._enabled = False
+            return
+        self._enabled = True
+
+        self._registry = client.CollectorRegistry()
+
+        self._requests_total = client.Counter(
+            "inference_requests_total",
+            "Total number of inference API requests.",
+            ("route", "status"),
+            registry=self._registry,
+        )
+        self._request_duration_seconds = client.Histogram(
+            "inference_request_duration_seconds",
+            "Wall-clock duration of inference API requests, in seconds.",
+            ("route",),
+            buckets=DURATION_BUCKETS,
+            registry=self._registry,
+        )
+        self._requests_in_progress = client.Gauge(
+            "inference_requests_in_progress",
+            "Number of inference API requests currently being served.",
+            ("route",),
+            registry=self._registry,
+        )
+        self._errors_total = client.Counter(
+            "inference_errors_total",
+            "Total number of request-level inference errors.",
+            ("route", "error_type"),
+            registry=self._registry,
+        )
+        self._input_image_size_bytes = client.Histogram(
+            "inference_input_image_size_bytes",
+            "Size of uploaded input images, in bytes.",
+            buckets=IMAGE_SIZE_BUCKETS,
+            registry=self._registry,
+        )
+        self._input_image_width_pixels = client.Histogram(
+            "inference_input_image_width_pixels",
+            "Pre-resize width of uploaded input images, in pixels.",
+            buckets=IMAGE_DIM_BUCKETS,
+            registry=self._registry,
+        )
+        self._input_image_height_pixels = client.Histogram(
+            "inference_input_image_height_pixels",
+            "Pre-resize height of uploaded input images, in pixels.",
+            buckets=IMAGE_DIM_BUCKETS,
+            registry=self._registry,
+        )
+        self._predicted_class_total = client.Counter(
+            "inference_predicted_class_total",
+            "Total number of predictions per predicted class.",
+            ("class",),
+            registry=self._registry,
+        )
+        self._confidence = client.Histogram(
+            "inference_confidence",
+            "Maximum predicted class probability of a prediction.",
+            buckets=CONFIDENCE_BUCKETS,
+            registry=self._registry,
+        )
+        self._predictive_entropy = client.Histogram(
+            "inference_predictive_entropy",
+            "Predictive entropy of the mean MC-Dropout prediction.",
+            buckets=ENTROPY_BUCKETS,
+            registry=self._registry,
+        )
+        self._uncertainty_std_max = client.Histogram(
+            "inference_uncertainty_std_max",
+            "Maximum per-class standard deviation across MC-Dropout passes.",
+            buckets=STD_BUCKETS,
+            registry=self._registry,
+        )
+        self._client = client
 
     @property
     def enabled(self) -> bool:
@@ -170,7 +244,7 @@ class Metrics:
             whether to register the HTTP middleware and the ``GET /metrics``
             route.
         """
-        raise NotImplementedError
+        return self._enabled
 
     def route_label(self, path: str) -> str:
         """Normalize a request path to a bounded-cardinality label.
@@ -184,7 +258,7 @@ class Metrics:
             label cardinality stays bounded. Pure: returns a value even when
             disabled.
         """
-        raise NotImplementedError
+        return path if path in ROUTE_LABELS else UNMATCHED_ROUTE
 
     def track_request_start(self, route: str) -> None:
         """Record that a request has started.
@@ -195,7 +269,9 @@ class Metrics:
         Args:
             route: The bounded route label, from :meth:`route_label`.
         """
-        raise NotImplementedError
+        if not self._enabled:
+            return
+        self._requests_in_progress.labels(route=route).inc()
 
     def track_request_end(
         self, route: str, status: int, duration_seconds: float
@@ -214,7 +290,11 @@ class Metrics:
             status: The HTTP status code of the completed response.
             duration_seconds: Wall-clock duration of the request.
         """
-        raise NotImplementedError
+        if not self._enabled:
+            return
+        self._requests_in_progress.labels(route=route).dec()
+        self._requests_total.labels(route=route, status=str(status)).inc()
+        self._request_duration_seconds.labels(route=route).observe(duration_seconds)
 
     def observe_error(self, route: str, error_type: str) -> None:
         """Record a request-level error.
@@ -228,7 +308,9 @@ class Metrics:
             route: The bounded route label, from :meth:`route_label`.
             error_type: One of the closed ``ERROR_TYPES`` values.
         """
-        raise NotImplementedError
+        if not self._enabled or error_type not in ERROR_TYPES:
+            return
+        self._errors_total.labels(route=route, error_type=error_type).inc()
 
     def observe_input_image(self, size_bytes: int, width: int, height: int) -> None:
         """Record size and dimensions of an uploaded input image.
@@ -244,7 +326,11 @@ class Metrics:
             width: Pre-resize width, in pixels.
             height: Pre-resize height, in pixels.
         """
-        raise NotImplementedError
+        if not self._enabled:
+            return
+        self._input_image_size_bytes.observe(size_bytes)
+        self._input_image_width_pixels.observe(width)
+        self._input_image_height_pixels.observe(height)
 
     def observe_predicted_class(self, predicted_class: str) -> None:
         """Record the predicted class of a request.
@@ -255,7 +341,9 @@ class Metrics:
         Args:
             predicted_class: The predicted class label.
         """
-        raise NotImplementedError
+        if not self._enabled:
+            return
+        self._predicted_class_total.labels(**{"class": predicted_class}).inc()
 
     def observe_confidence(self, probabilities: Dict[str, float]) -> None:
         """Record the confidence of a prediction.
@@ -267,7 +355,9 @@ class Metrics:
         Args:
             probabilities: Per-class predicted probabilities.
         """
-        raise NotImplementedError
+        if not self._enabled or not probabilities:
+            return
+        self._confidence.observe(max(probabilities.values()))
 
     def observe_uncertainty(
         self, predictive_entropy: float, std_per_class: Dict[str, float]
@@ -285,7 +375,11 @@ class Metrics:
             predictive_entropy: Predictive entropy of the mean prediction.
             std_per_class: Per-class standard deviation across MC passes.
         """
-        raise NotImplementedError
+        if not self._enabled:
+            return
+        self._predictive_entropy.observe(predictive_entropy)
+        if std_per_class:
+            self._uncertainty_std_max.observe(max(std_per_class.values()))
 
     def render_latest(self) -> Tuple[bytes, str]:
         """Render the current scrape payload for this instance's registry.
@@ -295,7 +389,12 @@ class Metrics:
             ``(client.generate_latest(registry), client.CONTENT_TYPE_LATEST)``.
             Returns ``(b"", _PLAIN_TEXT)`` when disabled.
         """
-        raise NotImplementedError
+        if not self._enabled:
+            return b"", _PLAIN_TEXT
+        return (
+            self._client.generate_latest(self._registry),
+            self._client.CONTENT_TYPE_LATEST,
+        )
 
 
 def build_metrics() -> Metrics:
@@ -310,4 +409,4 @@ def build_metrics() -> Metrics:
         ``prometheus_client`` is importable, otherwise a no-op
         :class:`Metrics`.
     """
-    raise NotImplementedError
+    return Metrics(_prometheus_client)

--- a/radiologist-inference/src/radiologist/inference/metrics.py
+++ b/radiologist-inference/src/radiologist/inference/metrics.py
@@ -1,0 +1,313 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Prometheus instrumentation for the inference serving layer.
+
+One :class:`Metrics` instance is built per FastAPI application by
+:func:`build_metrics`, each owning a private ``CollectorRegistry``.  Every
+observer degrades to a no-op when the optional ``prometheus_client``
+dependency is absent, so callers never guard their call sites.
+"""
+
+from typing import Any, Dict, FrozenSet, Optional, Tuple
+
+from radiologist.inference.optional import _prometheus_client  # noqa: F401
+
+# --- closed label sets (real values, not stubs) ---------------------------
+
+ROUTE_LABELS: FrozenSet[str] = frozenset(
+    {"/predict", "/explain", "/uncertainty", "/healthz", "/readyz", "/metrics"}
+)
+UNMATCHED_ROUTE: str = "unmatched"
+ERROR_TYPES: FrozenSet[str] = frozenset(
+    {"invalid_image", "empty_file", "no_model_loaded", "validation_error"}
+)
+
+# --- histogram buckets (real values, not stubs) ---------------------------
+
+_INF: float = float("inf")
+
+DURATION_BUCKETS: Tuple[float, ...] = (
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+    30.0,
+    _INF,
+)
+IMAGE_SIZE_BUCKETS: Tuple[float, ...] = (
+    1e3,
+    1e4,
+    5e4,
+    1e5,
+    2.5e5,
+    5e5,
+    1e6,
+    2.5e6,
+    5e6,
+    1e7,
+    _INF,
+)
+IMAGE_DIM_BUCKETS: Tuple[float, ...] = (
+    64,
+    128,
+    224,
+    256,
+    384,
+    512,
+    768,
+    1024,
+    2048,
+    4096,
+    _INF,
+)
+CONFIDENCE_BUCKETS: Tuple[float, ...] = (
+    0.0,
+    0.1,
+    0.2,
+    0.3,
+    0.4,
+    0.5,
+    0.6,
+    0.7,
+    0.8,
+    0.9,
+    1.0,
+    _INF,
+)
+ENTROPY_BUCKETS: Tuple[float, ...] = (
+    0.0,
+    0.05,
+    0.1,
+    0.2,
+    0.3,
+    0.4,
+    0.5,
+    0.6,
+    0.693,
+    0.8,
+    1.0,
+    1.5,
+    2.0,
+    _INF,
+)
+STD_BUCKETS: Tuple[float, ...] = (
+    0.0,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.15,
+    0.2,
+    0.25,
+    0.3,
+    0.4,
+    0.5,
+    _INF,
+)
+
+_PLAIN_TEXT: str = "text/plain; charset=utf-8"
+
+
+class Metrics:
+    """Per-application Prometheus metric catalogue and recording surface.
+
+    Args:
+        client: The imported ``prometheus_client`` module, or ``None`` when the
+            optional dependency is unavailable.  When ``None`` every recording
+            method is a no-op and :meth:`render_latest` returns an empty
+            payload, so call sites never branch on availability.
+    """
+
+    def __init__(self, client: Optional[Any]) -> None:
+        """Build the metric catalogue, or disable it, for one application.
+
+        When ``client`` is ``None`` sets an internal disabled flag and builds
+        nothing. Otherwise creates a fresh ``client.CollectorRegistry()``
+        owned solely by this instance and registers all ten metric families
+        onto it. Never touches the global default registry, so constructing
+        many instances in one process can never raise "Duplicated timeseries
+        in CollectorRegistry".
+
+        Args:
+            client: The imported ``prometheus_client`` module, or ``None``.
+        """
+        raise NotImplementedError
+
+    @property
+    def enabled(self) -> bool:
+        """Report whether this instance was built with a real client.
+
+        Returns:
+            ``True`` iff this instance was built with a real
+            ``prometheus_client`` module. Read by ``_build_app`` to decide
+            whether to register the HTTP middleware and the ``GET /metrics``
+            route.
+        """
+        raise NotImplementedError
+
+    def route_label(self, path: str) -> str:
+        """Normalize a request path to a bounded-cardinality label.
+
+        Args:
+            path: The raw request path.
+
+        Returns:
+            ``path`` when it is a member of ``ROUTE_LABELS``, else
+            ``UNMATCHED_ROUTE``. Never returns caller-controlled text, so
+            label cardinality stays bounded. Pure: returns a value even when
+            disabled.
+        """
+        raise NotImplementedError
+
+    def track_request_start(self, route: str) -> None:
+        """Record that a request has started.
+
+        Increments ``inference_requests_in_progress{route}``. No-op when
+        disabled.
+
+        Args:
+            route: The bounded route label, from :meth:`route_label`.
+        """
+        raise NotImplementedError
+
+    def track_request_end(
+        self, route: str, status: int, duration_seconds: float
+    ) -> None:
+        """Record that a request has finished.
+
+        Decrements ``inference_requests_in_progress{route}``, increments
+        ``inference_requests_total{route, status=str(status)}`` by one, and
+        observes ``duration_seconds`` into
+        ``inference_request_duration_seconds{route}``. No-op when disabled.
+        Must be safe to call from a ``finally`` block after a failed
+        dispatch.
+
+        Args:
+            route: The bounded route label, from :meth:`route_label`.
+            status: The HTTP status code of the completed response.
+            duration_seconds: Wall-clock duration of the request.
+        """
+        raise NotImplementedError
+
+    def observe_error(self, route: str, error_type: str) -> None:
+        """Record a request-level error.
+
+        Increments ``inference_errors_total{route, error_type}`` by one.
+        ``error_type`` must be a member of ``ERROR_TYPES``; an unknown value
+        is silently ignored rather than raised, so instrumentation can never
+        break a request. No-op when disabled.
+
+        Args:
+            route: The bounded route label, from :meth:`route_label`.
+            error_type: One of the closed ``ERROR_TYPES`` values.
+        """
+        raise NotImplementedError
+
+    def observe_input_image(self, size_bytes: int, width: int, height: int) -> None:
+        """Record size and dimensions of an uploaded input image.
+
+        Observes one sample into each of
+        ``inference_input_image_size_bytes``,
+        ``inference_input_image_width_pixels`` and
+        ``inference_input_image_height_pixels``. ``width``/``height`` are the
+        pre-resize dimensions of the uploaded file. No-op when disabled.
+
+        Args:
+            size_bytes: Size of the uploaded file, in bytes.
+            width: Pre-resize width, in pixels.
+            height: Pre-resize height, in pixels.
+        """
+        raise NotImplementedError
+
+    def observe_predicted_class(self, predicted_class: str) -> None:
+        """Record the predicted class of a request.
+
+        Increments ``inference_predicted_class_total{class}`` by one for
+        ``predicted_class``. Unlabelled by route. No-op when disabled.
+
+        Args:
+            predicted_class: The predicted class label.
+        """
+        raise NotImplementedError
+
+    def observe_confidence(self, probabilities: Dict[str, float]) -> None:
+        """Record the confidence of a prediction.
+
+        Observes ``max(probabilities.values())`` into
+        ``inference_confidence``. Observes nothing when ``probabilities`` is
+        empty. No-op when disabled.
+
+        Args:
+            probabilities: Per-class predicted probabilities.
+        """
+        raise NotImplementedError
+
+    def observe_uncertainty(
+        self, predictive_entropy: float, std_per_class: Dict[str, float]
+    ) -> None:
+        """Record predictive uncertainty of an MC-Dropout prediction.
+
+        Observes ``predictive_entropy`` into
+        ``inference_predictive_entropy``, and
+        ``max(std_per_class.values())`` into
+        ``inference_uncertainty_std_max``. The std observation is skipped
+        when ``std_per_class`` is empty; the entropy observation is not.
+        No-op when disabled.
+
+        Args:
+            predictive_entropy: Predictive entropy of the mean prediction.
+            std_per_class: Per-class standard deviation across MC passes.
+        """
+        raise NotImplementedError
+
+    def render_latest(self) -> Tuple[bytes, str]:
+        """Render the current scrape payload for this instance's registry.
+
+        Returns:
+            A tuple of ``(exposition payload, content type)``, i.e.
+            ``(client.generate_latest(registry), client.CONTENT_TYPE_LATEST)``.
+            Returns ``(b"", _PLAIN_TEXT)`` when disabled.
+        """
+        raise NotImplementedError
+
+
+def build_metrics() -> Metrics:
+    """Build the metrics recorder for one FastAPI application.
+
+    Reads the ``_prometheus_client`` sentinel at call time (never at import
+    time) so tests may disable instrumentation with
+    ``monkeypatch.setattr`` before building an application.
+
+    Returns:
+        A :class:`Metrics` bound to a freshly created private registry when
+        ``prometheus_client`` is importable, otherwise a no-op
+        :class:`Metrics`.
+    """
+    raise NotImplementedError

--- a/radiologist-inference/src/radiologist/inference/metrics.py
+++ b/radiologist-inference/src/radiologist/inference/metrics.py
@@ -260,7 +260,7 @@ class Metrics:
         """
         return path if path in ROUTE_LABELS else UNMATCHED_ROUTE
 
-    def track_request_start(self, route: str) -> None:
+    def observe_request_start(self, route: str) -> None:
         """Record that a request has started.
 
         Increments ``inference_requests_in_progress{route}``. No-op when
@@ -273,7 +273,7 @@ class Metrics:
             return
         self._requests_in_progress.labels(route=route).inc()
 
-    def track_request_end(
+    def observe_request_end(
         self, route: str, status: int, duration_seconds: float
     ) -> None:
         """Record that a request has finished.

--- a/radiologist-inference/src/radiologist/inference/optional.py
+++ b/radiologist-inference/src/radiologist/inference/optional.py
@@ -41,3 +41,8 @@ try:
     import uvicorn as _uvicorn  # type: ignore[import-untyped]
 except ImportError:
     _uvicorn = None  # type: ignore[assignment]
+
+try:
+    import prometheus_client as _prometheus_client  # type: ignore[import-untyped]
+except ImportError:
+    _prometheus_client = None  # type: ignore[assignment]

--- a/uv.lock
+++ b/uv.lock
@@ -5231,6 +5231,7 @@ dependencies = [
 [package.optional-dependencies]
 all = [
     { name = "fastapi" },
+    { name = "prometheus-client" },
     { name = "python-multipart" },
     { name = "typer" },
     { name = "uvicorn" },
@@ -5244,6 +5245,7 @@ registry = [
 ]
 serve = [
     { name = "fastapi" },
+    { name = "prometheus-client" },
     { name = "python-multipart" },
     { name = "uvicorn" },
 ]
@@ -5255,6 +5257,8 @@ requires-dist = [
     { name = "numpy", specifier = ">=2.2.0" },
     { name = "onnxruntime", specifier = ">=1.18.0" },
     { name = "pillow", specifier = ">=12.2.0" },
+    { name = "prometheus-client", marker = "extra == 'all'", specifier = ">=0.20.0" },
+    { name = "prometheus-client", marker = "extra == 'serve'", specifier = ">=0.20.0" },
     { name = "python-multipart", marker = "extra == 'all'", specifier = ">=0.0.9" },
     { name = "python-multipart", marker = "extra == 'serve'", specifier = ">=0.0.9" },
     { name = "radiologist-registry", editable = "radiologist-registry" },


### PR DESCRIPTION
## Summary

Instruments the FastAPI inference serving app (`radiologist-inference`) with a `GET /metrics` Prometheus text exposition covering ten metric families: RED request metrics, error taxonomy, input-image characteristics, and prediction/confidence/uncertainty output metrics — all sourced from values already flowing through the existing route handlers, gated behind the `serve`/`all` extra via a `_prometheus_client` optional-dependency sentinel.

- Per-application `CollectorRegistry` (fresh per `create_app()` call) — no cross-test/cross-app contamination, no shared global registry.
- Single new module `metrics.py`: one concrete `Metrics` class (no `Protocol`/`NullObject` ceremony), real no-ops when `prometheus-client` is absent.
- Closed label sets (`route`, `error_type`) bound cardinality; `/metrics` excludes itself from its own counters.
- No new CLI flag, no predictor changes, no change to `__all__`.

## Issues closed

- Closes #153 — Inference metrics skeleton (sentinel, `Metrics` contract, extras, route plumbing)
- Closes #154 — `GET /metrics` endpoint + RED request metrics
- Closes #155 — Error taxonomy metric
- Closes #156 — Input-image metrics
- Closes #157 — Prediction, confidence and uncertainty metrics
- Closes #158 — Refactor consolidation + README documentation

## Test plan

- [x] `pytest radiologist-inference/radiologist_inference_tests` — 163 passed
- [x] `mypy radiologist-inference/src` — clean
- [x] Every pre-existing test passes unmodified
- [x] Two apps built in the same process report independently; many `create_app()` calls never raise a duplicate-timeseries error
- [x] `prometheus-client` absent → app still serves every route, `GET /metrics` returns 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)