### PR TITLE
chore(publish): use exact-match ref lookup for tag existence check

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -197,7 +197,11 @@ jobs:
           set -euo pipefail
           TAG="${{ steps.tag.outputs.name }}"
           SHA="${{ needs.resolve.outputs.sha }}"
-          if gh api "repos/${GITHUB_REPOSITORY}/git/refs/tags/${TAG}" >/dev/null 2>&1; then
+          # `git/refs/tags/{TAG}` (plural) does prefix matching: a query for
+          # "0.1.0" also matches "0.1.0-radiologist-core" and silently
+          # short-circuits tag creation. `git/ref/tags/{TAG}` (singular) only
+          # matches the exact ref.
+          if gh api "repos/${GITHUB_REPOSITORY}/git/ref/tags/${TAG}" >/dev/null 2>&1; then
             echo "Tag ${TAG} already exists — nothing to do."
             exit 0
           fi


### PR DESCRIPTION
## Summary
- The `tag` job's idempotency guard in `publish.yml` queried GitHub's plural `git/refs/tags/{TAG}` endpoint, which does prefix matching.
- Because the five member packages' tags are `0.1.0-radiologist-<name>`, a query for the root package's bare tag `0.1.0` matched those existing refs and the job concluded "already exists," silently skipping tag creation — even though `radiologist==0.1.0` had just published successfully to PyPI.
- Switches to the singular `git/ref/tags/{TAG}` endpoint, which only matches the exact ref (confirmed empirically: it 404s for `0.1.0` and 200s for `0.1.0-radiologist-core`).

## Test plan
- [x] YAML syntax validated
- [x] Confirmed via `gh api` that the singular endpoint correctly 404s for the missing `0.1.0` tag and 200s for the existing `0.1.0-radiologist-core` tag
- [ ] Once merged, manually create the missing `0.1.0` tag on the commit that already published (`bb4b542a`), since re-running the workflow would attempt to re-publish an already-uploaded version