### PR TITLE
fix(etl): correctness hardening — ten verified defects

### DIFF
--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -31,6 +31,7 @@
 - [Narrowed shared-helper signature drops params](feedback_narrowed_shared_helper_signature_drops_params.md) — a "rewire onto shared helper X" issue's literal call-signature snippet can predate optional kwargs that landed afterward; grep old call sites' full kwargs before deleting any, extend the helper instead of regressing
 - [Review-fix reverts epic seam scope creep](feedback_review_fix_reverts_epic_seam_scope_creep.md) — when a review says an internal seam leaked into `__all__`, revert both the export and the test's expected set atomically; don't just widen the test to match the leak
 - [Spawn pool test module PYTHONPATH](feedback_spawn_pool_test_module_pythonpath.md) — process-pool tests need PYTHONPATH set (not just sys.path) so spawned children can import the test module's worker function
+- [OOM kills pytest under parallel agents](feedback_oom_kills_pytest_under_parallel_agents.md) — exit 137 + empty output looks like a hang/pass; run `-u`, file-by-file, and inject a serial mapper in your own tests
 - [Docstring lint cutover scope](feedback_docstring_lint_cutover_scope.md) — a "clean" claim measured under a still-suppressed rule isn't proof the flip is clean; re-verify after; scope src-only enforcement via per-file-ignores instead of writing test docstrings
 
 - [Epic slice readonly seam reuse](feedback_epic_slice_readonly_seam_reuse.md) — verify a "already implemented, check if it's a gap" hedge by reading the file before writing extra code

--- a/.claude/agent-memory/tdd-developer/MEMORY.md
+++ b/.claude/agent-memory/tdd-developer/MEMORY.md
@@ -37,6 +37,7 @@
 - [Epic slice readonly seam reuse](feedback_epic_slice_readonly_seam_reuse.md) — verify a "already implemented, check if it's a gap" hedge by reading the file before writing extra code
 - [Third-party version string in AC](feedback_third_party_version_string_in_ac.md) — an issue's literal example of a dependency's output string can drift from the pinned lockfile version; assert against the library's own constant, not the literal
 - [Worktree venv .pth corruption risk](feedback_worktree_venv_pth_corruption_risk.md) — `uv sync/run --active` needs both `VIRTUAL_ENV` and `PATH` exported in the same Bash call or it silently rewrites the shared venv's `.pth` files
+- [Optional refactor won't-do bar](feedback_optional_refactor_wont_do_bar.md) — when an optional issue states its own "not an improvement" threshold, apply it literally and report won't-do
 - [Publish workflow resolve pattern](project_publish_workflow_resolve_pattern.md) — checkout merge_commit_sha directly (it's known pre-checkout); tomli must be explicit release-group dep on py3.10
 - [Worktree shell chaining blocked](feedback_worktree_shell_chaining_blocked.md) — worktree-isolated Bash sandbox rejects any `&&`/`;`/`$VAR` shell line; use single flat commands with an inline `VAR=val /abs/bin` prefix instead of `pyenv activate`/`eval`
 - [cz uv provider cwd-relative lockfile](feedback_cz_uv_provider_cwd_relative_lockfile.md) — commitizen's `uv` version provider resolves `uv.lock`/`pyproject.toml` against cwd only; bumping a workspace member from its own dir needs a symlinked `uv.lock`

--- a/.claude/agent-memory/tdd-developer/feedback_oom_kills_pytest_under_parallel_agents.md
+++ b/.claude/agent-memory/tdd-developer/feedback_oom_kills_pytest_under_parallel_agents.md
@@ -1,0 +1,42 @@
+---
+name: oom-kills-pytest-under-parallel-agents
+description: Pytest runs that spawn process pools get SIGKILL (exit 137) with empty output when several agents share the box; run file-by-file unbuffered and inject a serial mapper in your own tests
+metadata:
+  type: feedback
+---
+
+When several agents work concurrently in worktrees on the same machine, a
+pytest run whose tests spawn a `ProcessPoolExecutor` (here `local_mapper` with
+`default_workers() == os.cpu_count()`) is killed by the OOM killer. Symptoms
+that look like a hang or a pass but are neither:
+
+- `EXIT=137` / `Killed` from the shell, with the redirect file **empty** —
+  pytest's buffered output never flushed, so it reads as "no failures".
+- A background task reported as "completed, exit code 0" because the wrapper's
+  exit code is not the killed child's.
+- Multi-minute "hangs" at collection when the box is thrashing on swap.
+
+**Why:** peak RSS is the pytest process (~550 MB with the full ML stack) plus
+one fully-imported worker per CPU (~450 MB each). Four workers exhausts a 8 GB
+box already carrying other agents.
+
+**How to apply:**
+
+- Always run pytest with `python -u -m pytest` and redirect to a file, so
+  partial progress survives a kill and you can tell OOM from a real failure.
+- Check `free -m` before trusting a "hang"; check for `Killed`/`137` before
+  trusting a silent exit 0.
+- Run the suite **one test file at a time** rather than a whole directory —
+  bounds peak memory and localises the kill.
+- In tests you write yourself, inject the stage's `mapper` seam with a serial
+  in-process helper that calls the *real* worker. That is the injection point
+  the production API already exposes, not a mock of owned code:
+
+  ```python
+  def _serial_mapper(jobs):
+      from radiologist.etl.shards import write_shard
+      return [write_shard(job) for job in jobs]
+  ```
+
+  Pre-existing tests that use the default pool cannot be changed when the issue
+  restricts which tests you may touch — only your new ones.

--- a/.claude/agent-memory/tdd-developer/feedback_optional_refactor_wont_do_bar.md
+++ b/.claude/agent-memory/tdd-developer/feedback_optional_refactor_wont_do_bar.md
@@ -1,0 +1,31 @@
+---
+name: optional-refactor-wont-do-bar
+description: When an optional refactor issue states its own "not an improvement" threshold (e.g. max parameter count), apply it literally and report won't-do rather than forcing the extraction
+metadata:
+  type: feedback
+---
+
+When an issue is marked **optional** and its technical notes pre-commit to a
+threshold for what counts as a non-improvement ("a helper with four parameters
+and two conditional branches is not an improvement"), draft both the inline and
+the extracted version, count against that threshold, and if the extraction
+exceeds it, close as **won't-do and say so**. That is the sanctioned outcome,
+not a failure to deliver.
+
+**Why:** the architect writes these thresholds precisely because they cannot see
+the merged code at spec time and are delegating a judgement call. Forcing an
+extraction that the author already declared not-an-improvement produces churn
+and a worse call site than the duplication it replaces. The orchestrator's
+prompt may still read as directive ("your job is to extract the shared logic")
+— the *issue body* is authoritative on this point and usually also asks whether
+the predicted duplication actually materialised.
+
+**How to apply:** count the parameters the helper genuinely needs after reading
+the *merged* code, not the code the issue was written against. Sibling issues
+that landed in between routinely add axes of variation the issue did not
+predict (an extra descriptive phrase, an interposed log call), pushing a
+predicted 3-axis difference to 4+. Report the drafted helper verbatim in your
+summary so a human can overrule cheaply, and name the extra axes you found.
+
+Related: [[feedback_review_fix_reverts_epic_seam_scope_creep]],
+[[feedback_epic_seam_convention_ownership_move]].

--- a/radiologist-cli/README.md
+++ b/radiologist-cli/README.md
@@ -59,3 +59,25 @@ that stage's full composed config tree. `core` composes its config with
 Hydra directly — `radiologist core --help` prints the full composed config
 tree. Both `etl` subcommands and `core` accept `key=value` overrides and
 `--multirun` sweeps.
+
+Each `etl` subcommand's result record carries the volume and failure fields the
+stage itself computed, so a scheduler can gate the next stage on the previous
+one's output without re-deriving anything or re-reading the manifest:
+
+| Subcommand | Emitted fields |
+|---|---|
+| `extract` | `run_id`, `manifest_path`, `total`, `succeeded`, `failed`, `failure_rate`, `excluded` |
+| `assign-split` | `run_id`, `split_manifest_path`, `source_manifest_count`, `record_count`, `duplicate_count`, `counts_by_split` |
+| `build` | `run_id`, `output_dir`, `manifest_path`, `report_path`, `shard_count`, `record_count`, `failed` |
+
+`failure_rate` is `failed / total` (`0.0` when nothing was processed) — the same
+rate the extract stage's own tolerance check gates on. `counts_by_split` maps
+each configured split name to its record count and always carries one entry per
+configured ratio, including splits that received zero records, so an empty split
+is visible in the result rather than absent from it. Being a nested mapping, it
+serialises as a nested object under `--output json`/`--output yaml` and flattens
+to one dotted `counts_by_split.<split>=<count>` line per split in the default
+`key=value` format.
+
+A run that fails prints no result record at all — only `Error: {message}` on
+stderr, with the exit code described above.

--- a/radiologist-cli/README.md
+++ b/radiologist-cli/README.md
@@ -22,7 +22,7 @@ pip install radiologist-cli
 
 | Extra | Installs | Enables |
 |---|---|---|
-| `etl` | `radiologist-etl[all]` | `radiologist etl ...` |
+| `etl` | `radiologist-etl[all]` | the optional execution backends (prefect/dask/ray/beam) for `radiologist etl ...`; the group itself starts on a plain install |
 | `registry` | `radiologist-registry[all]` | `radiologist registry ...` |
 | `inference` | `radiologist-inference[all]` | `radiologist infer ...` |
 | `all` | all of the above | every command group |

--- a/radiologist-cli/radiologist_cli_tests/test_etl_command.py
+++ b/radiologist-cli/radiologist_cli_tests/test_etl_command.py
@@ -663,12 +663,14 @@ def test_build_subcommand_prints_record_with_run_id_and_counts(
         "shard_count",
         "record_count",
         "failed",
+        "failure_rate",
     }
     assert payload["shard_count"] >= 1
     # Volume and failure fields: a build that sharded nothing usable is now
     # distinguishable from a healthy one.
     assert payload["record_count"] == len(_all_image_paths(images))
     assert payload["failed"] == 0
+    assert payload["failure_rate"] == 0.0
     assert Path(payload["manifest_path"]).exists()
     assert Path(payload["report_path"]).exists()
 

--- a/radiologist-cli/radiologist_cli_tests/test_etl_command.py
+++ b/radiologist-cli/radiologist_cli_tests/test_etl_command.py
@@ -252,7 +252,7 @@ def test_help_flag_prints_usage_naming_subcommands_and_exits_zero(
 
 def test_extract_missing_file_list_exits_not_found(tmp_path: Path) -> None:
     missing = tmp_path / "does-not-exist.txt"
-    returncode, _, stderr = _run_cli_subprocess(
+    returncode, stdout, stderr = _run_cli_subprocess(
         [
             "extract",
             f"file_list={missing}",
@@ -262,13 +262,14 @@ def test_extract_missing_file_list_exits_not_found(tmp_path: Path) -> None:
     )
 
     assert returncode == 2
+    assert stdout.strip() == ""
     assert "Error: " in stderr
     assert str(missing) in stderr
 
 
 def test_assign_split_missing_manifests_dir_exits_not_found(tmp_path: Path) -> None:
     missing = tmp_path / "no-manifests-here"
-    returncode, _, stderr = _run_cli_subprocess(
+    returncode, stdout, stderr = _run_cli_subprocess(
         [
             "assign-split",
             f"manifests_dir={missing}",
@@ -278,13 +279,14 @@ def test_assign_split_missing_manifests_dir_exits_not_found(tmp_path: Path) -> N
     )
 
     assert returncode == 2
+    assert stdout.strip() == ""
     assert "Error: " in stderr
     assert str(missing) in stderr
 
 
 def test_build_missing_split_manifest_exits_not_found(tmp_path: Path) -> None:
     missing = tmp_path / "no-such-manifest.jsonl"
-    returncode, _, stderr = _run_cli_subprocess(
+    returncode, stdout, stderr = _run_cli_subprocess(
         [
             "build",
             f"split_manifest={missing}",
@@ -294,6 +296,7 @@ def test_build_missing_split_manifest_exits_not_found(tmp_path: Path) -> None:
     )
 
     assert returncode == 2
+    assert stdout.strip() == ""
     assert "Error: " in stderr
     assert str(missing) in stderr
 
@@ -340,10 +343,15 @@ def test_extract_subcommand_prints_record_with_run_id_and_counts(
         "succeeded",
         "failed",
         "excluded",
+        "failure_rate",
     }
     assert payload["total"] == len(paths)
     assert payload["succeeded"] == len(paths)
     assert payload["failed"] == 0
+    # The rate the stage itself gates on, forwarded rather than re-derived.
+    assert payload["failure_rate"] == payload["failed"] / payload["total"]
+    # Every image in the listing is readable, so nothing failed.
+    assert payload["failure_rate"] == 0.0
 
 
 def test_extract_subcommand_applies_config_overrides(
@@ -511,9 +519,82 @@ def test_assign_split_subcommand_prints_record_with_run_id_and_counts(
         "source_manifest_count",
         "record_count",
         "duplicate_count",
+        "counts_by_split",
     }
     assert payload["source_manifest_count"] == 1
     assert payload["record_count"] == 4
+    # One entry per configured split ratio, serialised as a nested object in
+    # JSON rather than flattened into dotted keys.
+    assert set(payload["counts_by_split"]) == {"train", "val", "test"}
+    assert sum(payload["counts_by_split"].values()) == payload["record_count"]
+
+
+def test_assign_split_result_counts_a_split_that_received_no_records(
+    tmp_path: Path,
+    bypass_prefect_orchestration: None,
+    clear_global_hydra: None,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """Every configured split name is keyed in the emitted per-split counts,
+    including one whose ratio sends it zero records -- an empty split is the
+    most common reason a downstream training run fails immediately, so it must
+    be visible in the result rather than absent from it."""
+    images = _build_image_tree(tmp_path)
+    manifests_dir = tmp_path / "manifests"
+    _make_extract_manifest(tmp_path, images, manifests_dir)
+
+    exit_code = etl_group.run(
+        [
+            "assign-split",
+            "--output=json",
+            f"manifests_dir={manifests_dir}",
+            f"destination={tmp_path / 'dest'}",
+            'split_ratios=[["train", 1.0], ["holdout", 0.0]]',
+            f"hydra.run.dir={tmp_path / 'hydra_run'}",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    payload = json.loads(captured.out.strip().splitlines()[-1])
+    assert payload["counts_by_split"] == {"train": 4, "holdout": 0}
+
+
+def test_assign_split_key_value_output_prints_one_line_per_split_count(
+    tmp_path: Path,
+    bypass_prefect_orchestration: None,
+    clear_global_hydra: None,
+    capsys: pytest.CaptureFixture,
+) -> None:
+    """In the default key-value format the per-split counts flatten to one
+    dotted leaf line per split name, keyed by that name."""
+    images = _build_image_tree(tmp_path)
+    manifests_dir = tmp_path / "manifests"
+    _make_extract_manifest(tmp_path, images, manifests_dir)
+
+    exit_code = etl_group.run(
+        [
+            "assign-split",
+            f"manifests_dir={manifests_dir}",
+            f"destination={tmp_path / 'dest'}",
+            f"hydra.run.dir={tmp_path / 'hydra_run'}",
+        ]
+    )
+
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    lines = captured.out.strip().splitlines()
+    split_lines = {
+        line.split("=", 1)[0]: line.split("=", 1)[1]
+        for line in lines
+        if line.startswith("counts_by_split.")
+    }
+    assert set(split_lines) == {
+        "counts_by_split.train",
+        "counts_by_split.val",
+        "counts_by_split.test",
+    }
+    assert sum(int(value) for value in split_lines.values()) == 4
 
 
 def test_assign_split_subcommand_applies_config_overrides(
@@ -580,8 +661,14 @@ def test_build_subcommand_prints_record_with_run_id_and_counts(
         "manifest_path",
         "report_path",
         "shard_count",
+        "record_count",
+        "failed",
     }
     assert payload["shard_count"] >= 1
+    # Volume and failure fields: a build that sharded nothing usable is now
+    # distinguishable from a healthy one.
+    assert payload["record_count"] == len(_all_image_paths(images))
+    assert payload["failed"] == 0
     assert Path(payload["manifest_path"]).exists()
     assert Path(payload["report_path"]).exists()
 

--- a/radiologist-cli/radiologist_cli_tests/test_optional_require.py
+++ b/radiologist-cli/radiologist_cli_tests/test_optional_require.py
@@ -51,13 +51,26 @@ class TestRequire:
 
         assert "pip install 'radiologist-cli[inference]'" in str(excinfo.value)
 
-    def test_raises_cli_hint_not_business_hint_when_etl_feature_sentinel_missing(
+    def test_returns_the_etl_module_when_prefect_is_unavailable(
         self, monkeypatch
     ) -> None:
+        """The ``etl`` group gates on module importability only: prefect is an
+        optional execution backend, not a precondition for starting the group.
+        """
+        import radiologist.etl as etl_module
         from radiologist.cli.optional import require
         from radiologist.etl import optional as etl_optional
 
         monkeypatch.setattr(etl_optional, "_PREFECT_AVAILABLE", False)
+
+        assert require("etl") is etl_module
+
+    def test_raises_cli_hint_when_the_etl_package_is_absent(self, monkeypatch) -> None:
+        import radiologist.cli.optional as optional
+
+        monkeypatch.setattr(optional, "_etl", None)
+
+        from radiologist.cli.optional import require
 
         with pytest.raises(RuntimeError) as excinfo:
             require("etl")
@@ -65,6 +78,25 @@ class TestRequire:
         message = str(excinfo.value)
         assert "pip install 'radiologist-cli[etl]'" in message
         assert "radiologist-etl" not in message
+
+    def test_etl_group_dispatches_and_prints_usage_when_prefect_is_unavailable(
+        self, monkeypatch, capsys
+    ) -> None:
+        """End-to-end consequence of the relaxed gate: ``radiologist etl`` with
+        no subcommand reaches the group and prints its own usage line instead
+        of refusing to start."""
+        import radiologist.cli.groups.etl as etl_group
+        from radiologist.cli.main import run_group
+        from radiologist.etl import optional as etl_optional
+
+        monkeypatch.setattr(etl_optional, "_PREFECT_AVAILABLE", False)
+
+        exit_code = run_group("etl", [])
+
+        captured = capsys.readouterr()
+        assert exit_code != 0
+        for subcommand in etl_group.SUBCOMMANDS:
+            assert subcommand in captured.err
 
     def test_raises_cli_hint_not_business_hint_when_registry_feature_sentinel_missing(
         self, monkeypatch

--- a/radiologist-cli/src/radiologist/cli/groups/etl.py
+++ b/radiologist-cli/src/radiologist/cli/groups/etl.py
@@ -109,6 +109,7 @@ def extract_main(cfg: DictConfig) -> None:
             "total": result.total,
             "succeeded": result.succeeded,
             "failed": result.failed,
+            "failure_rate": result.failure_rate,
             "excluded": result.excluded,
         }
     )
@@ -142,6 +143,7 @@ def assign_split_main(cfg: DictConfig) -> None:
             "source_manifest_count": result.source_manifest_count,
             "record_count": result.record_count,
             "duplicate_count": result.duplicate_count,
+            "counts_by_split": result.counts_by_split,
         }
     )
 
@@ -174,6 +176,8 @@ def build_main(cfg: DictConfig) -> None:
             "manifest_path": result.manifest_path,
             "report_path": result.report_path,
             "shard_count": result.shard_count,
+            "record_count": result.record_count,
+            "failed": result.failed,
         }
     )
 

--- a/radiologist-cli/src/radiologist/cli/groups/etl.py
+++ b/radiologist-cli/src/radiologist/cli/groups/etl.py
@@ -178,6 +178,7 @@ def build_main(cfg: DictConfig) -> None:
             "shard_count": result.shard_count,
             "record_count": result.record_count,
             "failed": result.failed,
+            "failure_rate": result.failure_rate,
         }
     )
 

--- a/radiologist-cli/src/radiologist/cli/optional.py
+++ b/radiologist-cli/src/radiologist/cli/optional.py
@@ -65,8 +65,7 @@ def require(extra: str) -> ModuleType:
     Raises:
         RuntimeError: When the module is absent, or when its feature-level
             sentinel is unavailable (``registry`` ->
-            ``radiologist.registry.optional._wandb``, ``etl`` ->
-            ``radiologist.etl.optional._PREFECT_AVAILABLE``,
+            ``radiologist.registry.optional._wandb``; ``etl`` and
             ``inference`` -> module importability only), naming
             ``pip install 'radiologist-cli[<extra>]'``.
     """
@@ -75,12 +74,7 @@ def require(extra: str) -> ModuleType:
     if module is None:
         raise RuntimeError(hint)
 
-    if extra == "etl":
-        from radiologist.etl import optional as etl_optional
-
-        if not etl_optional._PREFECT_AVAILABLE:
-            raise RuntimeError(hint)
-    elif extra == "registry":
+    if extra == "registry":
         from radiologist.registry import optional as registry_optional
 
         if registry_optional._wandb is None:

--- a/radiologist-etl/README.md
+++ b/radiologist-etl/README.md
@@ -173,6 +173,7 @@ Common ones:
 | `assign-split` | `split_ratios` | `[[train,.70],[val,.15],[test,.15]]` | Ordered split contract |
 | `build` | `split_manifest` | required | Manifest produced by `assign-split` |
 | `build` | `shard_size` | `1000` | Max images per tar shard |
+| `build` | `max_failure_rate` | `0.0` | Unshardable-record tolerance before the run fails |
 | `build` | `runner` | `local` | Execution backend (see below) |
 
 ### Execution runners

--- a/radiologist-etl/README.md
+++ b/radiologist-etl/README.md
@@ -165,7 +165,7 @@ Common ones:
 | Subcommand | Key | Default | Description |
 |---|---|---|---|
 | `extract` | `file_list` | required | Newline-delimited listing of image URIs |
-| `extract` | `masks_root` | `null` | Segmentation mask directory |
+| `extract` | `masks_root` | `null` | Segmentation mask directory; requires `images_root`, which is used to mirror each image's relative path under it. Setting it without `images_root` is rejected immediately with a `ValueError` naming both, before any image is read. |
 | `extract` | `iqr_factor` | `1.5` | IQR multiplier for outlier threshold |
 | `extract` | `max_failure_rate` | `0.0` | Unreadable-image tolerance before the run fails |
 | `extract` | `runner` | `local` | Execution backend (see below) |

--- a/radiologist-etl/README.md
+++ b/radiologist-etl/README.md
@@ -169,7 +169,7 @@ Common ones:
 | `extract` | `iqr_factor` | `1.5` | IQR multiplier for outlier threshold |
 | `extract` | `max_failure_rate` | `0.0` | Unreadable-image tolerance before the run fails |
 | `extract` | `runner` | `local` | Execution backend (see below) |
-| `assign-split` | `manifests_dir` | required | Folder of extract manifests to merge |
+| `assign-split` | `manifests_dir` | required | Folder of extract manifests to merge. Only files whose name starts with `extract-` and ends in `.jsonl` are selected — any other file, including a split manifest written by a previous run, is ignored, so `destination` may equal `manifests_dir` |
 | `assign-split` | `split_ratios` | `[[train,.70],[val,.15],[test,.15]]` | Ordered split contract |
 | `build` | `split_manifest` | required | Manifest produced by `assign-split` |
 | `build` | `shard_size` | `1000` | Max images per tar shard |

--- a/radiologist-etl/README.md
+++ b/radiologist-etl/README.md
@@ -244,4 +244,4 @@ the execution backends above). The CLI entry points live in
 
 Core: `radiologist-utils`, `fsspec`, `gcsfs`, `numpy`, `Pillow`, `scikit-image`, `pandas`, `pyarrow`, `webdataset`.
 
-Optional: `prefect` (orchestration, install via `--extra prefect`). When not installed, `@flow` and `@task` are identity decorators and the pipeline runs as plain Python. `dask`/`ray`/`beam` extras add the corresponding execution runner backend.
+Optional: `prefect` (orchestration, install via `--extra prefect`). When not installed, `@flow` and `@task` are identity decorators and the pipeline runs as plain Python. The default `local` runner requires no extra: without prefect it resolves to an execution plan carrying no task runner, so all three stages run on a plain, no-extras install. `dask`/`ray`/`beam` extras add the corresponding execution runner backend; only those three families can be reported unavailable, and the error names the extra to install.

--- a/radiologist-etl/radiologist_etl_tests/test_assign_split_stage.py
+++ b/radiologist-etl/radiologist_etl_tests/test_assign_split_stage.py
@@ -464,3 +464,87 @@ class TestReportingAndReadability:
             result.split_manifest_path, storage_options={"auto_mkdir": True}
         )
         assert len(written) == 1
+
+
+class TestAssignSplitsInputIdentity:
+    def test_a_byte_identical_manifests_folder_elsewhere_yields_the_same_run_id(
+        self, tmp_path: Path
+    ) -> None:
+        from radiologist.etl import assign_splits
+
+        records = [
+            _make_record("/d/a.png", "a.png"),
+            _make_record("/d/b.png", "b.png"),
+        ]
+        run_ids = []
+        manifest_names = []
+        for location in ("here", "somewhere/deeper/else"):
+            manifests_dir = tmp_path / location / "manifests"
+            manifests_dir.mkdir(parents=True)
+            _write_manifest(manifests_dir, "extract-0001.jsonl", records)
+            result = assign_splits(str(manifests_dir), str(tmp_path / location / "out"))
+            run_ids.append(result.run_id)
+            manifest_names.append(Path(result.split_manifest_path).name)
+
+        assert run_ids[0] == run_ids[1]
+        assert manifest_names[0] == manifest_names[1]
+
+    def test_a_jsonl_file_without_the_extract_prefix_is_not_a_source_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        from radiologist.etl import assign_splits, records_reader
+
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+        dest_dir = tmp_path / "out"
+        _write_manifest(
+            manifests_dir, "extract-0001.jsonl", [_make_record("/d/a.png", "a.png")]
+        )
+        before = assign_splits(str(manifests_dir), str(dest_dir))
+
+        _write_manifest(
+            manifests_dir, "manifest-cafe.jsonl", [_make_record("/d/z.png", "z.png")]
+        )
+        after = assign_splits(str(manifests_dir), str(dest_dir))
+
+        assert after.run_id == before.run_id
+        assert after.source_manifest_count == 1
+        written = records_reader(after.split_manifest_path)
+        assert {r.path for r in written} == {"/d/a.png"}
+
+    def test_rerunning_in_place_is_stable_and_leaves_one_split_manifest(
+        self, tmp_path: Path
+    ) -> None:
+        from radiologist.etl import assign_splits
+
+        folder = tmp_path / "manifests"
+        folder.mkdir()
+        _write_manifest(
+            folder,
+            "extract-0001.jsonl",
+            [_make_record("/d/a.png", "a.png"), _make_record("/d/b.png", "b.png")],
+        )
+
+        first = assign_splits(str(folder), str(folder))
+        second = assign_splits(str(folder), str(folder))
+
+        assert second.run_id == first.run_id
+        assert second.source_manifest_count == first.source_manifest_count
+        assert second.record_count == first.record_count
+        assert sorted(p.name for p in folder.glob("manifest-*.jsonl")) == [
+            "manifest-" + first.run_id + ".jsonl"
+        ]
+
+    def test_a_folder_of_only_non_extract_jsonl_files_raises_naming_the_folder(
+        self, tmp_path: Path
+    ) -> None:
+        from radiologist.etl import assign_splits
+
+        manifests_dir = tmp_path / "manifests"
+        manifests_dir.mkdir()
+        _write_manifest(
+            manifests_dir, "manifest-cafe.jsonl", [_make_record("/d/z.png", "z.png")]
+        )
+
+        with pytest.raises(FileNotFoundError, match="manifests"):
+            assign_splits(str(manifests_dir), str(tmp_path / "out"))

--- a/radiologist-etl/radiologist_etl_tests/test_beam_executor.py
+++ b/radiologist-etl/radiologist_etl_tests/test_beam_executor.py
@@ -296,6 +296,41 @@ def test_run_shards_returns_one_outcome_per_job_in_input_order(
     assert all(o.written == 1 for o in outcomes)
 
 
+def test_run_shards_records_the_same_shard_path_as_local_dispatch_for_empty_split(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    from radiologist.etl import write_shard
+
+    records = [
+        ManifestRecord(
+            manifest_id="assignrun0000001",
+            path=str(p),
+            filename=p.name,
+            label=p.parent.name,
+            split="",
+            stats={},
+        )
+        for p in sorted(image_dir.rglob("*.png"))
+    ]
+    beam_root = tmp_path / "beam-shards"
+    local_root = tmp_path / "local-shards"
+
+    executor = _direct_executor(tmp_path / "parts")
+    beam_outcomes = executor.run_shards(
+        plan_shards(records, str(beam_root), shard_size=1)
+    )
+    local_outcomes = [
+        write_shard(job) for job in plan_shards(records, str(local_root), shard_size=1)
+    ]
+
+    assert [o.relative_path for o in beam_outcomes] == [
+        o.relative_path for o in local_outcomes
+    ]
+    assert beam_outcomes
+    for outcome in beam_outcomes:
+        assert (beam_root / outcome.relative_path).is_file()
+
+
 def test_parts_from_an_earlier_run_do_not_affect_a_later_run_over_other_inputs(
     image_dir: Path, tmp_path: Path
 ) -> None:

--- a/radiologist-etl/radiologist_etl_tests/test_beam_executor.py
+++ b/radiologist-etl/radiologist_etl_tests/test_beam_executor.py
@@ -30,6 +30,7 @@ must reject a parts location the workers could not reach.
 
 from __future__ import annotations
 
+import logging
 import tarfile
 from pathlib import Path
 
@@ -146,6 +147,15 @@ def _shard_contents(output_dir: str) -> dict:
     return contents
 
 
+def _scratch_files(parts_dir: Path) -> list:
+    """Every file left under the configured scratch directory, if it exists."""
+    if not parts_dir.exists():
+        return []
+    return sorted(
+        str(p.relative_to(parts_dir)) for p in parts_dir.rglob("*") if p.is_file()
+    )
+
+
 class _CountingBeamExecutor(BeamExecutor):
     """A real executor that also records how many times it was dispatched to."""
 
@@ -156,6 +166,31 @@ class _CountingBeamExecutor(BeamExecutor):
     def run_batches(self, *args, **kwargs):  # type: ignore[no-untyped-def]
         self.run_batches_calls += 1
         return super().run_batches(*args, **kwargs)
+
+
+class _LosingBeamExecutor(BeamExecutor):
+    """A real executor that loses a part between the pipeline and the read-back.
+
+    Reproduces the "pipeline reported success but wrote no part" failure
+    without touching how outcomes are written or read.
+    """
+
+    def _run_pipeline(self, label, elements, fn, **fn_kwargs):  # type: ignore[no-untyped-def] # noqa: E501
+        super()._run_pipeline(label, elements, fn, **fn_kwargs)
+        prefix = Path(fn_kwargs["parts_prefix"])
+        sorted(prefix.glob("part-*.jsonl"))[-1].unlink()
+
+
+class _SealingBeamExecutor(BeamExecutor):
+    """A real executor that makes its scratch directory unwritable once run.
+
+    The prefix underneath it can then no longer be unlinked, so reclamation
+    genuinely fails at the filesystem level.
+    """
+
+    def _run_pipeline(self, label, elements, fn, **fn_kwargs):  # type: ignore[no-untyped-def] # noqa: E501
+        super()._run_pipeline(label, elements, fn, **fn_kwargs)
+        Path(self.parts_dir).chmod(0o500)
 
 
 # --- runner selection --------------------------------------------------------
@@ -464,3 +499,135 @@ def test_a_beam_backed_extract_is_dispatched_as_a_single_unit_of_work(
 
     assert result.succeeded == len(paths)
     assert executor.run_batches_calls == 1
+
+
+# --- scratch reclamation -----------------------------------------------------
+
+
+def test_a_successful_batch_dispatch_leaves_no_scratch_behind(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    parts_dir = tmp_path / "parts"
+    executor = _direct_executor(parts_dir)
+    paths = _all_image_paths(image_dir)
+
+    outcomes = executor.run_batches(
+        [[p] for p in paths],
+        images_root=None,
+        masks_root=None,
+        manifest_id="beamrun000000001",
+        extractors=[],
+    )
+
+    assert [[r.path for r in o.records] for o in outcomes] == [[p] for p in paths]
+    assert [o.failures for o in outcomes] == [[] for _ in paths]
+    assert _scratch_files(parts_dir) == []
+
+
+def test_a_successful_shard_dispatch_leaves_no_scratch_behind(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    parts_dir = tmp_path / "parts"
+    executor = _direct_executor(parts_dir)
+    jobs = plan_shards(
+        _split_records(image_dir), str(tmp_path / "shards"), shard_size=1
+    )
+
+    outcomes = executor.run_shards(jobs)
+
+    assert [o.relative_path for o in outcomes] == [
+        f"{job.split}/{job.label}/{job.split}-{job.label.lower()}-{job.index:06d}.tar"
+        for job in jobs
+    ]
+    assert _scratch_files(parts_dir) == []
+
+
+def test_two_successive_dispatches_leave_no_scratch_behind(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    parts_dir = tmp_path / "parts"
+    executor = _direct_executor(parts_dir)
+    paths = _all_image_paths(image_dir)
+
+    executor.run_batches(
+        [paths[:2], paths[2:]],
+        images_root=None,
+        masks_root=None,
+        manifest_id="first-run-00000",
+        extractors=[],
+    )
+    second = executor.run_batches(
+        [paths[:1]],
+        images_root=None,
+        masks_root=None,
+        manifest_id="second-run-0000",
+        extractors=[],
+    )
+
+    assert [r.path for r in second[0].records] == paths[:1]
+    assert _scratch_files(parts_dir) == []
+
+
+def test_a_dispatch_missing_an_outcome_still_raises_and_still_reclaims_scratch(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    parts_dir = tmp_path / "parts"
+    executor = _LosingBeamExecutor(
+        pipeline_options={"runner": "DirectRunner"}, parts_dir=str(parts_dir)
+    )
+    paths = _all_image_paths(image_dir)
+
+    with pytest.raises(RuntimeError, match="wrote no part for unit"):
+        executor.run_batches(
+            [[p] for p in paths],
+            images_root=None,
+            masks_root=None,
+            manifest_id="beamrun000000001",
+            extractors=[],
+        )
+
+    assert _scratch_files(parts_dir) == []
+
+
+def test_scratch_that_cannot_be_removed_warns_and_still_returns_its_outcomes(
+    image_dir: Path, tmp_path: Path, caplog: pytest.LogCaptureFixture
+) -> None:
+    parts_dir = tmp_path / "parts"
+    executor = _SealingBeamExecutor(
+        pipeline_options={"runner": "DirectRunner"}, parts_dir=str(parts_dir)
+    )
+    paths = _all_image_paths(image_dir)
+
+    try:
+        with caplog.at_level(logging.WARNING):
+            outcomes = executor.run_batches(
+                [[p] for p in paths],
+                images_root=None,
+                masks_root=None,
+                manifest_id="beamrun000000001",
+                extractors=[],
+            )
+    finally:
+        parts_dir.chmod(0o755)
+
+    assert [[r.path for r in o.records] for o in outcomes] == [[p] for p in paths]
+    warnings = [r.getMessage() for r in caplog.records if r.levelno == logging.WARNING]
+    assert any(f"{parts_dir}/batches-" in message for message in warnings)
+
+
+def test_a_dispatch_of_no_units_creates_no_scratch_prefix(tmp_path: Path) -> None:
+    parts_dir = tmp_path / "parts"
+    executor = _direct_executor(parts_dir)
+
+    assert (
+        executor.run_batches(
+            [],
+            images_root=None,
+            masks_root=None,
+            manifest_id="beamrun000000001",
+            extractors=[],
+        )
+        == []
+    )
+    assert executor.run_shards([]) == []
+    assert not parts_dir.exists()

--- a/radiologist-etl/radiologist_etl_tests/test_build.py
+++ b/radiologist-etl/radiologist_etl_tests/test_build.py
@@ -540,6 +540,27 @@ def test_build_failure_message_names_every_unreadable_source_path(
     assert gone_b in message
 
 
+def test_build_failure_message_caps_the_enumerated_failures(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import BuildFailureError, build_shards
+
+    records = [
+        _record(str(tmp_path / f"gone_{i}.png"), f"gone_{i}.png", "NORMAL", "train")
+        for i in range(25)
+    ]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    with pytest.raises(BuildFailureError) as excinfo:
+        build_shards(manifest_path, str(tmp_path / "shards"), mapper=_serial_mapper)
+
+    message = str(excinfo.value)
+    assert str(tmp_path / "gone_0.png") in message
+    assert str(tmp_path / "gone_19.png") in message
+    assert str(tmp_path / "gone_20.png") not in message
+    assert "and 5 more" in message
+
+
 def test_no_manifest_and_no_report_are_written_when_the_run_is_failed(
     tmp_path: Path,
 ) -> None:

--- a/radiologist-etl/radiologist_etl_tests/test_build.py
+++ b/radiologist-etl/radiologist_etl_tests/test_build.py
@@ -66,6 +66,13 @@ def _make_split_manifest(root: Path, records: list[ManifestRecord]) -> str:
     return path
 
 
+def _serial_mapper(jobs):
+    """Run the real shard writer in-process, avoiding a process pool."""
+    from radiologist.etl.shards import write_shard
+
+    return [write_shard(job) for job in jobs]
+
+
 def _tar_members(tar_path: str) -> list[str]:
     with tarfile.open(tar_path) as tf:
         return [m.name for m in tf.getmembers()]
@@ -473,20 +480,286 @@ def test_shard_size_below_one_raises_value_error(tmp_path: Path) -> None:
         build_shards(manifest_path, str(tmp_path / "shards"), shard_size=0)
 
 
-def test_unreadable_image_is_reported_as_failure_not_written_as_shard_entry(
+# --- shard-write failure surfacing and gating ----------------------------------
+
+
+def test_fully_readable_manifest_reports_no_failures(tmp_path: Path) -> None:
+    from radiologist.etl.build import build_shards
+
+    path_a = _make_png(tmp_path, "a.png", "NORMAL")
+    records = [_record(path_a, "a.png", "NORMAL", "train")]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    result = build_shards(
+        manifest_path, str(tmp_path / "shards"), mapper=_serial_mapper
+    )
+
+    assert result.failed == 0
+    assert result.failure_rate == 0.0
+    assert result.record_count == 1
+    assert result.shard_count == 1
+
+
+def test_unreadable_image_under_default_tolerance_raises_naming_counts_and_rates(
     tmp_path: Path,
 ) -> None:
-    from radiologist.etl.build import build_shards
+    from radiologist.etl.build import BuildFailureError, build_shards
 
     missing_path = str(tmp_path / "gone.png")
     records = [_record(missing_path, "gone.png", "NORMAL", "train")]
     manifest_path = _make_split_manifest(tmp_path, records)
 
-    result = build_shards(manifest_path, str(tmp_path / "shards"))
+    with pytest.raises(BuildFailureError) as excinfo:
+        build_shards(manifest_path, str(tmp_path / "shards"), mapper=_serial_mapper)
 
-    assert result.record_count == 0
+    message = str(excinfo.value)
+    assert "1/1" in message
+    assert "100.00%" in message
+    assert "0.00%" in message
+    assert "max_failure_rate" in message
+
+
+def test_build_failure_message_names_every_unreadable_source_path(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import BuildFailureError, build_shards
+
+    gone_a = str(tmp_path / "gone_a.png")
+    gone_b = str(tmp_path / "gone_b.png")
+    records = [
+        _record(gone_a, "gone_a.png", "NORMAL", "train"),
+        _record(gone_b, "gone_b.png", "NORMAL", "train"),
+    ]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    with pytest.raises(BuildFailureError) as excinfo:
+        build_shards(manifest_path, str(tmp_path / "shards"), mapper=_serial_mapper)
+
+    message = str(excinfo.value)
+    assert gone_a in message
+    assert gone_b in message
+
+
+def test_no_manifest_and_no_report_are_written_when_the_run_is_failed(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import BuildFailureError, build_shards
+
+    missing_path = str(tmp_path / "gone.png")
+    records = [_record(missing_path, "gone.png", "NORMAL", "train")]
+    manifest_path = _make_split_manifest(tmp_path, records)
+    shard_root = tmp_path / "shards"
+
+    with pytest.raises(BuildFailureError):
+        build_shards(manifest_path, str(shard_root), mapper=_serial_mapper)
+
+    assert list(shard_root.rglob("manifest-*.jsonl")) == []
+    assert list(shard_root.rglob("split-report-*.json")) == []
+
+
+def test_tolerated_failures_are_counted_against_the_records_planned_into_shards(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import build_shards
+
+    ok_a = _make_png(tmp_path, "a.png", "NORMAL")
+    ok_b = _make_png(tmp_path, "b.png", "NORMAL")
+    ok_c = _make_png(tmp_path, "c.png", "NORMAL")
+    gone = str(tmp_path / "gone.png")
+    records = [
+        _record(ok_a, "a.png", "NORMAL", "train"),
+        _record(ok_b, "b.png", "NORMAL", "train"),
+        _record(ok_c, "c.png", "NORMAL", "train"),
+        _record(gone, "gone.png", "NORMAL", "train"),
+    ]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    result = build_shards(
+        manifest_path,
+        str(tmp_path / "shards"),
+        mapper=_serial_mapper,
+        max_failure_rate=0.5,
+    )
+
+    assert result.failed == 1
+    assert result.failure_rate == pytest.approx(0.25)
+
+
+def test_no_manifest_record_is_both_non_excluded_and_shard_less(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import build_shards
+
+    ok_a = _make_png(tmp_path, "a.png", "NORMAL")
+    gone = str(tmp_path / "gone.png")
+    records = [
+        _record(ok_a, "a.png", "NORMAL", "train"),
+        _record(gone, "gone.png", "NORMAL", "train"),
+    ]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    result = build_shards(
+        manifest_path,
+        str(tmp_path / "shards"),
+        mapper=_serial_mapper,
+        max_failure_rate=0.5,
+    )
+
     out_records = records_reader(result.manifest_path)
-    assert out_records[0].shard is None
+    assert out_records
+    assert all(r.excluded or r.shard is not None for r in out_records)
+
+
+def test_record_that_could_not_be_written_carries_the_shard_write_failed_reason(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import build_shards
+
+    ok_a = _make_png(tmp_path, "a.png", "NORMAL")
+    gone = str(tmp_path / "gone.png")
+    records = [
+        _record(ok_a, "a.png", "NORMAL", "train"),
+        _record(gone, "gone.png", "NORMAL", "train"),
+    ]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    result = build_shards(
+        manifest_path,
+        str(tmp_path / "shards"),
+        mapper=_serial_mapper,
+        max_failure_rate=0.5,
+    )
+
+    out_records = records_reader(result.manifest_path)
+    failed_record = next(r for r in out_records if r.filename == "gone.png")
+    assert failed_record.excluded is True
+    assert "shard_write_failed" in failed_record.exclusion_reason
+
+
+def test_already_excluded_record_keeps_its_reason_alongside_shard_write_failed(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import build_shards
+
+    gone = str(tmp_path / "gone.png")
+    already = ManifestRecord(
+        manifest_id="assignrun00000001",
+        path=gone,
+        filename="gone.png",
+        label="NORMAL",
+        split="train",
+        stats={},
+        excluded=True,
+        exclusion_reason="lung_out_of_frame",
+    )
+    records = [
+        _record(gone, "gone.png", "NORMAL", "train"),
+        already,
+    ]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    result = build_shards(
+        manifest_path,
+        str(tmp_path / "shards"),
+        mapper=_serial_mapper,
+        max_failure_rate=1.0,
+    )
+
+    out_records = records_reader(result.manifest_path)
+    reasons = {r.exclusion_reason for r in out_records}
+    assert "lung_out_of_frame|shard_write_failed" in reasons
+
+
+def test_split_report_excluded_count_includes_records_that_failed_to_be_written(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import build_shards
+
+    ok_a = _make_png(tmp_path, "a.png", "NORMAL")
+    gone = str(tmp_path / "gone.png")
+    records = [
+        _record(ok_a, "a.png", "NORMAL", "train"),
+        _record(gone, "gone.png", "NORMAL", "train"),
+    ]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    result = build_shards(
+        manifest_path,
+        str(tmp_path / "shards"),
+        mapper=_serial_mapper,
+        max_failure_rate=0.5,
+    )
+
+    report = json.loads(Path(result.report_path).read_text())
+    assert report["observed"]["NORMAL"]["excluded"] == pytest.approx(0.5)
+
+
+def test_manifest_of_only_excluded_records_reports_zero_failure_rate_and_succeeds(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import build_shards
+
+    path_a = _make_png(tmp_path, "a.png", "NORMAL")
+    records = [_record(path_a, "a.png", "NORMAL", "train", excluded=True)]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    result = build_shards(
+        manifest_path, str(tmp_path / "shards"), mapper=_serial_mapper
+    )
+
+    assert result.failed == 0
+    assert result.failure_rate == 0.0
+
+
+def test_two_different_tolerances_produce_the_same_run_id_and_output_folder(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.build import build_shards
+
+    path_a = _make_png(tmp_path, "a.png", "NORMAL")
+    records = [_record(path_a, "a.png", "NORMAL", "train")]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    result1 = build_shards(
+        manifest_path,
+        str(tmp_path / "shards"),
+        mapper=_serial_mapper,
+        max_failure_rate=0.0,
+    )
+    result2 = build_shards(
+        manifest_path,
+        str(tmp_path / "shards"),
+        mapper=_serial_mapper,
+        max_failure_rate=0.9,
+    )
+
+    assert result1.run_id == result2.run_id
+    assert result1.output_dir == result2.output_dir
+
+
+def test_tolerated_failures_emit_a_warning_naming_the_failure_count(
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    from radiologist.etl.build import build_shards
+
+    ok_a = _make_png(tmp_path, "a.png", "NORMAL")
+    gone = str(tmp_path / "gone.png")
+    records = [
+        _record(ok_a, "a.png", "NORMAL", "train"),
+        _record(gone, "gone.png", "NORMAL", "train"),
+    ]
+    manifest_path = _make_split_manifest(tmp_path, records)
+
+    with caplog.at_level("WARNING", logger="radiologist.etl.build"):
+        build_shards(
+            manifest_path,
+            str(tmp_path / "shards"),
+            mapper=_serial_mapper,
+            max_failure_rate=0.5,
+        )
+
+    assert any("1" in rec.getMessage() for rec in caplog.records)
 
 
 # --- storage options -----------------------------------------------------------

--- a/radiologist-etl/radiologist_etl_tests/test_execution.py
+++ b/radiologist-etl/radiologist_etl_tests/test_execution.py
@@ -372,3 +372,152 @@ def test_storage_options_from_cfg_returns_plain_dict_for_populated_options():
     cfg = OmegaConf.create({"storage_options": {"key": "abc123"}})
 
     assert storage_options_from_cfg(cfg) == {"key": "abc123"}
+
+
+# --- the shipped default runner works on a plain, no-extras install -------------
+
+
+def test_shipped_default_runner_resolves_without_prefect_installed(monkeypatch):
+    """The ``local`` family is unconditionally available: the shipped default
+    configuration must resolve on an install carrying no optional extras."""
+    from radiologist.etl import optional
+    from radiologist.etl.execution import resolve_execution
+
+    monkeypatch.setattr(optional, "_PREFECT_AVAILABLE", False)
+
+    cfg = _compose("extract")
+    plan = resolve_execution(cfg.runner)
+
+    assert plan.family == "local"
+
+
+def test_shipped_default_runner_carries_no_task_runner_without_prefect(monkeypatch):
+    """``conf/runner/local.yaml`` targets ``prefect.task_runners.
+    ProcessPoolTaskRunner``. Without prefect that target cannot be
+    instantiated, so a plan carrying no task runner is the observable proof
+    that it was never evaluated."""
+    from radiologist.etl import optional
+    from radiologist.etl.execution import resolve_execution
+
+    monkeypatch.setattr(optional, "_PREFECT_AVAILABLE", False)
+
+    cfg = _compose("extract")
+    plan = resolve_execution(cfg.runner)
+
+    assert plan.task_runner is None
+
+
+def test_shipped_build_default_runner_also_resolves_without_prefect(monkeypatch):
+    from radiologist.etl import optional
+    from radiologist.etl.execution import resolve_execution
+
+    monkeypatch.setattr(optional, "_PREFECT_AVAILABLE", False)
+
+    plan = resolve_execution(_compose("build").runner)
+
+    assert (plan.family, plan.task_runner) == ("local", None)
+
+
+@pytest.mark.parametrize(
+    ("runner_choice", "sentinel", "expected_extra"),
+    [
+        ("dask_local", "_PREFECT_DASK_AVAILABLE", "dask"),
+        ("ray_local", "_PREFECT_RAY_AVAILABLE", "ray"),
+        ("beam_direct", "_BEAM_AVAILABLE", "beam"),
+    ],
+)
+def test_unavailable_backend_names_a_declared_extra_in_prose_and_command(
+    monkeypatch, runner_choice, sentinel, expected_extra
+):
+    """Every family that can still be unavailable must offer a remedy the
+    user can actually follow: the extra named in the prose, the extra named
+    in the install command and an extra the package really declares must all
+    be the same string."""
+    from importlib.metadata import metadata
+
+    from radiologist.etl import optional
+    from radiologist.etl.execution import resolve_execution
+
+    monkeypatch.setattr(optional, sentinel, False)
+
+    overrides = [f"runner={runner_choice}"]
+    if runner_choice == "beam_direct":
+        overrides.append("runner.beam.parts_dir=/tmp/beam-parts")
+    cfg = _compose("extract", overrides=overrides)
+
+    with pytest.raises(RuntimeError) as excinfo:
+        resolve_execution(cfg.runner)
+
+    message = str(excinfo.value)
+    declared = set(metadata("radiologist-etl").get_all("Provides-Extra") or [])
+    assert expected_extra in declared
+    assert f"the {expected_extra} extra is required" in message
+    assert f"pip install 'radiologist-etl[{expected_extra}]'" in message
+
+
+def test_explicitly_null_batch_size_falls_back_to_the_documented_default():
+    from radiologist.etl.execution import resolve_execution
+
+    cfg = _compose("extract", overrides=["runner.batch_size=null"])
+    plan = resolve_execution(cfg.runner)
+
+    assert plan.batch_size == 64
+
+
+def _constant_stat(image, metadata, mask=None):
+    """A trivial StatExtractor: this test is about batch sizing, not features."""
+    return {"stat": 1.0}
+
+
+def test_extract_stage_runs_under_a_plan_built_from_a_null_batch_size(
+    tmp_path, image_dir
+):
+    """A null ``batch_size`` used to reach ``chunked()`` as ``None`` and blow
+    up with a TypeError once a stage actually ran under the plan.
+
+    The mapper is injected so the real ``process_batch`` runs in this process:
+    ``chunked(paths, batch_size)`` is evaluated before any dispatch, so a
+    process pool would add nothing to the assertion.
+    """
+    import functools
+
+    from radiologist.etl.execution import resolve_execution
+    from radiologist.etl.extract import extract
+    from radiologist.etl.processors import process_batch
+
+    plan = resolve_execution(
+        _compose("extract", overrides=["runner.batch_size=null"]).runner
+    )
+
+    images = [str(p) for p in sorted(image_dir.rglob("*.png"))]
+    listing = tmp_path / "listing.txt"
+    listing.write_text("\n".join(images) + "\n")
+
+    worker = functools.partial(
+        process_batch,
+        images_root=None,
+        masks_root=None,
+        manifest_id="placeholder",
+        extractors=[_constant_stat],
+    )
+
+    result = extract(
+        file_list=str(listing),
+        destination=str(tmp_path / "manifests"),
+        extractors=[_constant_stat],
+        iqr_columns=["stat"],
+        batch_size=plan.batch_size,
+        mapper=lambda batches: [worker(batch) for batch in batches],
+    )
+
+    assert result.total == len(images)
+
+
+def test_explicitly_null_family_still_yields_a_local_plan():
+    """Regression pin on existing behaviour, unchanged by this fix."""
+    from radiologist.etl.execution import resolve_execution
+
+    cfg = _compose("extract", overrides=["runner.family=null"])
+    plan = resolve_execution(cfg.runner)
+
+    assert plan.family == "local"

--- a/radiologist-etl/radiologist_etl_tests/test_extract.py
+++ b/radiologist-etl/radiologist_etl_tests/test_extract.py
@@ -458,6 +458,28 @@ def test_unreadable_image_with_zero_tolerance_raises_and_writes_no_manifest(
             max_failure_rate=0.0,
         )
 
+
+def test_extract_failure_message_caps_the_enumerated_failures(tmp_path):
+    from radiologist.etl.extract import ExtractionFailureError, extract
+
+    bad_paths = [str(tmp_path / f"missing_{i}.png") for i in range(25)]
+    listing = _write_listing(tmp_path, bad_paths)
+    destination = str(tmp_path / "dest")
+
+    with pytest.raises(ExtractionFailureError) as excinfo:
+        extract(
+            listing,
+            destination,
+            images_root=str(tmp_path),
+            max_failure_rate=0.0,
+        )
+
+    message = str(excinfo.value)
+    assert "missing_0.png" in message
+    assert "missing_19.png" in message
+    assert "missing_20.png" not in message
+    assert "and 5 more" in message
+
     assert not Path(destination).exists() or not any(Path(destination).iterdir())
 
 

--- a/radiologist-etl/radiologist_etl_tests/test_extract.py
+++ b/radiologist-etl/radiologist_etl_tests/test_extract.py
@@ -334,6 +334,33 @@ def test_masks_root_without_images_root_raises_value_error(image_dir, tmp_path):
         extract(listing, destination, masks_root="/some/masks")
 
 
+def test_the_stage_and_the_batch_worker_reject_the_root_pair_identically(
+    image_dir, tmp_path
+):
+    from radiologist.etl import process_batch
+    from radiologist.etl.extract import extract
+    from radiologist.etl.stats import make_haralick
+
+    paths = _all_image_paths(image_dir)
+    listing = _write_listing(tmp_path, paths)
+    destination = str(tmp_path / "dest")
+
+    with pytest.raises(ValueError) as stage_error:
+        extract(listing, destination, masks_root="/some/masks")
+
+    with pytest.raises(ValueError) as worker_error:
+        process_batch(
+            paths,
+            images_root=None,
+            masks_root="/some/masks",
+            manifest_id="run-0000000000000001",
+            extractors=[make_haralick(features=["mean"])],
+        )
+
+    assert str(stage_error.value) == str(worker_error.value)
+    assert "masks_root" in str(stage_error.value)
+
+
 # --- run-id / manifest naming stability -------------------------------------
 
 

--- a/radiologist-etl/radiologist_etl_tests/test_identity.py
+++ b/radiologist-etl/radiologist_etl_tests/test_identity.py
@@ -513,3 +513,42 @@ def test_records_reader_accepts_storage_options_positionally(tmp_path: Path) -> 
     records_no_opts = records_reader(dest)
     records_with_opts = records_reader(dest, {})
     assert records_with_opts == records_no_opts
+
+
+def test_directory_digest_is_location_independent_for_identical_basenames(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.identity import directory_digest
+
+    here = tmp_path / "here" / "manifests"
+    there = tmp_path / "somewhere" / "else" / "manifests"
+    for d in (here, there):
+        _write_jsonl(d / "extract-a.jsonl", b'{"x": 1}\n')
+        _write_jsonl(d / "extract-b.jsonl", b'{"y": 2}\n')
+
+    assert directory_digest(str(here)) == directory_digest(str(there))
+
+
+def test_directory_digest_ignores_entries_whose_basename_lacks_the_prefix(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.identity import directory_digest
+
+    d = tmp_path / "manifests"
+    _write_jsonl(d / "extract-a.jsonl", b'{"x": 1}\n')
+    before = directory_digest(str(d), prefix="extract-")
+    _write_jsonl(d / "manifest-deadbeef.jsonl", b'{"z": 3}\n')
+    after = directory_digest(str(d), prefix="extract-")
+    assert before == after
+
+
+def test_directory_digest_with_a_prefix_still_tracks_matching_manifests(
+    tmp_path: Path,
+) -> None:
+    from radiologist.etl.identity import directory_digest
+
+    d = tmp_path / "manifests"
+    _write_jsonl(d / "extract-a.jsonl", b'{"x": 1}\n')
+    before = directory_digest(str(d), prefix="extract-")
+    _write_jsonl(d / "extract-b.jsonl", b'{"y": 2}\n')
+    assert directory_digest(str(d), prefix="extract-") != before

--- a/radiologist-etl/radiologist_etl_tests/test_prefect_pipelines.py
+++ b/radiologist-etl/radiologist_etl_tests/test_prefect_pipelines.py
@@ -766,3 +766,206 @@ def test_run_build_resolves_the_plan_and_attaches_its_task_runner(
 
     assert Path(result.manifest_path).exists()
     assert seen_execution and isinstance(seen_execution[0], ExecutionPlan)
+
+
+# --- issue #200: zero-valued knobs and distinct build artifacts ---------------
+
+
+def _make_split_manifest_with_missing(
+    tmp_path: Path, image_dir: Path, missing: int = 1
+) -> str:
+    """A split manifest over the real corpus plus ``missing`` unreadable paths.
+
+    The fabricated paths point at files that were never written, so
+    ``write_shard`` collects them as ``(path, message)`` failures — the
+    build stage's observable failure population.
+    """
+    from radiologist.etl.manifest import JsonlWriter, ManifestRecord
+
+    paths = [str(p) for p in sorted(image_dir.rglob("*.png"))]
+    paths += [str(image_dir / "NORMAL" / f"ghost{i:03d}.png") for i in range(missing)]
+    records = [
+        ManifestRecord(
+            manifest_id="assignrun0000001",
+            path=path,
+            filename=Path(path).name,
+            label=Path(path).parent.name,
+            split="train",
+            stats={},
+        )
+        for path in paths
+    ]
+    manifest_path = str(
+        tmp_path / "split-manifests" / "manifest-assignrun0000001.jsonl"
+    )
+    JsonlWriter().write(records, manifest_path)
+    return manifest_path
+
+
+def test_extract_flow_with_batch_size_configured_as_zero_raises_naming_the_size(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    listing = _write_listing(tmp_path, _all_image_paths(image_dir))
+    cfg = _extract_cfg(Path(listing), tmp_path / "dest", batch_size=0)
+
+    with pytest.raises(ValueError, match=r"size must be >= 1, got 0"):
+        prefect_pipelines.extract_flow.fn(cfg)
+
+
+def test_extract_flow_with_workers_configured_as_zero_raises(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    listing = _write_listing(tmp_path, _all_image_paths(image_dir))
+    cfg = _extract_cfg(Path(listing), tmp_path / "dest", workers=0)
+
+    with pytest.raises(ValueError):
+        prefect_pipelines.extract_flow.fn(cfg)
+
+
+def test_build_flow_with_workers_configured_as_zero_raises(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    split_manifest = _make_split_manifest(tmp_path, image_dir)
+    cfg = _build_cfg(Path(split_manifest), tmp_path / "shards", workers=0)
+
+    with pytest.raises(ValueError):
+        prefect_pipelines.build_flow.fn(cfg)
+
+
+def test_extract_flow_with_absent_batch_size_and_workers_uses_the_stage_defaults(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    paths = _all_image_paths(image_dir)
+    listing = _write_listing(tmp_path, paths)
+    cfg = _extract_cfg(Path(listing), tmp_path / "dest", batch_size=None, workers=None)
+
+    result = prefect_pipelines.extract_flow.fn(cfg)
+
+    assert result.total == len(paths)
+    assert Path(result.manifest_path).exists()
+
+
+def test_build_flow_with_absent_workers_uses_the_stage_default(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    split_manifest = _make_split_manifest(tmp_path, image_dir)
+    cfg = _build_cfg(Path(split_manifest), tmp_path / "shards", workers=None)
+
+    result = prefect_pipelines.build_flow.fn(cfg)
+
+    assert result.shard_count > 0
+    assert Path(result.manifest_path).exists()
+
+
+def test_extract_flow_dispatches_work_in_batches_of_the_configured_batch_size(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A positive configured batch size reaches the stage unchanged.
+
+    Companion to the zero-valued cases above: the same accessor feeds both,
+    so this pins the non-zero half of its contract.
+    """
+    from radiologist.etl.processors import process_batch
+
+    image_dir = tmp_path / "images"
+    paths = []
+    for i in range(9):
+        p = image_dir / "NORMAL" / f"img{i:03d}.png"
+        p.parent.mkdir(parents=True, exist_ok=True)
+        Image.fromarray(np.zeros((10, 10, 3), dtype=np.uint8)).save(str(p))
+        paths.append(str(p))
+
+    listing = _write_listing(tmp_path, paths)
+    cfg = _extract_cfg(
+        Path(listing),
+        tmp_path / "dest",
+        batch_size=3,
+        runner={
+            "family": "local",
+            "task_runner": {"_target_": "prefect.task_runners.ThreadPoolTaskRunner"},
+        },
+    )
+
+    spy = _MapSpy(process_batch)
+    monkeypatch.setattr(prefect_pipelines, "extract_batch_task", spy)
+
+    prefect_pipelines.extract_flow.fn(cfg)
+
+    dispatched = [batch for call in spy.calls for batch in call]
+    assert dispatched, "expected batches to be dispatched"
+    assert [len(batch) for batch in dispatched] == [3, 3, 3]
+
+
+def test_build_flow_creates_the_split_report_and_the_output_link_under_distinct_keys(
+    monkeypatch: pytest.MonkeyPatch, image_dir: Path, tmp_path: Path
+) -> None:
+    split_manifest = _make_split_manifest(tmp_path, image_dir)
+    cfg = _build_cfg(Path(split_manifest), tmp_path / "shards")
+
+    table: dict = {}
+    link: dict = {}
+    monkeypatch.setattr(
+        prefect_pipelines, "create_table_artifact", lambda **kw: table.update(kw)
+    )
+    monkeypatch.setattr(
+        prefect_pipelines, "create_link_artifact", lambda **kw: link.update(kw)
+    )
+
+    result = prefect_pipelines.build_flow.fn(cfg)
+
+    assert table["table"], "expected the split-report rows"
+    assert link["link"] == result.output_dir
+    assert table["key"] != link["key"]
+    assert link["key"] == f"build-{result.run_id}"
+
+
+def test_build_flow_with_tolerance_above_the_failure_rate_completes_and_counts(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    split_manifest = _make_split_manifest_with_missing(tmp_path, image_dir, missing=1)
+    cfg = _build_cfg(Path(split_manifest), tmp_path / "shards", max_failure_rate=0.5)
+
+    result = prefect_pipelines.build_flow.fn(cfg)
+
+    assert result.failed == 1
+    assert Path(result.manifest_path).exists()
+
+
+def test_build_flow_with_tolerance_below_the_failure_rate_fails(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    from radiologist.etl.build import BuildFailureError
+
+    split_manifest = _make_split_manifest_with_missing(tmp_path, image_dir, missing=1)
+    cfg = _build_cfg(Path(split_manifest), tmp_path / "shards", max_failure_rate=0.1)
+
+    with pytest.raises(BuildFailureError):
+        prefect_pipelines.build_flow.fn(cfg)
+
+
+def test_build_flow_with_no_tolerance_configured_behaves_as_zero(
+    image_dir: Path, tmp_path: Path
+) -> None:
+    from radiologist.etl.build import BuildFailureError
+
+    split_manifest = _make_split_manifest_with_missing(tmp_path, image_dir, missing=1)
+    cfg = _build_cfg(Path(split_manifest), tmp_path / "shards")
+
+    with pytest.raises(BuildFailureError):
+        prefect_pipelines.build_flow.fn(cfg)
+
+
+def test_build_flow_output_link_description_names_the_failure_count(
+    monkeypatch: pytest.MonkeyPatch, image_dir: Path, tmp_path: Path
+) -> None:
+    split_manifest = _make_split_manifest_with_missing(tmp_path, image_dir, missing=1)
+    cfg = _build_cfg(Path(split_manifest), tmp_path / "shards", max_failure_rate=0.5)
+
+    link: dict = {}
+    monkeypatch.setattr(
+        prefect_pipelines, "create_link_artifact", lambda **kw: link.update(kw)
+    )
+
+    result = prefect_pipelines.build_flow.fn(cfg)
+
+    assert f"{result.failed} failed" in link["description"]

--- a/radiologist-etl/radiologist_etl_tests/test_process_batch.py
+++ b/radiologist-etl/radiologist_etl_tests/test_process_batch.py
@@ -25,6 +25,8 @@ per-batch worker the extract stage's mapper dispatches."""
 
 from __future__ import annotations
 
+import pytest
+
 
 def test_readable_images_in_a_batch_each_produce_a_record(image_dir):
     from radiologist.etl.models import BatchOutcome
@@ -123,3 +125,69 @@ def test_records_have_no_lung_out_of_frame_flag_without_masks(image_dir):
     )
 
     assert all(r.lung_out_of_frame is None for r in outcome.records)
+
+
+# --- masks_root/images_root invariant ----------------------------------------
+
+
+def test_a_mask_root_without_an_images_root_is_rejected_naming_both_settings(
+    image_dir, mask_dir
+):
+    from radiologist.etl import process_batch
+    from radiologist.etl.stats import make_haralick
+
+    paths = [str(p) for p in sorted(image_dir.rglob("*.png"))]
+
+    with pytest.raises(ValueError) as excinfo:
+        process_batch(
+            paths,
+            images_root=None,
+            masks_root=str(mask_dir),
+            manifest_id="run-0000000000000001",
+            extractors=[make_haralick(features=["mean"])],
+        )
+
+    message = str(excinfo.value)
+    assert "masks_root" in message
+    assert "images_root" in message
+
+
+def test_the_invalid_root_pair_is_rejected_before_any_image_is_read(tmp_path):
+    from radiologist.etl import process_batch
+    from radiologist.etl.stats import make_haralick
+
+    absent = [str(tmp_path / "nowhere" / f"img{i}.png") for i in range(3)]
+
+    for paths in ([], absent):
+        with pytest.raises(ValueError, match="images_root"):
+            process_batch(
+                paths,
+                images_root=None,
+                masks_root=str(tmp_path / "masks"),
+                manifest_id="run-0000000000000001",
+                extractors=[make_haralick(features=["mean"])],
+            )
+
+
+def test_dispatching_beam_batches_without_an_images_root_surfaces_the_error(
+    image_dir, mask_dir, tmp_path
+):
+    from radiologist.etl.beam_executor import BeamExecutor
+    from radiologist.etl.stats import make_haralick
+
+    paths = [str(p) for p in sorted(image_dir.rglob("*.png"))]
+    executor = BeamExecutor(
+        pipeline_options={"runner": "DirectRunner"},
+        parts_dir=str(tmp_path / "parts"),
+    )
+
+    with pytest.raises(Exception) as excinfo:
+        executor.run_batches(
+            [paths],
+            images_root=None,
+            masks_root=str(mask_dir),
+            manifest_id="run-0000000000000001",
+            extractors=[make_haralick(features=["mean"])],
+        )
+
+    assert "images_root" in str(excinfo.value)

--- a/radiologist-etl/radiologist_etl_tests/test_shard_building.py
+++ b/radiologist-etl/radiologist_etl_tests/test_shard_building.py
@@ -197,3 +197,45 @@ def test_write_shard_relative_path_resolves_against_shard_root(tmp_path: Path) -
 
     resolved = str(Path(shard_root) / outcome.relative_path)
     assert Path(resolved).exists()
+
+
+def _empty_split_outcome(tmp_path: Path):
+    from radiologist.etl.models import ShardJob
+    from radiologist.etl.shards import write_shard
+
+    path_a = _make_png(tmp_path, "scan001.png", "NORMAL")
+    shard_root = str(tmp_path / "shards")
+    job = ShardJob(
+        split="",
+        label="NORMAL",
+        index=0,
+        shard_root=shard_root,
+        records=[_record(path_a, "scan001.png", "NORMAL", "")],
+    )
+    return shard_root, write_shard(job)
+
+
+def test_write_shard_relative_path_resolves_against_shard_root_for_empty_split(
+    tmp_path: Path,
+) -> None:
+    shard_root, outcome = _empty_split_outcome(tmp_path)
+
+    resolved = Path(shard_root) / outcome.relative_path
+    assert resolved.is_file()
+    assert _tar_members(str(resolved))
+
+
+def test_write_shard_relative_path_is_not_absolute_for_empty_split(
+    tmp_path: Path,
+) -> None:
+    _, outcome = _empty_split_outcome(tmp_path)
+
+    assert not outcome.relative_path.startswith("/")
+
+
+def test_write_shard_relative_path_names_label_then_filename_for_empty_split(
+    tmp_path: Path,
+) -> None:
+    _, outcome = _empty_split_outcome(tmp_path)
+
+    assert outcome.relative_path == "NORMAL/-normal-000000.tar"

--- a/radiologist-etl/src/radiologist/etl/__init__.py
+++ b/radiologist-etl/src/radiologist/etl/__init__.py
@@ -26,7 +26,11 @@ from __future__ import annotations
 
 from radiologist.etl.assign import assign_splits
 from radiologist.etl.beam_executor import BeamExecutor
-from radiologist.etl.build import build_shards
+from radiologist.etl.build import (
+    SHARD_WRITE_FAILED_REASON,
+    BuildFailureError,
+    build_shards,
+)
 from radiologist.etl.execution import (
     ExecutionPlan,
     default_workers,
@@ -36,6 +40,8 @@ from radiologist.etl.execution import (
 from radiologist.etl.extract import ExtractionFailureError, extract
 from radiologist.etl.filters import filter_iqr, filter_lung_out_of_frame
 from radiologist.etl.identity import (
+    EXTRACT_MANIFEST_PREFIX,
+    EXTRACT_MANIFEST_SUFFIX,
     compute_assign_run_id,
     compute_build_run_id,
     compute_extract_run_id,
@@ -79,6 +85,7 @@ __all__: list[str] = [
     "BeamExecutor",
     "build_flow",
     "build_shards",
+    "BuildFailureError",
     "BuildResult",
     "compute_assign_run_id",
     "compute_build_run_id",
@@ -90,6 +97,8 @@ __all__: list[str] = [
     "ExecutionPlan",
     "extract",
     "extract_flow",
+    "EXTRACT_MANIFEST_PREFIX",
+    "EXTRACT_MANIFEST_SUFFIX",
     "ExtractionFailureError",
     "ExtractResult",
     "filter_iqr",
@@ -110,6 +119,7 @@ __all__: list[str] = [
     "run_extract",
     "ShardJob",
     "ShardOutcome",
+    "SHARD_WRITE_FAILED_REASON",
     "SplitRatios",
     "StatExtractor",
     "storage_options_from_cfg",

--- a/radiologist-etl/src/radiologist/etl/assign.py
+++ b/radiologist-etl/src/radiologist/etl/assign.py
@@ -42,7 +42,11 @@ from dataclasses import replace
 
 import fsspec  # type: ignore[import-untyped]
 
-from radiologist.etl.identity import compute_assign_run_id
+from radiologist.etl.identity import (
+    EXTRACT_MANIFEST_PREFIX,
+    EXTRACT_MANIFEST_SUFFIX,
+    compute_assign_run_id,
+)
 from radiologist.etl.manifest import JsonlWriter, records_reader
 from radiologist.etl.models import AssignSplitResult
 from radiologist.etl.split import SplitRatios, assign_split, normalize_ratios
@@ -53,8 +57,6 @@ logger = logging.getLogger(__name__)
 # (dict-ratios) pipeline gave it. Changing this order or these fractions
 # re-partitions every corpus and must be treated as a breaking data change.
 _DEFAULT_RATIOS: SplitRatios = (("train", 0.70), ("val", 0.15), ("test", 0.15))
-
-_MANIFEST_SUFFIX = ".jsonl"
 
 
 def assign_splits(
@@ -67,7 +69,10 @@ def assign_splits(
     """Concatenate, dedupe, and split-assign every extract manifest in a folder.
 
     Args:
-        manifests_dir: folder of extract manifests, read in sorted name order.
+        manifests_dir: folder scanned for ``extract-``-prefixed ``.jsonl``
+            manifests, read in sorted name order. Anything else in the folder —
+            including a split manifest this stage wrote on a previous run — is
+            ignored, so ``destination`` may safely equal ``manifests_dir``.
         destination: folder the split manifest is written into.
         ratios: explicitly ordered split ratios; defaults to
             ``[("train", 0.70), ("val", 0.15), ("test", 0.15)]``.
@@ -88,13 +93,20 @@ def assign_splits(
         entries = fs.ls(path, detail=True)
     except FileNotFoundError:
         entries = []
+    # Selects exactly the set compute_assign_run_id fingerprints — the same two
+    # constants, the same basename test. Sorting the full names (not the
+    # basenames) keeps multi-manifest merge order unchanged for existing corpora.
     manifest_files = sorted(
-        entry["name"]
-        for entry in entries
-        if entry.get("type") == "file" and str(entry["name"]).endswith(_MANIFEST_SUFFIX)
+        name
+        for entry, name in ((entry, str(entry["name"])) for entry in entries)
+        if entry.get("type") == "file"
+        and name.rsplit("/", 1)[-1].startswith(EXTRACT_MANIFEST_PREFIX)
+        and name.endswith(EXTRACT_MANIFEST_SUFFIX)
     )
     if not manifest_files:
-        raise FileNotFoundError(f"No extract manifest found in {manifests_dir!r}")
+        raise FileNotFoundError(
+            f"No {EXTRACT_MANIFEST_PREFIX!r} manifest found in {manifests_dir!r}"
+        )
 
     seen_paths: dict = {}
     seen_filenames: dict = {}

--- a/radiologist-etl/src/radiologist/etl/assign.py
+++ b/radiologist-etl/src/radiologist/etl/assign.py
@@ -45,9 +45,10 @@ import fsspec  # type: ignore[import-untyped]
 from radiologist.etl.identity import (
     EXTRACT_MANIFEST_PREFIX,
     EXTRACT_MANIFEST_SUFFIX,
+    _matches,
     compute_assign_run_id,
 )
-from radiologist.etl.manifest import JsonlWriter, records_reader
+from radiologist.etl.manifest import JsonlWriter, ManifestRecord, records_reader
 from radiologist.etl.models import AssignSplitResult
 from radiologist.etl.split import SplitRatios, assign_split, normalize_ratios
 
@@ -93,26 +94,25 @@ def assign_splits(
         entries = fs.ls(path, detail=True)
     except FileNotFoundError:
         entries = []
-    # Selects exactly the set compute_assign_run_id fingerprints — the same two
-    # constants, the same basename test. Sorting the full names (not the
-    # basenames) keeps multi-manifest merge order unchanged for existing corpora.
+    # Selects exactly the set compute_assign_run_id fingerprints — the same
+    # shared predicate, applied to the same two constants. Sorting the full
+    # names (not the basenames) keeps multi-manifest merge order unchanged
+    # for existing corpora.
     manifest_files = sorted(
-        name
-        for entry, name in ((entry, str(entry["name"])) for entry in entries)
-        if entry.get("type") == "file"
-        and name.rsplit("/", 1)[-1].startswith(EXTRACT_MANIFEST_PREFIX)
-        and name.endswith(EXTRACT_MANIFEST_SUFFIX)
+        str(entry["name"])
+        for entry in entries
+        if _matches(entry, EXTRACT_MANIFEST_PREFIX, EXTRACT_MANIFEST_SUFFIX)
     )
     if not manifest_files:
         raise FileNotFoundError(
             f"No {EXTRACT_MANIFEST_PREFIX!r} manifest found in {manifests_dir!r}"
         )
 
-    seen_paths: dict = {}
-    seen_filenames: dict = {}
+    seen_paths: dict[str, ManifestRecord] = {}
+    seen_filenames: dict[str, str] = {}
     duplicate_count = 0
-    records: list = []
-    collided_filenames: set = set()
+    records: list[ManifestRecord] = []
+    collided_filenames: set[str] = set()
     for name in manifest_files:
         uri = fs.unstrip_protocol(name)
         for record in records_reader(uri, storage_options=storage_options):
@@ -146,8 +146,8 @@ def assign_splits(
         manifests_dir, config, storage_options=storage_options
     )
 
-    counts_by_split: dict = {name: 0 for name, _ in ordered_ratios}
-    final_records = []
+    counts_by_split: dict[str, int] = {name: 0 for name, _ in ordered_ratios}
+    final_records: list[ManifestRecord] = []
     for record in records:
         split = assign_split(record.filename, ordered_ratios)
         counts_by_split[split] += 1

--- a/radiologist-etl/src/radiologist/etl/beam_executor.py
+++ b/radiologist-etl/src/radiologist/etl/beam_executor.py
@@ -44,6 +44,7 @@ process-pool one.
 from __future__ import annotations
 
 import json
+import logging
 import uuid
 from collections.abc import Mapping, Sequence
 from typing import Any
@@ -58,6 +59,8 @@ from radiologist.etl.models import BatchOutcome, ShardJob, ShardOutcome
 from radiologist.etl.processors import process_batch
 from radiologist.etl.shards import write_shard
 from radiologist.etl.stats import StatExtractor
+
+logger = logging.getLogger(__name__)
 
 # fsspec reports a bare filesystem path as ``None``; ``file``/``local`` are
 # the explicit spellings of the same thing.
@@ -299,21 +302,22 @@ class BeamExecutor:
             return []
 
         parts_prefix = self._run_prefix("batches")
-        self._run_pipeline(
-            label="Batches",
-            elements=list(enumerate(units)),
-            fn=_beam_process_batch,
-            images_root=images_root,
-            masks_root=masks_root,
-            manifest_id=manifest_id,
-            extractors=extractors,
-            parts_prefix=parts_prefix,
-            storage_options=self.storage_options,
-        )
-        return [
-            _batch_outcome_from_json(payload)
-            for payload in _read_parts(parts_prefix, len(units), self.storage_options)
-        ]
+        try:
+            self._run_pipeline(
+                label="Batches",
+                elements=list(enumerate(units)),
+                fn=_beam_process_batch,
+                images_root=images_root,
+                masks_root=masks_root,
+                manifest_id=manifest_id,
+                extractors=extractors,
+                parts_prefix=parts_prefix,
+                storage_options=self.storage_options,
+            )
+            payloads = _read_parts(parts_prefix, len(units), self.storage_options)
+        finally:
+            self._reclaim(parts_prefix)
+        return [_batch_outcome_from_json(payload) for payload in payloads]
 
     def run_shards(self, jobs: Sequence[ShardJob]) -> list[ShardOutcome]:
         """Run every shard-writing job through one Beam pipeline.
@@ -337,21 +341,43 @@ class BeamExecutor:
             return []
 
         parts_prefix = self._run_prefix("shards")
-        self._run_pipeline(
-            label="Shards",
-            elements=list(enumerate(units)),
-            fn=_beam_write_shard,
-            parts_prefix=parts_prefix,
-            storage_options=self.storage_options,
-        )
-        return [
-            _shard_outcome_from_json(payload)
-            for payload in _read_parts(parts_prefix, len(units), self.storage_options)
-        ]
+        try:
+            self._run_pipeline(
+                label="Shards",
+                elements=list(enumerate(units)),
+                fn=_beam_write_shard,
+                parts_prefix=parts_prefix,
+                storage_options=self.storage_options,
+            )
+            payloads = _read_parts(parts_prefix, len(units), self.storage_options)
+        finally:
+            self._reclaim(parts_prefix)
+        return [_shard_outcome_from_json(payload) for payload in payloads]
 
     def _run_prefix(self, kind: str) -> str:
         """A parts prefix unique to this dispatch, so runs never read each other's."""
         return f"{self.parts_dir.rstrip('/')}/{kind}-{uuid.uuid4().hex}"
+
+    def _reclaim(self, parts_prefix: str) -> None:
+        """Remove this dispatch's scratch prefix, best-effort.
+
+        The prefix is minted per dispatch and nothing outside the dispatch
+        can reference the parts beneath it, so removing it is always safe —
+        and it is removed whether the dispatch succeeded or failed, because
+        a failed remote run is exactly the one that would otherwise strand
+        the most objects. Reclamation is never allowed to fail a dispatch
+        nor to replace an exception already on its way out, so every
+        problem — a permissions refusal, a prefix that has already vanished,
+        a backend without recursive removal — becomes a warning naming the
+        prefix. The configured ``parts_dir`` itself is never touched.
+        """
+        try:
+            fs, path = fsspec.url_to_fs(parts_prefix, **(self.storage_options or {}))
+            fs.rm(path, recursive=True)
+        except Exception as exc:  # noqa: BLE001 - reclamation is best-effort
+            logger.warning(
+                "Could not reclaim Beam scratch prefix %s: %s", parts_prefix, exc
+            )
 
     def _run_pipeline(
         self,

--- a/radiologist-etl/src/radiologist/etl/build.py
+++ b/radiologist-etl/src/radiologist/etl/build.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import functools
 import json
+import logging
 from collections import defaultdict
 
 import fsspec  # type: ignore[import-untyped]
@@ -50,6 +51,8 @@ from radiologist.etl.manifest import JsonlWriter, records_reader
 from radiologist.etl.models import BuildResult
 from radiologist.etl.shards import plan_shards, write_shard
 from radiologist.etl.split import SplitRatios
+
+logger = logging.getLogger(__name__)
 
 
 class BuildFailureError(RuntimeError):
@@ -86,8 +89,10 @@ def build_shards(
         run_label: optional label folded into the run id.
         mapper: shard-dispatching callable; defaults to a local process-pool mapper.
         storage_options: extra kwargs forwarded to fsspec.
-        max_failure_rate: tolerated share of records that cannot be written into
-            a shard. Accepted but not yet enforced.
+        max_failure_rate: tolerated share of the records planned into shards that
+            may fail to be written before the run is failed. Failures at or below
+            the tolerance mark their records excluded with
+            :data:`SHARD_WRITE_FAILED_REASON`.
 
     Returns:
         A :class:`~radiologist.etl.models.BuildResult` describing the run.
@@ -95,6 +100,9 @@ def build_shards(
     Raises:
         FileNotFoundError: if ``split_manifest_path`` does not exist.
         ValueError: if ``shard_size < 1``.
+        BuildFailureError: if the share of records that could not be written into
+            a shard exceeds ``max_failure_rate``. Raised before the manifest and
+            the split report are written.
     """
     if shard_size < 1:
         raise ValueError(f"shard_size must be >= 1, got {shard_size!r}")
@@ -125,6 +133,44 @@ def build_shards(
         )
 
     outcomes = mapper(jobs) if jobs else []
+
+    failures: list[tuple[str, str]] = []
+    for outcome in outcomes:
+        failures.extend(outcome.failures)
+
+    # ``planned`` is the population plan_shards actually grouped into jobs:
+    # the non-excluded records of the input manifest.
+    planned = sum(1 for record in records if not record.excluded)
+    failed = len(failures)
+    failure_rate = failed / planned if planned else 0.0
+
+    if failed:
+        logger.warning(
+            "build stage: %d/%d record(s) could not be written into a shard",
+            failed,
+            planned,
+        )
+
+    if failure_rate > max_failure_rate:
+        failure_desc = "; ".join(f"{p!r} ({msg})" for p, msg in failures)
+        raise BuildFailureError(
+            f"build stage failed: {failed}/{planned} record(s) could not be "
+            f"written into a shard (failure rate {failure_rate:.2%} exceeds "
+            f"max_failure_rate {max_failure_rate:.2%}): {failure_desc}"
+        )
+
+    # Tolerated failures still must not leave a record non-excluded and
+    # shard-less — that combination breaks the manifest invariant the
+    # training datamodule relies on.
+    failed_paths = {path for path, _ in failures}
+    for record in records:
+        if record.path in failed_paths:
+            record.excluded = True
+            record.exclusion_reason = (
+                f"{record.exclusion_reason}|{SHARD_WRITE_FAILED_REASON}"
+                if record.exclusion_reason
+                else SHARD_WRITE_FAILED_REASON
+            )
 
     path_to_shard: dict[str, str] = {}
     for outcome in outcomes:
@@ -176,4 +222,6 @@ def build_shards(
         report_path=report_path,
         shard_count=shard_count,
         record_count=record_count,
+        failed=failed,
+        failure_rate=failure_rate,
     )

--- a/radiologist-etl/src/radiologist/etl/build.py
+++ b/radiologist-etl/src/radiologist/etl/build.py
@@ -154,9 +154,11 @@ def build_shards(
     for outcome in outcomes:
         failures.extend(outcome.failures)
 
-    # ``planned`` is the population plan_shards actually grouped into jobs:
-    # the non-excluded records of the input manifest.
-    planned = sum(1 for record in records if not record.excluded)
+    # ``planned`` is read off the jobs plan_shards actually built, not
+    # re-derived from ``records`` — the two are equal today, but reading
+    # plan_shards' own output keeps that true by construction rather than by
+    # two modules agreeing on the same selection rule independently.
+    planned = sum(len(job.records) for job in jobs)
     failed = len(failures)
     failure_rate = failed / planned if planned else 0.0
 

--- a/radiologist-etl/src/radiologist/etl/build.py
+++ b/radiologist-etl/src/radiologist/etl/build.py
@@ -59,6 +59,22 @@ class BuildFailureError(RuntimeError):
     """Raised when the share of unsharded records exceeds max_failure_rate."""
 
 
+# A systemic failure (a moved source root, revoked credentials) fails every
+# planned record, so an unbounded rendering of ``failures`` could grow to
+# tens of megabytes for a large manifest and land, unbounded, in an
+# exception message that callers — and Prefect, when running under a flow —
+# persist verbatim. Cap the enumeration; report the remainder as a count.
+_MAX_REPORTED_FAILURES = 20
+
+
+def _describe_failures(failures: list[tuple[str, str]]) -> str:
+    head = failures[:_MAX_REPORTED_FAILURES]
+    desc = "; ".join(f"{p!r} ({msg})" for p, msg in head)
+    if len(failures) > _MAX_REPORTED_FAILURES:
+        desc += f"; ... and {len(failures) - _MAX_REPORTED_FAILURES} more"
+    return desc
+
+
 # Exclusion reason code stamped on a record whose image could not be written
 # into its tar shard. Reason codes are pipe-joined when a record accumulates
 # more than one.
@@ -152,7 +168,7 @@ def build_shards(
         )
 
     if failure_rate > max_failure_rate:
-        failure_desc = "; ".join(f"{p!r} ({msg})" for p, msg in failures)
+        failure_desc = _describe_failures(failures)
         raise BuildFailureError(
             f"build stage failed: {failed}/{planned} record(s) could not be "
             f"written into a shard (failure rate {failure_rate:.2%} exceeds "

--- a/radiologist-etl/src/radiologist/etl/build.py
+++ b/radiologist-etl/src/radiologist/etl/build.py
@@ -52,6 +52,16 @@ from radiologist.etl.shards import plan_shards, write_shard
 from radiologist.etl.split import SplitRatios
 
 
+class BuildFailureError(RuntimeError):
+    """Raised when the share of unsharded records exceeds max_failure_rate."""
+
+
+# Exclusion reason code stamped on a record whose image could not be written
+# into its tar shard. Reason codes are pipe-joined when a record accumulates
+# more than one.
+SHARD_WRITE_FAILED_REASON: str = "shard_write_failed"
+
+
 def build_shards(
     split_manifest_path: str,
     shard_root: str,
@@ -61,6 +71,7 @@ def build_shards(
     run_label: str | None = None,
     mapper: ShardMapper | None = None,
     storage_options: dict | None = None,
+    max_failure_rate: float = 0.0,
 ) -> BuildResult:
     """Build WebDataset tar shards, a shard-annotated manifest, and a split report.
 
@@ -75,6 +86,8 @@ def build_shards(
         run_label: optional label folded into the run id.
         mapper: shard-dispatching callable; defaults to a local process-pool mapper.
         storage_options: extra kwargs forwarded to fsspec.
+        max_failure_rate: tolerated share of records that cannot be written into
+            a shard. Accepted but not yet enforced.
 
     Returns:
         A :class:`~radiologist.etl.models.BuildResult` describing the run.

--- a/radiologist-etl/src/radiologist/etl/conf/build.yaml
+++ b/radiologist-etl/src/radiologist/etl/conf/build.yaml
@@ -11,5 +11,6 @@ split_ratios: # report only — never used for assignment here
   - ["val", 0.15]
   - ["test", 0.15]
 workers: null
+max_failure_rate: 0.0 # unshardable-record tolerance before the run fails
 run_label: null
 storage_options: null

--- a/radiologist-etl/src/radiologist/etl/execution.py
+++ b/radiologist-etl/src/radiologist/etl/execution.py
@@ -186,18 +186,27 @@ _BACKEND_EXTRAS = {
 
 
 def _cfg_get(cfg: Any, key: str, default: Any = None) -> Any:
-    """Fetch ``key`` from a ``DictConfig``, plain ``dict``, or ``None``."""
+    """Fetch ``key`` from a ``DictConfig``, plain ``dict``, or ``None``.
+
+    A key that is present but explicitly ``null`` falls back to ``default``,
+    exactly as an absent key does: ``runner.batch_size=null`` means "use the
+    documented default", not "use ``None``".
+    """
     if cfg is None:
         return default
     getter = getattr(cfg, "get", None)
     if getter is not None:
-        return getter(key, default)
-    return getattr(cfg, key, default)
+        value = getter(key, default)
+    else:
+        value = getattr(cfg, key, default)
+    return default if value is None else value
 
 
 def _backend_available(family: str) -> bool:
     if family == "local":
-        return bool(optional._PREFECT_AVAILABLE)
+        # The local family needs no extra: without prefect the flows fall back
+        # to plain Python and the plan simply carries no task runner.
+        return True
     if family == "dask":
         return bool(optional._PREFECT_DASK_AVAILABLE)
     if family == "ray":
@@ -248,10 +257,23 @@ def resolve_execution(
     )
 
     if not _backend_available(family):
-        extra = _BACKEND_EXTRAS.get(family, "prefect")
+        # Only dask/ray/beam can be unavailable, and all three are keys here,
+        # so prose and install command always name the same declared extra.
+        extra = _BACKEND_EXTRAS[family]
         raise RuntimeError(
-            f"the {family} extra is required to use the {family} runner family. "
+            f"the {extra} extra is required to use the {extra} runner family. "
             f"Install with: pip install 'radiologist-etl[{extra}]'"
+        )
+
+    if family == "local" and not optional._PREFECT_AVAILABLE:
+        # The shipped local runner targets a prefect task runner. Without
+        # prefect that target cannot be instantiated — and does not need to
+        # be, since the flows only attach a runner when prefect is available.
+        return ExecutionPlan(
+            family="local",
+            task_runner=None,
+            beam=None,
+            batch_size=resolved_batch_size,
         )
 
     if family == "beam":

--- a/radiologist-etl/src/radiologist/etl/extract.py
+++ b/radiologist-etl/src/radiologist/etl/extract.py
@@ -47,7 +47,10 @@ from radiologist.etl.filters import filter_iqr, filter_lung_out_of_frame
 from radiologist.etl.identity import compute_extract_run_id
 from radiologist.etl.manifest import JsonlWriter, ManifestRecord
 from radiologist.etl.models import ExtractResult
-from radiologist.etl.processors import process_batch
+from radiologist.etl.processors import (
+    _MASKS_ROOT_REQUIRES_IMAGES_ROOT,
+    process_batch,
+)
 from radiologist.etl.stats import StatExtractor, lung_asymmetry, make_haralick
 
 
@@ -154,10 +157,7 @@ def extract(
         ExtractionFailureError: if ``failed / total`` exceeds ``max_failure_rate``.
     """
     if masks_root is not None and images_root is None:
-        raise ValueError(
-            "masks_root requires images_root to resolve the mask mirror path — "
-            "both are required together"
-        )
+        raise ValueError(_MASKS_ROOT_REQUIRES_IMAGES_ROOT)
 
     paths = read_file_list(file_list, storage_options=storage_options)
 

--- a/radiologist-etl/src/radiologist/etl/extract.py
+++ b/radiologist-etl/src/radiologist/etl/extract.py
@@ -58,6 +58,22 @@ class ExtractionFailureError(RuntimeError):
     """Raised when the share of unreadable images exceeds max_failure_rate."""
 
 
+# A systemic failure (a moved source root, revoked credentials) fails every
+# planned image, so an unbounded rendering of ``failures`` could grow to tens
+# of megabytes for a large corpus and land, unbounded, in an exception
+# message that callers — and Prefect, when running under a flow — persist
+# verbatim. Cap the enumeration; report the remainder as a count.
+_MAX_REPORTED_FAILURES = 20
+
+
+def _describe_failures(failures: list[tuple[str, str]]) -> str:
+    head = failures[:_MAX_REPORTED_FAILURES]
+    desc = "; ".join(f"{p!r} ({msg})" for p, msg in head)
+    if len(failures) > _MAX_REPORTED_FAILURES:
+        desc += f"; ... and {len(failures) - _MAX_REPORTED_FAILURES} more"
+    return desc
+
+
 def read_file_list(
     file_list: str,
     storage_options: dict | None = None,
@@ -220,7 +236,7 @@ def extract(
     failure_rate = failed / total if total else 0.0
 
     if failure_rate > max_failure_rate:
-        failure_desc = "; ".join(f"{p!r} ({msg})" for p, msg in failures)
+        failure_desc = _describe_failures(failures)
         raise ExtractionFailureError(
             f"extract stage failed: {failed}/{total} image(s) unreadable "
             f"(failure rate {failure_rate:.2%} exceeds max_failure_rate "

--- a/radiologist-etl/src/radiologist/etl/identity.py
+++ b/radiologist-etl/src/radiologist/etl/identity.py
@@ -49,6 +49,19 @@ def _not_found(uri: str) -> FileNotFoundError:
     return FileNotFoundError(f"No such file or directory: {uri!r}")
 
 
+def _matches(entry: Mapping[str, Any], prefix: str, suffix: str) -> bool:
+    """True when a listing entry is a file whose basename matches prefix/suffix.
+
+    The one predicate ``directory_digest`` and the assign-split folder scan
+    both use, so the rule for "what counts as a matching manifest" can never
+    diverge between the run-id fingerprint and the stage that reads the files.
+    """
+    if entry.get("type") != "file":
+        return False
+    basename = str(entry["name"]).rsplit("/", 1)[-1]
+    return basename.startswith(prefix) and basename.endswith(suffix)
+
+
 def content_digest(
     uri: str,
     storage_options: dict | None = None,
@@ -123,13 +136,9 @@ def directory_digest(
         raise _not_found(directory) from exc
 
     pairs = sorted(
-        (basename, entry.get("size"))
-        for entry, basename in (
-            (entry, str(entry["name"]).rsplit("/", 1)[-1]) for entry in entries
-        )
-        if entry.get("type") == "file"
-        and basename.startswith(prefix)
-        and basename.endswith(suffix)
+        (str(entry["name"]).rsplit("/", 1)[-1], entry.get("size"))
+        for entry in entries
+        if _matches(entry, prefix, suffix)
     )
     payload = json.dumps(pairs)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/radiologist-etl/src/radiologist/etl/identity.py
+++ b/radiologist-etl/src/radiologist/etl/identity.py
@@ -100,15 +100,17 @@ def directory_digest(
     storage_options: dict | None = None,
     prefix: str = "",
 ) -> str:
-    """Hash the sorted (name, size) pairs of a directory's matching entries.
+    """Hash the sorted (basename, size) pairs of a directory's matching entries.
+
+    Only the final path component of each entry is hashed, so a byte-identical
+    folder copied to another location yields the same digest.
 
     Args:
         directory: fsspec-compatible URI to the directory.
-        suffix: only entries ending in this suffix are included.
+        suffix: only entries whose basename ends with this suffix are included.
         storage_options: extra kwargs forwarded to fsspec.
         prefix: only entries whose basename starts with this prefix are
-            included. Accepted but not yet enforced; ``""`` matches on suffix
-            alone.
+            included; ``""`` matches on suffix alone.
 
     Returns:
         The full 64-char hex digest, obtained with a single detailed listing
@@ -121,9 +123,13 @@ def directory_digest(
         raise _not_found(directory) from exc
 
     pairs = sorted(
-        (str(entry["name"]), entry.get("size"))
-        for entry in entries
-        if entry.get("type") == "file" and str(entry["name"]).endswith(suffix)
+        (basename, entry.get("size"))
+        for entry, basename in (
+            (entry, str(entry["name"]).rsplit("/", 1)[-1]) for entry in entries
+        )
+        if entry.get("type") == "file"
+        and basename.startswith(prefix)
+        and basename.endswith(suffix)
     )
     payload = json.dumps(pairs)
     return hashlib.sha256(payload.encode("utf-8")).hexdigest()
@@ -172,9 +178,16 @@ def compute_assign_run_id(
         storage_options: extra kwargs forwarded to fsspec.
 
     Returns:
-        16-char id over ``directory_digest(manifests_dir)`` + ``config_digest(config)``.
+        16-char id over the digest of the folder's ``extract-``-prefixed
+        manifests + ``config_digest(config)``. Files the extract stage did not
+        write — including this stage's own previous output — are ignored.
     """
-    input_digest = directory_digest(manifests_dir, storage_options=storage_options)
+    input_digest = directory_digest(
+        manifests_dir,
+        suffix=EXTRACT_MANIFEST_SUFFIX,
+        storage_options=storage_options,
+        prefix=EXTRACT_MANIFEST_PREFIX,
+    )
     return _stage_run_id("assign", input_digest, config_digest(config))
 
 

--- a/radiologist-etl/src/radiologist/etl/identity.py
+++ b/radiologist-etl/src/radiologist/etl/identity.py
@@ -37,6 +37,13 @@ from typing import Any
 
 import fsspec  # type: ignore[import-untyped]
 
+# Filename prefix and suffix the extract stage writes
+# ("{destination}/extract-{run_id}.jsonl"). Single source of truth for "this
+# file is an extract manifest", shared by the assign-split folder scan and the
+# assign-split run-id fingerprint so the two can never disagree.
+EXTRACT_MANIFEST_PREFIX: str = "extract-"
+EXTRACT_MANIFEST_SUFFIX: str = ".jsonl"
+
 
 def _not_found(uri: str) -> FileNotFoundError:
     return FileNotFoundError(f"No such file or directory: {uri!r}")
@@ -91,6 +98,7 @@ def directory_digest(
     directory: str,
     suffix: str = ".jsonl",
     storage_options: dict | None = None,
+    prefix: str = "",
 ) -> str:
     """Hash the sorted (name, size) pairs of a directory's matching entries.
 
@@ -98,6 +106,9 @@ def directory_digest(
         directory: fsspec-compatible URI to the directory.
         suffix: only entries ending in this suffix are included.
         storage_options: extra kwargs forwarded to fsspec.
+        prefix: only entries whose basename starts with this prefix are
+            included. Accepted but not yet enforced; ``""`` matches on suffix
+            alone.
 
     Returns:
         The full 64-char hex digest, obtained with a single detailed listing

--- a/radiologist-etl/src/radiologist/etl/models.py
+++ b/radiologist-etl/src/radiologist/etl/models.py
@@ -84,6 +84,8 @@ class BuildResult:
         report_path: ``{output_dir}/split-report-{run_id}.json``.
         shard_count: number of tar shards written.
         record_count: non-excluded records written into shards.
+        failed: records that were planned into a shard but could not be written.
+        failure_rate: ``failed / planned``, ``0.0`` when nothing was planned.
     """
 
     run_id: str
@@ -92,6 +94,8 @@ class BuildResult:
     report_path: str
     shard_count: int
     record_count: int
+    failed: int = 0
+    failure_rate: float = 0.0
 
 
 @dataclass(frozen=True)

--- a/radiologist-etl/src/radiologist/etl/prefect_pipelines.py
+++ b/radiologist-etl/src/radiologist/etl/prefect_pipelines.py
@@ -94,6 +94,23 @@ def _haralick_list(cfg_node: object, key: str) -> list | None:
     return (list(val) or None) if val else None
 
 
+def _opt_int(cfg: DictConfig, key: str) -> int | None:
+    """Read an optional integer stage setting out of a config.
+
+    Args:
+        cfg: the stage's config node.
+        key: the key to resolve.
+
+    Returns:
+        ``int(value)`` when ``key`` resolves to a non-null value — including a
+        configured ``0``, which reaches the stage and is rejected there rather
+        than silently replaced by a default — and ``None`` when the key is
+        absent or explicitly null.
+    """
+    value = OmegaConf.select(cfg, key)
+    return int(value) if value is not None else None
+
+
 @task(cache_policy=INPUTS)
 def extract_batch_task(
     paths: list[str],
@@ -280,7 +297,7 @@ def extract_flow(
             f"{_PREFECT_IMPORT_ERROR}: prefect is missing. This run will not be recorded!"
         )
 
-    batch_size = int(cfg.batch_size) if OmegaConf.select(cfg, "batch_size") else None
+    batch_size = _opt_int(cfg, "batch_size")
     plan = (
         execution
         if execution is not None
@@ -329,7 +346,7 @@ def extract_flow(
             if OmegaConf.select(cfg, "iqr_factor") is not None
             else 1.5
         ),
-        workers=int(cfg.workers) if OmegaConf.select(cfg, "workers") else None,
+        workers=_opt_int(cfg, "workers"),
         batch_size=plan.batch_size,
         max_failure_rate=(
             float(cfg.max_failure_rate)
@@ -432,10 +449,15 @@ def build_flow(cfg: DictConfig, execution: ExecutionPlan | None = None) -> Build
         shard_root=cfg.shard_root,
         shard_size=int(cfg.shard_size),
         ratios=_ordered_ratios(cfg),
-        workers=int(cfg.workers) if OmegaConf.select(cfg, "workers") else None,
+        workers=_opt_int(cfg, "workers"),
         run_label=OmegaConf.select(cfg, "run_label"),
         mapper=mapper,
         storage_options=storage_options,
+        max_failure_rate=(
+            float(cfg.max_failure_rate)
+            if OmegaConf.select(cfg, "max_failure_rate") is not None
+            else 0.0
+        ),
     )
 
     opts = storage_options or {}
@@ -448,7 +470,7 @@ def build_flow(cfg: DictConfig, execution: ExecutionPlan | None = None) -> Build
     ]
     create_table_artifact(
         table=rows,
-        key=f"build-{result.run_id}",
+        key=f"build-report-{result.run_id}",
         description=f"Shard split report for run {result.run_id}",
     )
 
@@ -457,7 +479,8 @@ def build_flow(cfg: DictConfig, execution: ExecutionPlan | None = None) -> Build
         key=f"build-{result.run_id}",
         description=(
             f"Build output for run {result.run_id}: "
-            f"{result.shard_count} shard(s), {result.record_count} record(s)."
+            f"{result.shard_count} shard(s), {result.record_count} record(s), "
+            f"{result.failed} failed."
         ),
     )
     return result
@@ -472,7 +495,7 @@ def run_extract(cfg: DictConfig) -> ExtractResult:
     Returns:
         An :class:`~radiologist.etl.models.ExtractResult` describing the run.
     """
-    batch_size = int(cfg.batch_size) if OmegaConf.select(cfg, "batch_size") else None
+    batch_size = _opt_int(cfg, "batch_size")
     plan = resolve_execution(OmegaConf.select(cfg, "runner"), batch_size=batch_size)
     flow_to_run = with_task_runner(extract_flow, plan)
     return flow_to_run(cfg, execution=plan)

--- a/radiologist-etl/src/radiologist/etl/processors.py
+++ b/radiologist-etl/src/radiologist/etl/processors.py
@@ -35,6 +35,15 @@ from radiologist.etl.models import BatchOutcome
 from radiologist.etl.stats import StatExtractor
 from radiologist.utils import read_image
 
+# Raised verbatim by both the extract stage and the per-batch worker when a
+# masks root is supplied without the images root the mirror path needs. It is
+# package-private: an implementation detail shared by two sibling modules, not
+# a public API, so it is deliberately absent from the package's ``__all__``.
+_MASKS_ROOT_REQUIRES_IMAGES_ROOT = (
+    "masks_root requires images_root to resolve the mask mirror path — "
+    "both are required together"
+)
+
 
 def _resolve_mask(
     image_path: str,
@@ -159,7 +168,16 @@ def process_batch(
         A :class:`~radiologist.etl.models.BatchOutcome`: one record per
         readable image, one ``(path, message)`` entry per unreadable one.
         Never raises for a single bad image.
+
+    Raises:
+        ValueError: if ``masks_root`` is set without ``images_root``. This
+            describes the call rather than any one image — it is identical
+            for every path in the batch and is detectable before any image
+            is opened — so it propagates instead of being collected.
     """
+    if masks_root is not None and images_root is None:
+        raise ValueError(_MASKS_ROOT_REQUIRES_IMAGES_ROOT)
+
     records: list[ManifestRecord] = []
     failures: list[tuple[str, str]] = []
     for path in paths:

--- a/radiologist-etl/src/radiologist/etl/shards.py
+++ b/radiologist-etl/src/radiologist/etl/shards.py
@@ -99,8 +99,9 @@ def write_shard(
     """
     opts = storage_options or {}
     shard_filename = f"{job.split}-{job.label.lower()}-{job.index:06d}.tar"
-    relative_path = "/".join([job.split, job.label, shard_filename])
-    shard_path = fst.pathjoin(job.shard_root, job.split, job.label, shard_filename)
+    parts = [p for p in (job.split, job.label, shard_filename) if p]
+    relative_path = "/".join(parts)
+    shard_path = fst.pathjoin(job.shard_root, *parts)
 
     fs_dst, dst_path = fsspec.url_to_fs(shard_path, **opts)
     if hasattr(fs_dst, "makedirs"):


### PR DESCRIPTION
## Summary

Implements the epic **"radiologist-etl correctness hardening (ten verified defects)"** (milestone #17). A plain no-extras install now runs all three ETL stages end to end; every stage either produces a manifest whose invariants hold or fails loudly; run ids are reproducible and location-independent; every shipped config key is honoured; no dispatch leaves scratch behind.

- Closes #195, #196, #197, #198, #199, #200, #201, #202, #203
- #204 (optional failure-rate-gate unification) was evaluated against its own stated bar and closed as won't-do — see the issue comment for the reasoning. A smaller, real duplication it surfaced (unbounded failure-description strings) is fixed in this PR instead.

## What changed, per defect

1. **#195** — skeleton: behaviour-preserving public API contract (`BuildFailureError`, `SHARD_WRITE_FAILED_REASON`, `EXTRACT_MANIFEST_PREFIX`/`_SUFFIX`, `max_failure_rate` param, `directory_digest(prefix=...)`) landing with zero behaviour change.
2. **#196** — the build stage now surfaces and gates shard-write failures: `BuildFailureError` fires above `max_failure_rate`, tolerated failures are marked `excluded=True` with `SHARD_WRITE_FAILED_REASON` so no manifest record is ever both non-excluded and shard-less.
3. **#197** — assign-split's run id now fingerprints only `extract-*.jsonl` manifests, by basename, so it's portable across locations and stable when input equals output. **This is the one run-id change in the epic** — announce before merging to `main`, since the next assign-split/build run on any real corpus lands under a new id.
4. **#198** — the shard path recorded in the build manifest now resolves to the tar actually written, including for the empty split.
5. **#199** — the local runner family (and `radiologist etl` generally) now works without prefect installed; the CLI's `etl` extra gate is now importability-only.
6. **#200** — zero-valued execution knobs (e.g. `workers=0`) are honoured/rejected instead of silently replaced by a default; the build flow now surfaces its split-report table and output link as two distinct orchestration artifacts.
7. **#201** — Beam scratch parts are reclaimed after every dispatch, success or failure, without ever masking a real exception.
8. **#202** — requesting mask-based features without `images_root` now fails immediately with a message naming both settings.
9. **#203** — all three ETL CLI subcommands emit the failure/volume fields operators need to gate a pipeline on.

## Review-driven fixes (post-implementation, pre-merge)

Four parallel code reviews (bugs/spec-divergence, simplicity/DRY, conventions, performance) were run against the full diff. Bugs/spec-divergence came back clean — every epic-wide hard constraint verified to hold. The other three surfaced real findings, all fixed here:

- Rebased the branch to linear history (was 6 `--no-ff` merge-bubble commits from parallel-agent integration — violated this repo's mandatory rebase-merge convention; safe since the branch had never been pushed).
- `identity.py`/`assign.py` each re-implemented the extract-manifest matching predicate independently; extracted the shared rule (`_matches`) while keeping `directory_digest` fully generic.
- `assign.py`'s new dedup/collision-tracking block used bare `dict`/`list`/`set` annotations; parameterized them.
- `build_shards` re-derived its failure-rate denominator from `records` instead of reading it off the shard plan it already built; now reads `sum(len(job.records) for job in jobs)`.
- Both `extract()`'s and `build_shards()`'s failure-gate exceptions built an unbounded failure-description string — a systemic failure (moved bucket, revoked creds) on a large corpus could put tens of MB into an exception message Prefect persists verbatim. Capped at 20 entries per stage.
- `BuildResult.failure_rate` existed but wasn't emitted in the CLI's build payload, even though `ExtractResult.failure_rate` was — fixed for consistency with the epic's own acceptance criterion.

## Test plan

- [x] Full `radiologist-etl` + `radiologist-cli` suite green on Python 3.10.16 with all extras: **374 passed, 0 failed**
- [x] mypy clean on every changed source file
- [x] All pre-commit hooks (license, isort, black, flake8, mypy, commitizen) pass on every commit
- [x] Four-dimension code review completed; all actionable findings fixed
- [ ] Announce the #197 run-id change to anyone with real corpora before merging to `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
