### PR TITLE
fix(deps): cap fastapi below the version that breaks Prefect's embedded router

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,9 @@ addopts = [
     "--deselect=radiologist-core/radiologist_core_tests/test_onnx_export_callback.py::test_on_fit_end_noop_when_no_active_wandb_run",
 ]
 
+[tool.uv]
+constraint-dependencies = ["fastapi<0.116.0"]
+
 [tool.uv.build-backend]
 namespace = true
 

--- a/radiologist-etl/radiologist_etl_tests/test_prefect_engine_canary.py
+++ b/radiologist-etl/radiologist_etl_tests/test_prefect_engine_canary.py
@@ -1,0 +1,76 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Regression canary for a real (non-``.fn``) Prefect flow run.
+
+Every other Prefect-touching test in this suite deliberately bypasses
+Prefect's orchestration layer via the documented ``.fn`` escape hatch (see
+``test_prefect_pipelines.py``'s module docstring) because this environment's
+embedded local/ephemeral Prefect API server is incompatible with newer
+FastAPI internals (``AttributeError: 'PrefectRouter' object has no
+attribute 'routes'``, see GitHub issue #192). That bypass is correct for
+testing ETL business logic, but it structurally cannot catch a regression
+in the Prefect/FastAPI/Starlette dependency triangle itself, since it never
+exercises the real routing code path.
+
+This test intentionally does the opposite: it runs a trivial ``@flow`` for
+real, forcing the local/ephemeral server path, so any future dependency
+drift on this axis fails here — one clear, obviously-diagnosable test —
+instead of manifesting as confusing, unrelated-looking failures scattered
+across the suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from radiologist.etl.optional import _PREFECT_AVAILABLE
+
+pytestmark = pytest.mark.skipif(
+    not _PREFECT_AVAILABLE, reason="prefect extra not installed"
+)
+
+
+def test_real_flow_run_completes_against_local_ephemeral_server(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A real (non-``.fn``) flow run must complete and return its result.
+
+    Forces Prefect's local/ephemeral API server path by clearing
+    ``PREFECT_API_URL``/``PREFECT_API_KEY`` (rather than pointing at a real
+    backend), then invokes a trivial ``@flow``-decorated function as a
+    caller would — through Prefect's orchestration layer, not through
+    ``.fn`` — so this test genuinely exercises the routing code path that
+    broke in issue #192.
+    """
+    monkeypatch.setenv("PREFECT_API_URL", "")
+    monkeypatch.setenv("PREFECT_API_KEY", "")
+
+    from prefect import flow
+
+    @flow
+    def _trivial_flow() -> int:
+        return 1
+
+    result = _trivial_flow()
+
+    assert result == 1

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,7 @@ members = [
     "radiologist-registry",
     "radiologist-utils",
 ]
+constraints = [{ name = "fastapi", specifier = "<0.116.0" }]
 
 [[package]]
 name = "aiohappyeyeballs"
@@ -1372,18 +1373,16 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.137.1"
+version = "0.115.14"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
-    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d5/b1/e5b92c59d2c37817e77c1a8c2fc1f79cdcc04c68253e5406b43e3204cba7/fastapi-0.137.1.tar.gz", hash = "sha256:822360704230d9533d8d9475399613525968aa2f0b5bd2a3ccc9f18c88fd541c", size = 408293, upload-time = "2026-06-15T11:28:20.79Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/53/8c38a874844a8b0fa10dd8adf3836ac154082cf88d3f22b544e9ceea0a15/fastapi-0.115.14.tar.gz", hash = "sha256:b1de15cdc1c499a4da47914db35d0e4ef8f1ce62b624e94e0e5824421df99739", size = 296263, upload-time = "2025-06-26T15:29:08.21Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/da/35/380b9a5922f4340e51c309cde09e5bd32e62f02302971bee30dc15aa0624/fastapi-0.137.1-py3-none-any.whl", hash = "sha256:64f6983c59e45c4b9fdc44e57cb8035c2451ee91ea8e8ec042aca37de7cf6b69", size = 121877, upload-time = "2026-06-15T11:28:19.523Z" },
+    { url = "https://files.pythonhosted.org/packages/53/50/b1222562c6d270fea83e9c9075b8e8600b8479150a18e4516a6138b980d1/fastapi-0.115.14-py3-none-any.whl", hash = "sha256:6c0c8bf9420bd58f565e585036d971872472b4f7d3f6c73b698e10cffdefb3ca", size = 95514, upload-time = "2025-06-26T15:29:06.49Z" },
 ]
 
 [[package]]
@@ -4194,7 +4193,7 @@ wheels = [
 
 [[package]]
 name = "prefect"
-version = "3.7.4"
+version = "3.7.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiosqlite" },
@@ -4248,16 +4247,15 @@ dependencies = [
     { name = "semver" },
     { name = "sniffio" },
     { name = "sqlalchemy", extra = ["asyncio"] },
-    { name = "starlette" },
     { name = "toml" },
     { name = "typing-extensions" },
     { name = "uvicorn" },
     { name = "websockets" },
     { name = "whenever", marker = "python_full_version >= '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0a/f6/0992db98fc12ee627a8d492b2a370762b6ed8f3edcb36f78077431e8196a/prefect-3.7.4.tar.gz", hash = "sha256:65a143310a42850caa1d7f21c2d9be5dfd18ee4b7baa1ce6dd8c6b421bc3e4ea", size = 14098696, upload-time = "2026-06-05T17:52:18.752Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/72/9c43690f3041281917a35f6edcd5e4517fd64026fab3b4efff5940022775/prefect-3.7.2.tar.gz", hash = "sha256:51825cc97abe935bfaee9363c8a6a4400f30981e757d52dd0a787169b2e948ab", size = 14067456, upload-time = "2026-05-23T01:06:41.861Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/77/69/b674cc47e0f35094a44b1671ad092e243acaa75157ae84725819aeeae9c5/prefect-3.7.4-py3-none-any.whl", hash = "sha256:1ab7c5e9d418eb6e7dbb870b08704a2cce9ff054369c3bd1a9e9b0f8ec0d1257", size = 14987192, upload-time = "2026-06-05T17:52:14.651Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/2c/60db5ea3c1f2186eb840c73fe70d6721c887b4ff1b7f1e5048fe08012a7e/prefect-3.7.2-py3-none-any.whl", hash = "sha256:8a16b6de41364bc4e120c17d03fcde674d8459b38ead635762d820973047fdbc", size = 14944703, upload-time = "2026-05-23T01:06:37.648Z" },
 ]
 
 [[package]]
@@ -6459,15 +6457,14 @@ asyncio = [
 
 [[package]]
 name = "starlette"
-version = "1.3.1"
+version = "0.46.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/eb/e3/7c1dc7381d9f8ab7d854328ebfa884e62cb3f3d8549ddfd37c7814f42afa/starlette-1.3.1.tar.gz", hash = "sha256:05d0213193f2fbaae60e2ecb593b4add4262ad4e46536b54abe36f11a71724e0", size = 2703240, upload-time = "2026-06-12T09:23:11.602Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ce/20/08dfcd9c983f6a6f4a1000d934b9e6d626cff8d2eeb77a89a68eef20a2b7/starlette-0.46.2.tar.gz", hash = "sha256:7f7361f34eed179294600af672f565727419830b54b7b084efe44bb82d2fccd5", size = 2580846, upload-time = "2025-04-13T13:56:17.942Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ec/bb/2799cc2ede3ed41131f8975621e7213dfc7ef4acbbaadfa440f32500c370/starlette-1.3.1-py3-none-any.whl", hash = "sha256:c7372aae11c3c3f26a42df7bd626cec2f47d03483d261d369516a615a53714c6", size = 73632, upload-time = "2026-06-12T09:23:10.017Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/0c/9d30a4ebeb6db2b25a841afbb80f6ef9a854fc3b41be131d249a977b4959/starlette-0.46.2-py3-none-any.whl", hash = "sha256:595633ce89f8ffa71a015caed34a5b2dc1c0cdb3f0f1fbd1e69339cf2abeec35", size = 72037, upload-time = "2025-04-13T13:56:16.21Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Prefect 3.7.4's embedded local/ephemeral API server (spun up in-process whenever `PREFECT_API_URL` isn't pointed at a real backend, e.g. during local test isolation) crashes on route matching:

```
AttributeError: 'PrefectRouter' object has no attribute 'routes'. Did you mean: 'route'?
```

**Root cause** (verified by manual bisection, see #192): Prefect ships a `PrefectRouter` subclass to back this server. Somewhere between FastAPI 0.115.0 and 0.137.1, FastAPI changed its internal `APIRouter` route-matching-cache implementation to expect a `.routes` attribute — `PrefectRouter` was never updated for it. Prefect's own declared range (`fastapi<1.0.0,>=0.111.0`) is wide enough that `uv` legitimately resolves to the broken 0.137.1.

- `fastapi==0.137.1` → crashes.
- `fastapi==0.115.0` → a real (non-`.fn()`) flow run completes successfully.

## Fix

- Added `[tool.uv] constraint-dependencies = ["fastapi<0.116.0"]` to the root `pyproject.toml`, capping the transitive resolution workspace-wide without adding `fastapi` as an unnecessary direct dependency to `radiologist-etl`.
- Regenerated `uv.lock`. Resolved versions: `fastapi==0.115.14`, `starlette==0.46.2`, `prefect==3.7.2` (still satisfies `radiologist-etl`'s own `prefect>=3.7.0`).
- Added a regression canary (`radiologist-etl/radiologist_etl_tests/test_prefect_engine_canary.py`) that forces the local-server path and runs a **real** `@flow` invocation (not the `.fn()` escape hatch the rest of the suite uses) — this is the only test in the suite that would actually catch a regression of this specific bug class.

`radiologist-inference` is the only other workspace member with a direct `fastapi` dependency (`fastapi>=0.100.0`) — confirmed unaffected.

Refs #192

## Test plan
- [x] Canary test: RED confirmed pre-fix (`AttributeError` reproduced), GREEN post-fix.
- [x] `make test-inference` — 135 passed
- [x] `make test-etl` — 43 passed (includes new canary)
- [x] `make test-cli` — 79 passed
- [x] `make test` (full workspace) — 583 passed, 2 deselected (pre-existing, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)