### PR TITLE
feat: explicit registry provenance for inference predictor loading

### DIFF
--- a/docs/reference/cli-inference.md
+++ b/docs/reference/cli-inference.md
@@ -19,17 +19,23 @@ Every command prints a single keyed record to stdout via
 Every command that loads a model shares the same dispatch rule, implemented
 via `verbs.load_predictor`/`verbs.get_verb`:
 
-- **Local path** — pass `--path` to load an ONNX file directly from disk via
-  `BasePredictor.from_path`.
+- **Local path only** — pass `--path` with no selector flag to load an ONNX
+  file directly from disk via `BasePredictor.from_path`.
 - **Registry selector** — pass any of `--run-id`, `--tags`, `--groups`, or
-  `--metric` (without `--path`) to resolve and download an artifact from the
-  W&B Model Registry via `BasePredictor.from_selector`. The resolved file is
-  saved into `--local-dir` (defaults to `.`).
-- Exactly one of the two strategies must be usable: providing neither
-  `--path` nor any selector flag raises an error (except for `serve`, where
-  omitting both starts the server with no model loaded — see below), and
-  providing both `--path` and a selector flag also raises an error rather
-  than silently favoring one.
+  `--metric` *together with* `--path` to resolve and download an artifact
+  from the W&B Model Registry via `BasePredictor.from_selector`. `--path`
+  supplies the entity/project (e.g. `entity/project`) the selector resolves
+  against; the resolved file is saved into `--local-dir` (defaults to `.`).
+  A registry selector given without `--path` raises an error rather than
+  silently falling back to W&B's ambient default entity/project.
+- Providing neither `--path` nor any selector flag raises an error (except
+  for `serve`, where omitting both starts the server with no model loaded —
+  see below).
+
+The resolved artifact's provenance — its fully qualified registry name and
+version — is surfaced in every command's output record as
+`model_qualified_name` and `model_version`. Both are `null` when the
+predictor was loaded via `--path` alone (no registry lookup took place).
 
 `uncertainty` loads a single-session `MCDropoutPredictor`: the same ONNX
 model serves both the deterministic and the stochastic MC-Dropout forward
@@ -54,24 +60,27 @@ carrying the predicted class label and per-class probabilities.
 radiologist infer predict chest_xray.png --path model.onnx
 
 # Registry-backed resolution
-radiologist infer predict chest_xray.png --run-id abc123 --local-dir ./models
+radiologist infer predict chest_xray.png --path entity/project \
+    --run-id abc123 --local-dir ./models
 
 # With explicit normalization and input shape
 radiologist infer predict chest_xray.png --path model.onnx \
     --mean 128 --std 65 --input-shape 1,3,224,224
 ```
 
-Emitted keys: `predicted_class`, `probabilities` (nested `Dict[str, float]`).
+Emitted keys: `predicted_class`, `probabilities` (nested `Dict[str, float]`),
+`model_qualified_name`, `model_version` (both `null` unless a registry
+selector was used).
 
 | Option | Description |
 |---|---|
 | `image_path` (argument) | Path to the input chest X-ray image. |
 | `--path` | Path to the deterministic ONNX model. |
-| `--run-id` | W&B run ID identifying the registry artifact to resolve. Mutually exclusive with `--path`. |
+| `--run-id` | W&B run ID identifying the registry artifact to resolve. Requires `--path` (supplies the entity/project). |
 | `--tags` | Registry artifact tag(s) to filter by when `--run-id` is not used. Repeatable. |
 | `--groups` | Registry artifact group(s) to filter by when `--run-id` is not used. Repeatable. |
 | `--metric` | Metric name used to pick the best-scoring artifact among candidates matching `--tags`/`--groups`. |
-| `--local-dir` | Local directory the resolved registry artifact is downloaded into. Ignored when `--path` is used. Defaults to `.`. |
+| `--local-dir` | Local directory the resolved registry artifact is downloaded into. Ignored when `--path` is used with no registry selector. Defaults to `.`. |
 | `--mean` | Normalization mean (requires `--std`). |
 | `--std` | Normalization std (requires `--mean`). |
 | `--input-shape` | Fallback `[N,C,H,W]` as comma-separated ints, e.g. `1,3,224,224`. |
@@ -91,17 +100,18 @@ radiologist infer explain chest_xray.png --path model.onnx
 ```
 
 Emitted keys: `predicted_class`, `saliency_shape` (list of ints),
-`saliency_path` (`null` unless `--out` was given).
+`saliency_path` (`null` unless `--out` was given), `model_qualified_name`,
+`model_version` (both `null` unless a registry selector was used).
 
 | Option | Description |
 |---|---|
 | `image_path` (argument) | Path to the input chest X-ray image. |
 | `--path` | Path to the deterministic ONNX model. |
-| `--run-id` | W&B run ID identifying the registry artifact to resolve. Mutually exclusive with `--path`. |
+| `--run-id` | W&B run ID identifying the registry artifact to resolve. Requires `--path` (supplies the entity/project). |
 | `--tags` | Registry artifact tag(s) to filter by when `--run-id` is not used. Repeatable. |
 | `--groups` | Registry artifact group(s) to filter by when `--run-id` is not used. Repeatable. |
 | `--metric` | Metric name used to pick the best-scoring artifact among candidates matching `--tags`/`--groups`. |
-| `--local-dir` | Local directory the resolved registry artifact is downloaded into. Ignored when `--path` is used. Defaults to `.`. |
+| `--local-dir` | Local directory the resolved registry artifact is downloaded into. Ignored when `--path` is used with no registry selector. Defaults to `.`. |
 | `--out` | Path to save the saliency map as a `.npy` file. When omitted, only the shape is printed. |
 | `--mean` | Normalization mean (requires `--std`). |
 | `--std` | Normalization std (requires `--mean`). |
@@ -119,24 +129,27 @@ predictive entropy.
 radiologist infer uncertainty chest_xray.png --path model.onnx
 
 # Registry-backed resolution
-radiologist infer uncertainty chest_xray.png --run-id abc123 --local-dir ./models
+radiologist infer uncertainty chest_xray.png --path entity/project \
+    --run-id abc123 --local-dir ./models
 
 # More stochastic passes for a tighter estimate
 radiologist infer uncertainty chest_xray.png --path model.onnx --n-passes 100
 ```
 
 Emitted keys: `predicted_class`, `n_passes`, `predictive_entropy`,
-`mean_probabilities`, `std_probabilities` (both nested `Dict[str, float]`).
+`mean_probabilities`, `std_probabilities` (both nested `Dict[str, float]`),
+`model_qualified_name`, `model_version` (both `null` unless a registry
+selector was used).
 
 | Option | Description |
 |---|---|
 | `image_path` (argument) | Path to the input chest X-ray image. |
 | `--path` | Path to the MC-Dropout ONNX model. |
-| `--run-id` | W&B run ID identifying the registry artifact to resolve. Mutually exclusive with `--path`. |
+| `--run-id` | W&B run ID identifying the registry artifact to resolve. Requires `--path` (supplies the entity/project). |
 | `--tags` | Registry artifact tag(s) to filter by when `--run-id` is not used. Repeatable. |
 | `--groups` | Registry artifact group(s) to filter by when `--run-id` is not used. Repeatable. |
 | `--metric` | Metric name used to pick the best-scoring artifact among candidates matching `--tags`/`--groups`. |
-| `--local-dir` | Local directory the resolved registry artifact is downloaded into. Ignored when `--path` is used. Defaults to `.`. |
+| `--local-dir` | Local directory the resolved registry artifact is downloaded into. Ignored when `--path` is used with no registry selector. Defaults to `.`. |
 | `--n-passes` | Number of stochastic forward passes. Defaults to `30`. |
 | `--mean` | Normalization mean (requires `--std`). |
 | `--std` | Normalization std (requires `--mean`). |
@@ -155,7 +168,8 @@ record before the server starts accepting connections.
 radiologist infer serve --path model.onnx --host 0.0.0.0 --port 8000
 
 # Serve a registry-resolved model as a Classifier
-radiologist infer serve --run-id abc123 --local-dir ./models --predict
+radiologist infer serve --path entity/project \
+    --run-id abc123 --local-dir ./models --predict
 
 # Start with no model loaded (routes return 503 until one is available)
 radiologist infer serve
@@ -168,16 +182,18 @@ available. `/healthz` (liveness) and `/readyz` (readiness) are always
 available regardless of predictor state.
 
 Emitted keys: `host`, `port`, `verb`, `model_path` (`null` unless `--path`
-was given), `model_run_id` (`null` unless `--run-id` was given).
+was given), `model_run_id` (`null` unless `--run-id` was given),
+`model_qualified_name`, `model_version` (both `null` unless a registry
+selector was used).
 
 | Option | Description |
 |---|---|
 | `--path` | Path to the deterministic ONNX model. |
-| `--run-id` | W&B run ID identifying the registry artifact to resolve. Mutually exclusive with `--path`. |
+| `--run-id` | W&B run ID identifying the registry artifact to resolve. Requires `--path` (supplies the entity/project). |
 | `--tags` | Registry artifact tag(s) to filter by when `--run-id` is not used. Repeatable. |
 | `--groups` | Registry artifact group(s) to filter by when `--run-id` is not used. Repeatable. |
 | `--metric` | Metric name used to pick the best-scoring artifact among candidates matching `--tags`/`--groups`. |
-| `--local-dir` | Local directory the resolved registry artifact is downloaded into. Ignored when `--path` is used. Defaults to `.`. |
+| `--local-dir` | Local directory the resolved registry artifact is downloaded into. Ignored when `--path` is used with no registry selector. Defaults to `.`. |
 | `--host` | Host interface to bind the HTTP server to. Defaults to `127.0.0.1`. |
 | `--port` | TCP port to bind the HTTP server to. Defaults to `8000`. |
 | `--predict` | Serve a `Classifier` (predict verb). |

--- a/radiologist-cli/radiologist_cli_tests/test_inference_commands.py
+++ b/radiologist-cli/radiologist_cli_tests/test_inference_commands.py
@@ -103,6 +103,8 @@ class TestPredictCommand:
                 [
                     "predict",
                     image_path,
+                    "--path",
+                    "entity/project",
                     "--run-id",
                     "run1",
                     "--local-dir",
@@ -115,6 +117,8 @@ class TestPredictCommand:
         assert "predicted_class" in record
         assert set(record["probabilities"].keys()) == {"NORMAL", "ABNORMAL"}
         assert pulled_art.download.call_count == 1
+        assert record["model_qualified_name"] == "entity/project/model-run1:best"
+        assert record["model_version"] == "best"
 
     def test_predict_missing_model_file_exits_2(self, tmp_path, make_png_path):
         from radiologist.cli.groups.inference import app
@@ -125,6 +129,45 @@ class TestPredictCommand:
         result = runner.invoke(app, ["predict", image_path, "--path", missing_path])
 
         assert result.exit_code == 2, result.output
+
+    def test_predict_with_local_path_emits_null_provenance_entries(
+        self, tmp_path, build_det_onnx, make_png_path, monkeypatch
+    ):
+        from radiologist.cli.groups.inference import app
+
+        monkeypatch.setenv("RADIOLOGIST_OUTPUT", "json")
+        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+        image_path = make_png_path(tmp_path)
+
+        result = runner.invoke(app, ["predict", image_path, "--path", det_path])
+
+        assert result.exit_code == 0, result.output
+        record = json.loads(result.output)
+        assert record["model_qualified_name"] is None
+        assert record["model_version"] is None
+
+    def test_predict_with_registry_selector_and_no_path_exits_nonzero(
+        self, tmp_path, make_png_path
+    ):
+        from radiologist.cli.groups.inference import app
+
+        image_path = make_png_path(tmp_path)
+
+        result = runner.invoke(app, ["predict", image_path, "--run-id", "run1"])
+
+        assert result.exit_code != 0
+        assert "--path" in result.output
+
+    def test_predict_with_neither_path_nor_selector_exits_nonzero(
+        self, tmp_path, make_png_path
+    ):
+        from radiologist.cli.groups.inference import app
+
+        image_path = make_png_path(tmp_path)
+
+        result = runner.invoke(app, ["predict", image_path])
+
+        assert result.exit_code != 0
 
 
 class TestExplainCommand:
@@ -167,6 +210,64 @@ class TestExplainCommand:
         assert record["saliency_path"] is None
         assert isinstance(record["saliency_shape"], list)
         assert len(list(tmp_path.glob("*.npy"))) == 0
+        assert record["model_qualified_name"] is None
+        assert record["model_version"] is None
+
+    def test_explain_with_registry_selector_emits_provenance(
+        self, tmp_path, build_det_onnx, make_png_path, monkeypatch
+    ):
+        from radiologist.cli.groups.inference import app
+
+        monkeypatch.setenv("RADIOLOGIST_OUTPUT", "json")
+        build_det_onnx(tmp_path, filename="det.onnx")
+        image_path = make_png_path(tmp_path)
+        mock_wandb, pulled_art = _make_registry_wandb_mock()
+        pulled_art.download.return_value = str(tmp_path)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            result = runner.invoke(
+                app,
+                [
+                    "explain",
+                    image_path,
+                    "--path",
+                    "entity/project",
+                    "--run-id",
+                    "run1",
+                    "--local-dir",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        record = json.loads(result.output)
+        assert record["model_qualified_name"] == "entity/project/model-run1:best"
+        assert record["model_version"] == "best"
+
+    def test_explain_with_registry_selector_and_no_path_exits_nonzero(
+        self, tmp_path, make_png_path
+    ):
+        from radiologist.cli.groups.inference import app
+
+        image_path = make_png_path(tmp_path)
+
+        result = runner.invoke(app, ["explain", image_path, "--run-id", "run1"])
+
+        assert result.exit_code != 0
+        assert "--path" in result.output
+
+    def test_explain_with_neither_path_nor_selector_exits_nonzero(
+        self, tmp_path, make_png_path
+    ):
+        from radiologist.cli.groups.inference import app
+
+        image_path = make_png_path(tmp_path)
+
+        result = runner.invoke(app, ["explain", image_path])
+
+        assert result.exit_code != 0
 
 
 class TestUncertaintyCommand:
@@ -209,6 +310,80 @@ class TestUncertaintyCommand:
         assert result.exit_code == 0, result.output
         record = json.loads(result.output)
         assert record["n_passes"] == 13
+
+    def test_uncertainty_with_local_path_emits_null_provenance_entries(
+        self, tmp_path, build_mcd_onnx, make_png_path, monkeypatch
+    ):
+        from radiologist.cli.groups.inference import app
+
+        monkeypatch.setenv("RADIOLOGIST_OUTPUT", "json")
+        mcd_path = build_mcd_onnx(tmp_path, filename="mcd.onnx")
+        image_path = make_png_path(tmp_path)
+
+        result = runner.invoke(app, ["uncertainty", image_path, "--path", mcd_path])
+
+        assert result.exit_code == 0, result.output
+        record = json.loads(result.output)
+        assert record["model_qualified_name"] is None
+        assert record["model_version"] is None
+
+    def test_uncertainty_with_registry_selector_emits_provenance(
+        self, tmp_path, build_mcd_onnx, make_png_path, monkeypatch
+    ):
+        from radiologist.cli.groups.inference import app
+
+        monkeypatch.setenv("RADIOLOGIST_OUTPUT", "json")
+        mcd_dir = tmp_path / "mcd"
+        mcd_dir.mkdir()
+        build_mcd_onnx(mcd_dir, filename="mcd.onnx")
+        image_path = make_png_path(tmp_path)
+        mock_wandb, pulled_art = _make_registry_wandb_mock()
+        pulled_art.download.return_value = str(mcd_dir)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            result = runner.invoke(
+                app,
+                [
+                    "uncertainty",
+                    image_path,
+                    "--path",
+                    "entity/project",
+                    "--run-id",
+                    "run1",
+                    "--local-dir",
+                    str(tmp_path),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        record = json.loads(result.output)
+        assert record["model_qualified_name"] == "entity/project/model-run1:best"
+        assert record["model_version"] == "best"
+
+    def test_uncertainty_with_registry_selector_and_no_path_exits_nonzero(
+        self, tmp_path, make_png_path
+    ):
+        from radiologist.cli.groups.inference import app
+
+        image_path = make_png_path(tmp_path)
+
+        result = runner.invoke(app, ["uncertainty", image_path, "--run-id", "run1"])
+
+        assert result.exit_code != 0
+        assert "--path" in result.output
+
+    def test_uncertainty_with_neither_path_nor_selector_exits_nonzero(
+        self, tmp_path, make_png_path
+    ):
+        from radiologist.cli.groups.inference import app
+
+        image_path = make_png_path(tmp_path)
+
+        result = runner.invoke(app, ["uncertainty", image_path])
+
+        assert result.exit_code != 0
 
 
 class TestOutputFormat:

--- a/radiologist-cli/radiologist_cli_tests/test_registry_commands.py
+++ b/radiologist-cli/radiologist_cli_tests/test_registry_commands.py
@@ -63,6 +63,15 @@ class TestResolveCommand:
         assert result.exit_code != 0
         assert "Error:" in result.output
 
+    def test_without_base_path_argument_exits_non_zero_without_contacting_registry(
+        self,
+    ):
+        with patch("radiologist.registry.resolver._wandb") as resolver_wandb:
+            result = runner.invoke(app, ["resolve", "--run-id", "R"])
+
+        assert result.exit_code != 0
+        resolver_wandb.Api.assert_not_called()
+
 
 class TestPullCommand:
     def test_registry_backed_selector_resolves_then_downloads(self, tmp_path):
@@ -136,6 +145,25 @@ class TestPullCommand:
             )
 
         assert result.exit_code == 2
+
+    def test_registry_backed_selector_with_blank_path_exits_non_zero(self, tmp_path):
+        local_dir = tmp_path / "out"
+
+        with patch("radiologist.registry.resolver._wandb") as mock_wandb:
+            result = runner.invoke(
+                app,
+                [
+                    "pull",
+                    "   ",
+                    "--local-dir",
+                    str(local_dir),
+                    "--run-id",
+                    "R",
+                ],
+            )
+
+        assert result.exit_code != 0
+        mock_wandb.Api.assert_not_called()
 
 
 class TestPushCommand:
@@ -256,6 +284,27 @@ class TestPromoteCommand:
         assert "production" in result.output
         assert "model-R:best" in result.output
         assert "model-R-mcd:best" in result.output
+
+    def test_without_base_path_argument_exits_non_zero_without_contacting_registry(
+        self,
+    ):
+        with patch("radiologist.registry.resolver._wandb") as resolver_wandb:
+            result = runner.invoke(
+                app,
+                [
+                    "promote",
+                    "--run-id",
+                    "R",
+                    "--det-collection",
+                    "DC",
+                    "--mcd-collection",
+                    "MC",
+                    "--force",
+                ],
+            )
+
+        assert result.exit_code != 0
+        resolver_wandb.Api.assert_not_called()
 
 
 class TestTransitionToProductionCommand:

--- a/radiologist-cli/radiologist_cli_tests/test_serve_command.py
+++ b/radiologist-cli/radiologist_cli_tests/test_serve_command.py
@@ -96,6 +96,8 @@ class TestServeCommand:
         assert record["verb"] == "explain"
         assert record["model_path"] == det_path
         assert record["model_run_id"] is None
+        assert record["model_qualified_name"] is None
+        assert record["model_version"] is None
 
     def test_serve_with_registry_run_id_emits_record_with_model_run_id(
         self, tmp_path, build_mcd_onnx, monkeypatch
@@ -120,6 +122,8 @@ class TestServeCommand:
                     [
                         "serve",
                         "--uncertainty",
+                        "--path",
+                        "entity/project",
                         "--run-id",
                         "run1",
                         "--local-dir",
@@ -131,8 +135,24 @@ class TestServeCommand:
         mock_uvicorn.run.assert_called_once()
         record = json.loads(result.output)
         assert record["model_run_id"] == "run1"
-        assert record["model_path"] is None
+        assert record["model_path"] == "entity/project"
         assert record["verb"] == "uncertainty"
+        assert record["model_qualified_name"] == "entity/project/model-run1:best"
+        assert record["model_version"] == "best"
+
+    def test_serve_with_registry_selector_and_no_path_exits_nonzero_without_serving(
+        self, tmp_path, monkeypatch
+    ):
+        import radiologist.inference.optional as optional_mod
+        from radiologist.cli.groups.inference import app
+
+        mock_uvicorn = MagicMock()
+        with patch.object(optional_mod, "_uvicorn", mock_uvicorn):
+            result = runner.invoke(app, ["serve", "--run-id", "run1"])
+
+        assert result.exit_code != 0
+        assert "--path" in result.output
+        mock_uvicorn.run.assert_not_called()
 
     def test_serve_with_no_model_source_starts_with_no_predictor_and_null_record(
         self, tmp_path, make_png_path, monkeypatch
@@ -152,6 +172,8 @@ class TestServeCommand:
         record = json.loads(result.output)
         assert record["model_path"] is None
         assert record["model_run_id"] is None
+        assert record["model_qualified_name"] is None
+        assert record["model_version"] is None
 
         (fastapi_app,), _ = mock_uvicorn.run.call_args
         client = TestClient(fastapi_app)

--- a/radiologist-cli/src/radiologist/cli/groups/inference.py
+++ b/radiologist-cli/src/radiologist/cli/groups/inference.py
@@ -62,18 +62,21 @@ def _parse_int_list(value: Optional[str]) -> Optional[List[int]]:
     return [int(part) for part in value.split(",")]
 
 
-def _provenance_record(predictor: "BasePredictor") -> Dict[str, Optional[str]]:
+def _provenance_record(
+    predictor: Optional["BasePredictor"],
+) -> Dict[str, Optional[str]]:
     """Build the reportable provenance record for a loaded predictor.
 
     Args:
-        predictor: Loaded predictor instance.
+        predictor: Loaded predictor instance, or ``None`` when no predictor
+            was loaded (e.g. ``serve`` started without a source).
 
     Returns:
         A dict with keys ``model_qualified_name`` and ``model_version``, both
         ``None`` when the predictor carries no provenance (i.e. it was loaded
-        from a local file path rather than a registry selector).
+        from a local file path rather than a registry selector) or is absent.
     """
-    ref = predictor.provenance
+    ref = predictor.provenance if predictor is not None else None
     if ref is None:
         return {"model_qualified_name": None, "model_version": None}
     return {"model_qualified_name": ref.qualified_name, "model_version": ref.version}
@@ -84,7 +87,10 @@ def _provenance_record(predictor: "BasePredictor") -> Dict[str, Optional[str]]:
 def predict(
     image_path: str = typer.Argument(..., help="Path to the input chest X-ray image."),
     path: Optional[str] = typer.Option(
-        None, "--path", help="Path to the deterministic ONNX model."
+        None,
+        "--path",
+        help="Path to the deterministic ONNX model, or (with a registry "
+        "selector flag) the entity/project prefix to resolve against.",
     ),
     run_id: Optional[str] = typer.Option(
         None,
@@ -156,7 +162,10 @@ def predict(
 def explain(
     image_path: str = typer.Argument(..., help="Path to the input chest X-ray image."),
     path: Optional[str] = typer.Option(
-        None, "--path", help="Path to the deterministic ONNX model."
+        None,
+        "--path",
+        help="Path to the deterministic ONNX model, or (with a registry "
+        "selector flag) the entity/project prefix to resolve against.",
     ),
     run_id: Optional[str] = typer.Option(
         None,
@@ -236,7 +245,10 @@ def explain(
 def uncertainty(
     image_path: str = typer.Argument(..., help="Path to the input chest X-ray image."),
     path: Optional[str] = typer.Option(
-        None, "--path", help="Path to the MC-Dropout ONNX model."
+        None,
+        "--path",
+        help="Path to the MC-Dropout ONNX model, or (with a registry "
+        "selector flag) the entity/project prefix to resolve against.",
     ),
     run_id: Optional[str] = typer.Option(
         None,
@@ -315,7 +327,10 @@ def uncertainty(
 @exit_on_error
 def serve(
     path: Optional[str] = typer.Option(
-        None, "--path", help="Path to the deterministic ONNX model."
+        None,
+        "--path",
+        help="Path to the deterministic ONNX model, or (with a registry "
+        "selector flag) the entity/project prefix to resolve against.",
     ),
     run_id: Optional[str] = typer.Option(
         None,
@@ -386,11 +401,6 @@ def serve(
         else None
     )
     fastapi_app = create_app(predictor)
-    provenance = (
-        _provenance_record(predictor)
-        if predictor is not None
-        else {"model_qualified_name": None, "model_version": None}
-    )
     emit(
         {
             "host": host,
@@ -398,7 +408,7 @@ def serve(
             "verb": verb_name,
             "model_path": path,
             "model_run_id": run_id,
-            **provenance,
+            **_provenance_record(predictor),
         }
     )
     _inference_optional._uvicorn.run(fastapi_app, host=host, port=port)

--- a/radiologist-cli/src/radiologist/cli/groups/inference.py
+++ b/radiologist-cli/src/radiologist/cli/groups/inference.py
@@ -73,7 +73,10 @@ def _provenance_record(predictor: "BasePredictor") -> Dict[str, Optional[str]]:
         ``None`` when the predictor carries no provenance (i.e. it was loaded
         from a local file path rather than a registry selector).
     """
-    raise NotImplementedError
+    ref = predictor.provenance
+    if ref is None:
+        return {"model_qualified_name": None, "model_version": None}
+    return {"model_qualified_name": ref.qualified_name, "model_version": ref.version}
 
 
 @app.command()
@@ -87,7 +90,7 @@ def predict(
         None,
         "--run-id",
         help="W&B run ID identifying the registry artifact to resolve. "
-        "Mutually exclusive with --path.",
+        "Requires --path (supplies the entity/project to resolve against).",
     ),
     tags: Optional[List[str]] = typer.Option(
         None,
@@ -111,7 +114,7 @@ def predict(
         ".",
         "--local-dir",
         help="Local directory the resolved registry artifact is downloaded "
-        "into. Ignored when --path is used.",
+        "into. Ignored when no registry selector is given.",
     ),
     mean: Optional[float] = typer.Option(
         None, "--mean", help="Normalization mean (requires --std)."
@@ -143,6 +146,7 @@ def predict(
         {
             "predicted_class": result.predicted_class,
             "probabilities": result.probabilities,
+            **_provenance_record(classifier),
         }
     )
 
@@ -158,7 +162,7 @@ def explain(
         None,
         "--run-id",
         help="W&B run ID identifying the registry artifact to resolve. "
-        "Mutually exclusive with --path.",
+        "Requires --path (supplies the entity/project to resolve against).",
     ),
     tags: Optional[List[str]] = typer.Option(
         None,
@@ -182,7 +186,7 @@ def explain(
         ".",
         "--local-dir",
         help="Local directory the resolved registry artifact is downloaded "
-        "into. Ignored when --path is used.",
+        "into. Ignored when no registry selector is given.",
     ),
     out: Optional[str] = typer.Option(
         None, "--out", help="Path to save the saliency map as a .npy file."
@@ -222,6 +226,7 @@ def explain(
             "predicted_class": result.predicted_class,
             "saliency_shape": list(result.saliency_map.shape),
             "saliency_path": saliency_path,
+            **_provenance_record(explainer),
         }
     )
 
@@ -237,7 +242,7 @@ def uncertainty(
         None,
         "--run-id",
         help="W&B run ID identifying the registry artifact to resolve. "
-        "Mutually exclusive with --path.",
+        "Requires --path (supplies the entity/project to resolve against).",
     ),
     tags: Optional[List[str]] = typer.Option(
         None,
@@ -261,7 +266,7 @@ def uncertainty(
         ".",
         "--local-dir",
         help="Local directory the resolved registry artifact is downloaded "
-        "into. Ignored when --path is used.",
+        "into. Ignored when no registry selector is given.",
     ),
     n_passes: int = typer.Option(
         30, "--n-passes", help="Number of stochastic forward passes."
@@ -301,6 +306,7 @@ def uncertainty(
             "predictive_entropy": result.predictive_entropy,
             "mean_probabilities": result.mean_probabilities,
             "std_probabilities": result.std_per_class,
+            **_provenance_record(predictor),
         }
     )
 
@@ -315,7 +321,7 @@ def serve(
         None,
         "--run-id",
         help="W&B run ID identifying the registry artifact to resolve. "
-        "Mutually exclusive with --path.",
+        "Requires --path (supplies the entity/project to resolve against).",
     ),
     tags: Optional[List[str]] = typer.Option(
         None,
@@ -339,7 +345,7 @@ def serve(
         ".",
         "--local-dir",
         help="Local directory the resolved registry artifact is downloaded "
-        "into. Ignored when --path is used.",
+        "into. Ignored when no registry selector is given.",
     ),
     host: str = typer.Option(
         "127.0.0.1", "--host", help="Host interface to bind the HTTP server to."
@@ -380,6 +386,11 @@ def serve(
         else None
     )
     fastapi_app = create_app(predictor)
+    provenance = (
+        _provenance_record(predictor)
+        if predictor is not None
+        else {"model_qualified_name": None, "model_version": None}
+    )
     emit(
         {
             "host": host,
@@ -387,6 +398,7 @@ def serve(
             "verb": verb_name,
             "model_path": path,
             "model_run_id": run_id,
+            **provenance,
         }
     )
     _inference_optional._uvicorn.run(fastapi_app, host=host, port=port)

--- a/radiologist-cli/src/radiologist/cli/groups/inference.py
+++ b/radiologist-cli/src/radiologist/cli/groups/inference.py
@@ -30,7 +30,7 @@ repo-wide :func:`radiologist.cli.errors.exit_on_error` decorator and
 :func:`radiologist.cli.errors.run_typer_app` runner.
 """
 
-from typing import List, Optional
+from typing import TYPE_CHECKING, Dict, List, Optional
 
 import numpy as np
 import typer
@@ -40,6 +40,9 @@ from radiologist.inference import optional as _inference_optional
 from radiologist.inference import verbs
 from radiologist.inference.app import create_app
 from radiologist.utils.cli import emit
+
+if TYPE_CHECKING:
+    from radiologist.inference.base_predictor import BasePredictor
 
 app = typer.Typer(name="infer", add_completion=False)
 
@@ -57,6 +60,20 @@ def _parse_int_list(value: Optional[str]) -> Optional[List[int]]:
     if value is None:
         return None
     return [int(part) for part in value.split(",")]
+
+
+def _provenance_record(predictor: "BasePredictor") -> Dict[str, Optional[str]]:
+    """Build the reportable provenance record for a loaded predictor.
+
+    Args:
+        predictor: Loaded predictor instance.
+
+    Returns:
+        A dict with keys ``model_qualified_name`` and ``model_version``, both
+        ``None`` when the predictor carries no provenance (i.e. it was loaded
+        from a local file path rather than a registry selector).
+    """
+    raise NotImplementedError
 
 
 @app.command()

--- a/radiologist-inference/radiologist_inference_tests/test_predictor_provenance.py
+++ b/radiologist-inference/radiologist_inference_tests/test_predictor_provenance.py
@@ -1,0 +1,148 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Behavioral tests: resolved artifact provenance travels with the predictor.
+
+Drives through the public API only: BasePredictor.provenance (inherited by
+Classifier), from_selector, from_path. Fixtures build a real ONNX model so no
+mocks are needed for locally owned code; the registry is faked at the
+resolve/pull boundary the same way test_classifier.py does.
+"""
+
+from typing import List, Optional, Tuple
+
+import numpy as np
+import pytest
+
+from radiologist.inference import Classifier
+from radiologist.registry import ArtifactRef, RegistrySelector
+
+CLASSES = ["NORMAL", "ABNORMAL"]
+
+
+class _FakeSelectorRegistry:
+    def __init__(self, det_path: str) -> None:
+        self._det_path = det_path
+        self.resolve_calls: List[Tuple[str, Optional[str]]] = []
+        self.pull_calls: List[Tuple[str, str]] = []
+
+    def resolve(
+        self,
+        path: str,
+        run_id=None,
+        groups=None,
+        tags=None,
+        metric=None,
+        version=None,
+        include_sweeps: bool = False,
+    ) -> ArtifactRef:
+        self.resolve_calls.append((path, run_id))
+        resolved_run_id = run_id or "resolved-run"
+        return ArtifactRef(
+            qualified_name=f"{path}/model-{resolved_run_id}:best",
+            run_id=resolved_run_id,
+            artifact_name=f"model-{resolved_run_id}",
+            version="best",
+        )
+
+    def pull(self, artifact_path: str, local_dir: str) -> str:
+        self.pull_calls.append((artifact_path, local_dir))
+        return self._det_path
+
+
+class TestPredictorProvenance:
+    def test_from_selector_reports_fully_qualified_artifact_name(
+        self, det_onnx_path, tmp_path
+    ):
+        """A predictor resolved from a registry selector reports the fully
+        qualified name of the artifact it was resolved from, including the
+        entity/project prefix."""
+        fake_registry = _FakeSelectorRegistry(det_onnx_path)
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        classifier = Classifier.from_selector(
+            selector, local_dir=str(tmp_path), registry=fake_registry
+        )
+
+        assert classifier.provenance is not None
+        assert (
+            classifier.provenance.qualified_name
+            == "entity/project/model/model-run123:best"
+        )
+
+    def test_from_selector_reports_resolved_artifact_version(
+        self, det_onnx_path, tmp_path
+    ):
+        """A predictor resolved from a registry selector reports the resolved
+        artifact version."""
+        fake_registry = _FakeSelectorRegistry(det_onnx_path)
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        classifier = Classifier.from_selector(
+            selector, local_dir=str(tmp_path), registry=fake_registry
+        )
+
+        assert classifier.provenance is not None
+        assert classifier.provenance.version == "best"
+
+    def test_from_path_reports_no_provenance(self, det_onnx_path):
+        """A predictor loaded from a local ONNX file path reports no
+        provenance (provenance is None)."""
+        classifier = Classifier.from_path(model_path=det_onnx_path)
+
+        assert classifier.provenance is None
+
+    def test_from_selector_prediction_matches_direct_path_load(
+        self, det_onnx_path, tmp_path
+    ):
+        """A predictor resolved from a registry selector still produces the
+        same prediction as the same model loaded directly from disk —
+        provenance is additive; inference behavior is unaffected."""
+        fake_registry = _FakeSelectorRegistry(det_onnx_path)
+        selector = RegistrySelector(path="entity/project/model", run_id="run123")
+
+        selector_classifier = Classifier.from_selector(
+            selector, local_dir=str(tmp_path), registry=fake_registry
+        )
+        path_classifier = Classifier.from_path(model_path=det_onnx_path)
+
+        image = np.zeros((224, 224, 3), dtype=np.uint8)
+        selector_result = selector_classifier.predict(image=image)
+        path_result = path_classifier.predict(image=image)
+
+        assert selector_result.predicted_class == path_result.predicted_class
+        assert selector_result.probabilities == path_result.probabilities
+
+    def test_provenance_cannot_be_reassigned_from_outside_the_predictor(
+        self, det_onnx_path
+    ):
+        """The reported provenance cannot be reassigned from outside the
+        predictor (read-only property)."""
+        classifier = Classifier.from_path(model_path=det_onnx_path)
+
+        with pytest.raises(AttributeError):
+            classifier.provenance = ArtifactRef(
+                qualified_name="entity/project/model/model-x:best",
+                run_id="x",
+                artifact_name="model-x",
+                version="best",
+            )

--- a/radiologist-inference/radiologist_inference_tests/test_verbs.py
+++ b/radiologist-inference/radiologist_inference_tests/test_verbs.py
@@ -147,7 +147,9 @@ class TestLoadPredictorFromLocalPath:
 
 
 class TestLoadPredictorFromRegistry:
-    def test_predict_verb_with_run_id_resolves_classifier_from_registry(self, tmp_path):
+    def test_predict_verb_with_path_and_run_id_resolves_classifier_from_registry(
+        self, tmp_path
+    ):
         build_det_onnx(tmp_path, filename="det.onnx")
         verb = get_verb("predict")
         mock_wandb, pulled_art = _make_registry_wandb_mock()
@@ -158,7 +160,7 @@ class TestLoadPredictorFromRegistry:
         with patch.object(resolver_mod, "_wandb", mock_wandb):
             predictor = load_predictor(
                 verb,
-                path=None,
+                path="entity/project",
                 run_id="run1",
                 tags=None,
                 groups=None,
@@ -167,8 +169,14 @@ class TestLoadPredictorFromRegistry:
             )
 
         assert isinstance(predictor, Classifier)
+        api_instance = mock_wandb.Api.return_value
+        resolve_calls = [
+            call for call in api_instance.artifact.call_args_list if call.kwargs
+        ]
+        assert len(resolve_calls) == 1
+        assert resolve_calls[0].kwargs["name"].startswith("entity/project/")
 
-    def test_uncertainty_verb_with_run_id_resolves_against_mcd_suffixed_run_id(
+    def test_uncertainty_verb_with_path_and_run_id_resolves_against_mcd_suffixed_run_id(
         self, tmp_path
     ):
         build_mcd_onnx(tmp_path, filename="mcd.onnx")
@@ -183,7 +191,7 @@ class TestLoadPredictorFromRegistry:
         with patch.object(resolver_mod, "_wandb", mock_wandb):
             predictor = load_predictor(
                 verb,
-                path=None,
+                path="entity/project",
                 run_id="run1",
                 tags=None,
                 groups=None,
@@ -198,6 +206,7 @@ class TestLoadPredictorFromRegistry:
         ]
         assert len(resolve_calls) == 1
         assert "run1-mcd" in resolve_calls[0].kwargs["name"]
+        assert resolve_calls[0].kwargs["name"].startswith("entity/project/")
 
 
 class TestLoadPredictorRaisesWhenNoSourceGiven:
@@ -223,15 +232,74 @@ class TestLoadPredictorRaisesWhenNoSourceGiven:
         assert "--metric" in message
 
 
-class TestLoadPredictorGuardsAgainstBothSourcesGiven:
-    def test_path_and_run_id_together_raises_value_error(self, tmp_path):
-        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+class TestLoadPredictorUsesPathAsRegistryOverride:
+    def test_path_and_run_id_together_resolves_from_registry_under_path_entity_project(
+        self, tmp_path
+    ):
+        build_det_onnx(tmp_path, filename="det.onnx")
+        verb = get_verb("predict")
+        mock_wandb, pulled_art = _make_registry_wandb_mock()
+        pulled_art.download.return_value = str(tmp_path)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            predictor = load_predictor(
+                verb,
+                path="entity/project",
+                run_id="run1",
+                tags=None,
+                groups=None,
+                metric=None,
+                local_dir=str(tmp_path),
+            )
+
+        assert isinstance(predictor, Classifier)
+        api_instance = mock_wandb.Api.return_value
+        resolve_calls = [
+            call for call in api_instance.artifact.call_args_list if call.kwargs
+        ]
+        assert len(resolve_calls) == 1
+        assert resolve_calls[0].kwargs["name"].startswith("entity/project/")
+
+    def test_path_and_tags_together_resolves_from_registry_under_path_entity_project(
+        self, tmp_path
+    ):
+        build_det_onnx(tmp_path, filename="det.onnx")
+        verb = get_verb("predict")
+        mock_wandb, pulled_art = _make_registry_wandb_mock()
+        pulled_art.download.return_value = str(tmp_path)
+
+        import radiologist.registry.resolver as resolver_mod
+
+        with patch.object(resolver_mod, "_wandb", mock_wandb):
+            predictor = load_predictor(
+                verb,
+                path="entity/project",
+                run_id=None,
+                tags=["a"],
+                groups=None,
+                metric=None,
+                local_dir=str(tmp_path),
+            )
+
+        assert isinstance(predictor, Classifier)
+        api_instance = mock_wandb.Api.return_value
+        resolve_calls = [
+            call for call in api_instance.artifact.call_args_list if call.kwargs
+        ]
+        assert len(resolve_calls) == 1
+        assert resolve_calls[0].kwargs["name"].startswith("entity/project/")
+
+
+class TestLoadPredictorRequiresPathWithSelector:
+    def test_run_id_without_path_raises_value_error_naming_path(self, tmp_path):
         verb = get_verb("predict")
 
         with pytest.raises(ValueError) as exc_info:
             load_predictor(
                 verb,
-                path=det_path,
+                path=None,
                 run_id="run1",
                 tags=None,
                 groups=None,
@@ -241,16 +309,14 @@ class TestLoadPredictorGuardsAgainstBothSourcesGiven:
 
         message = str(exc_info.value)
         assert "--path" in message
-        assert "--run-id" in message
 
-    def test_path_and_tags_together_raises_value_error(self, tmp_path):
-        det_path = build_det_onnx(tmp_path, filename="det.onnx")
+    def test_tags_without_path_raises_value_error_naming_path(self, tmp_path):
         verb = get_verb("predict")
 
         with pytest.raises(ValueError) as exc_info:
             load_predictor(
                 verb,
-                path=det_path,
+                path=None,
                 run_id=None,
                 tags=["a"],
                 groups=None,
@@ -260,4 +326,37 @@ class TestLoadPredictorGuardsAgainstBothSourcesGiven:
 
         message = str(exc_info.value)
         assert "--path" in message
-        assert "--tags" in message
+
+    def test_groups_without_path_raises_value_error_naming_path(self, tmp_path):
+        verb = get_verb("predict")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_predictor(
+                verb,
+                path=None,
+                run_id=None,
+                tags=None,
+                groups=["g"],
+                metric=None,
+                local_dir=str(tmp_path),
+            )
+
+        message = str(exc_info.value)
+        assert "--path" in message
+
+    def test_metric_without_path_raises_value_error_naming_path(self, tmp_path):
+        verb = get_verb("predict")
+
+        with pytest.raises(ValueError) as exc_info:
+            load_predictor(
+                verb,
+                path=None,
+                run_id=None,
+                tags=None,
+                groups=None,
+                metric="f1",
+                local_dir=str(tmp_path),
+            )
+
+        message = str(exc_info.value)
+        assert "--path" in message

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -38,6 +38,7 @@ import onnxruntime as ort  # type: ignore[import-untyped]
 from PIL import Image as PILImage  # type: ignore[import-untyped]
 
 from radiologist.inference.models import ModelMetadata
+from radiologist.registry.models import ArtifactRef
 from radiologist.registry.selector import resolve_selector
 from radiologist.registry.wandb_registry import WandbRegistry
 
@@ -58,12 +59,24 @@ class _PredictorState:
     model_metadata: ModelMetadata
     mean: Optional[float] = field(default=None)
     std: Optional[float] = field(default=None)
+    provenance: Optional[ArtifactRef] = field(default=None)
+    # contract: set only by from_selector; None for from_path-loaded predictors
 
 
 class BasePredictor:
     """Common loading and preprocessing surface for all predictor classes."""
 
     _state: _PredictorState
+
+    @property
+    def provenance(self) -> Optional[ArtifactRef]:
+        """The ArtifactRef this predictor was resolved from.
+
+        Returns:
+            The resolved ``ArtifactRef``, or ``None`` when this predictor was
+            loaded from a local file path rather than a registry selector.
+        """
+        return self._state.provenance
 
     @classmethod
     def from_path(

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -30,8 +30,9 @@ from __future__ import annotations
 
 import json
 import os
+from contextlib import contextmanager
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Dict, Generator, List, Optional, Tuple, Union
 
 import numpy as np
 import onnxruntime as ort  # type: ignore[import-untyped]
@@ -160,10 +161,8 @@ class BasePredictor:
         """
         _validate_mean_std(mean, std)
         reg = registry if registry is not None else WandbRegistry()
-        try:
+        with _translate_wandb_missing():
             model_path = reg.pull(artifact_path=artifact_path, local_dir=local_dir)
-        except RuntimeError as exc:
-            raise RuntimeError(_INFERENCE_WANDB_MISSING_MSG) from exc
         return cls.from_path(
             model_path=model_path, mean=mean, std=std, input_shape=input_shape
         )
@@ -213,10 +212,17 @@ def _resolve_and_pull(
 ) -> Tuple[str, ArtifactRef]:
     """Resolve a selector to an artifact ref, then pull its ONNX file."""
     reg = registry if registry is not None else WandbRegistry()
-    try:
+    with _translate_wandb_missing():
         ref = resolve_selector(selector, reg)
         local_path = reg.pull(artifact_path=ref.qualified_name, local_dir=local_dir)
-        return local_path, ref
+    return local_path, ref
+
+
+@contextmanager
+def _translate_wandb_missing() -> Generator[None, None, None]:
+    """Translate a missing-wandb RuntimeError into the inference-extra message."""
+    try:
+        yield
     except RuntimeError as exc:
         raise RuntimeError(_INFERENCE_WANDB_MISSING_MSG) from exc
 

--- a/radiologist-inference/src/radiologist/inference/base_predictor.py
+++ b/radiologist-inference/src/radiologist/inference/base_predictor.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 import json
 import os
 from dataclasses import dataclass, field
-from typing import TYPE_CHECKING, Dict, List, Optional, Union
+from typing import TYPE_CHECKING, Dict, List, Optional, Tuple, Union
 
 import numpy as np
 import onnxruntime as ort  # type: ignore[import-untyped]
@@ -198,22 +198,25 @@ class BasePredictor:
             ValueError: If exactly one of mean/std is provided.
         """
         _validate_mean_std(mean, std)
-        model_path = _resolve_and_pull(selector, local_dir, registry)
-        return cls.from_path(
+        model_path, resolved_ref = _resolve_and_pull(selector, local_dir, registry)
+        instance = cls.from_path(
             model_path=model_path, mean=mean, std=std, input_shape=input_shape
         )
+        instance._state.provenance = resolved_ref
+        return instance
 
 
 def _resolve_and_pull(
     selector: "RegistrySelector",
     local_dir: str,
     registry: Optional["ModelRegistry"] = None,
-) -> str:
+) -> Tuple[str, ArtifactRef]:
     """Resolve a selector to an artifact ref, then pull its ONNX file."""
     reg = registry if registry is not None else WandbRegistry()
     try:
         ref = resolve_selector(selector, reg)
-        return reg.pull(artifact_path=ref.qualified_name, local_dir=local_dir)
+        local_path = reg.pull(artifact_path=ref.qualified_name, local_dir=local_dir)
+        return local_path, ref
     except RuntimeError as exc:
         raise RuntimeError(_INFERENCE_WANDB_MISSING_MSG) from exc
 

--- a/radiologist-inference/src/radiologist/inference/verbs.py
+++ b/radiologist-inference/src/radiologist/inference/verbs.py
@@ -39,6 +39,11 @@ _MUTUALLY_EXCLUSIVE_MSG = (
     "Provide either --path or a registry selector "
     "(--run-id/--tags/--groups/--metric), not both."
 )
+_PATH_REQUIRED_WITH_SELECTOR_MSG = (
+    "--path is required when using a registry selector "
+    "(--run-id/--tags/--groups/--metric); it supplies the entity/project "
+    "to resolve against."
+)
 
 
 @dataclass(frozen=True)

--- a/radiologist-inference/src/radiologist/inference/verbs.py
+++ b/radiologist-inference/src/radiologist/inference/verbs.py
@@ -35,10 +35,6 @@ _SELECTOR_REQUIRED_MSG = (
     "Provide either --path or a registry selector "
     "(--run-id/--tags/--groups/--metric)."
 )
-_MUTUALLY_EXCLUSIVE_MSG = (
-    "Provide either --path or a registry selector "
-    "(--run-id/--tags/--groups/--metric), not both."
-)
 _PATH_REQUIRED_WITH_SELECTOR_MSG = (
     "--path is required when using a registry selector "
     "(--run-id/--tags/--groups/--metric); it supplies the entity/project "
@@ -114,20 +110,22 @@ def load_predictor(
 ) -> BasePredictor:
     """Single loading path for every verb.
 
-    When the (verb-adjusted) flags are registry-backed, resolves via
-    ``verb.predictor_cls.from_selector(...)``; else when ``path`` is a local
-    path, ``verb.predictor_cls.from_path(model_path=path)``; else raises
-    ``ValueError`` naming ``--path`` and the registry selector flags.
-    ``path`` and any registry selector flag are mutually exclusive: passing
-    both raises ``ValueError`` rather than silently favoring one. When
-    ``verb.mcd_convention`` is ``True``, ``run_id`` is rewritten via
-    ``apply_mcd_convention`` before building the selector.
+    When the (verb-adjusted) flags are registry-backed, ``--path`` is
+    required — it supplies the entity/project ``selector_from_flags``
+    resolves against — and resolution proceeds via
+    ``verb.predictor_cls.from_selector(...)``. When only ``path`` is given
+    (no registry selector flag), it is treated as a local ONNX file and
+    loaded via ``verb.predictor_cls.from_path(model_path=path)``. When
+    neither is given, raises ``ValueError`` naming ``--path`` and the
+    registry selector flags. When ``verb.mcd_convention`` is ``True``,
+    ``run_id`` is rewritten via ``apply_mcd_convention`` before building the
+    selector.
 
     Args:
         verb: Registered verb descriptor naming the predictor class to
             construct and whether the ``{run_id}-mcd`` convention applies.
-        path: Local ONNX file path. Mutually exclusive with the registry
-            selector flags (``run_id``/``tags``/``groups``/``metric``).
+        path: Local ONNX file path, or (when combined with a registry
+            selector flag) the entity/project prefix to resolve against.
         run_id: Registry selector run id. Rewritten via
             ``apply_mcd_convention`` when ``verb.mcd_convention`` is ``True``.
         tags: Registry selector tags.
@@ -146,9 +144,9 @@ def load_predictor(
         Loaded predictor instance of ``verb.predictor_cls``.
 
     Raises:
-        ValueError: If neither ``path`` nor a registry selector flag
-            (``run_id``/``tags``/``groups``/``metric``) is provided, or if
-            both ``path`` and a registry selector flag are provided.
+        ValueError: If a registry selector flag (``run_id``/``tags``/
+            ``groups``/``metric``) is provided without ``path``, or if
+            neither ``path`` nor a registry selector flag is provided.
     """
     effective_run_id = apply_mcd_convention(run_id) if verb.mcd_convention else run_id
     selector = selector_from_flags(
@@ -160,9 +158,9 @@ def load_predictor(
     )
     has_path = path is not None
     registry_backed = selector.is_registry_backed()
-    if has_path and registry_backed:
-        raise ValueError(_MUTUALLY_EXCLUSIVE_MSG)
-    if registry_backed:
+    if registry_backed and not has_path:
+        raise ValueError(_PATH_REQUIRED_WITH_SELECTOR_MSG)
+    if registry_backed and has_path:
         return verb.predictor_cls.from_selector(
             selector,
             local_dir=local_dir,

--- a/radiologist-registry/README.md
+++ b/radiologist-registry/README.md
@@ -42,8 +42,10 @@ Exported from `radiologist.registry`:
   framework-neutral description of which artifact to resolve
   (`path`, `run_id`, `groups`, `tags`, `metric`, `version`,
   `include_sweeps`). `resolve_selector(selector, registry)` validates that
-  `run_id` and `tags` are not both set, then delegates to
-  `registry.resolve(...)`.
+  `run_id` and `tags` are not both set, and that a registry-backed selector
+  (any of `run_id`/`tags`/`groups`/`metric`/`version` set) carries a
+  non-blank `path` — the entity/project to resolve against — then delegates
+  to `registry.resolve(...)`.
 - **`ArtifactRef`** — resolved artifact pointer (`qualified_name`, `run_id`,
   `artifact_name`, `version`).
 - **`ExportResult`** — paths and metadata for a freshly exported model pair

--- a/radiologist-registry/radiologist_registry_tests/test_registry_selector.py
+++ b/radiologist-registry/radiologist_registry_tests/test_registry_selector.py
@@ -206,3 +206,56 @@ def test_resolve_selector_raises_valueerror_when_run_id_and_tags_both_set(
         resolve_selector(selector, registry)
 
     assert registry.calls == []
+
+
+def test_resolve_selector_raises_valueerror_when_registry_backed_and_path_empty(
+    registry: FakeModelRegistry,
+) -> None:
+    selector = RegistrySelector(path="", run_id="run-123")
+
+    with pytest.raises(ValueError, match="base path"):
+        resolve_selector(selector, registry)
+
+    assert registry.calls == []
+
+
+def test_resolve_selector_raises_valueerror_when_registry_backed_and_path_blank(
+    registry: FakeModelRegistry,
+) -> None:
+    selector = RegistrySelector(path="   ", tags=["prod"])
+
+    with pytest.raises(ValueError, match="base path"):
+        resolve_selector(selector, registry)
+
+    assert registry.calls == []
+
+
+def test_resolve_selector_prefers_run_id_tags_error_over_path_error(
+    registry: FakeModelRegistry,
+) -> None:
+    selector = RegistrySelector(path="", run_id="run-123", tags=["prod"])
+
+    with pytest.raises(ValueError, match="either --run-id or --tags"):
+        resolve_selector(selector, registry)
+
+    assert registry.calls == []
+
+
+def test_resolve_selector_with_path_and_search_criteria_still_resolves(
+    registry: FakeModelRegistry, canned_ref: ArtifactRef
+) -> None:
+    selector = RegistrySelector(path="entity/project", run_id="run-123")
+
+    result = resolve_selector(selector, registry)
+
+    assert result == canned_ref
+
+
+def test_resolve_selector_with_path_and_no_search_criteria_is_unaffected(
+    registry: FakeModelRegistry, canned_ref: ArtifactRef
+) -> None:
+    selector = RegistrySelector(path="models/local.onnx")
+
+    result = resolve_selector(selector, registry)
+
+    assert result == canned_ref

--- a/radiologist-registry/src/radiologist/registry/selector.py
+++ b/radiologist-registry/src/radiologist/registry/selector.py
@@ -103,6 +103,11 @@ def selector_from_flags(
     )
 
 
+_PATH_REQUIRED_MSG = (
+    "A base path (entity/project) is required to resolve a registry selector."
+)
+
+
 def resolve_selector(
     selector: RegistrySelector, registry: ModelRegistry
 ) -> ArtifactRef:
@@ -116,10 +121,13 @@ def resolve_selector(
         The resolved artifact pointer.
 
     Raises:
-        ValueError: If both `run_id` and `tags` are set on the selector.
+        ValueError: If both `run_id` and `tags` are set on the selector, or
+            if the selector is registry-backed but carries a blank `path`.
     """
     if selector.run_id and selector.tags:
         raise ValueError("Provide either --run-id or --tags, not both.")
+    if selector.is_registry_backed() and not selector.path.strip():
+        raise ValueError(_PATH_REQUIRED_MSG)
     return registry.resolve(
         path=selector.path,
         run_id=selector.run_id,


### PR DESCRIPTION
## Summary
Milestone #18 (Epic 1). Registry-backed inference loading previously accepted a selector (`--run-id`/`--tags`/`--groups`/`--metric`) without `--path`, silently falling back to W&B's ambient default entity/project, and rejected the one combination (`--path` + selector) that would make resolution deterministic. This inverts that contract:

- A registry selector now requires `--path` (supplies the entity/project); `--path` alone still loads a local ONNX file unchanged.
- The same guarantee is hardened at the shared `radiologist-registry` `resolve_selector` seam, so it holds for any caller, not just the inference CLI path.
- Resolved artifact provenance (qualified name + version) is now surfaced as `model_qualified_name`/`model_version` in CLI output across `predict`/`explain`/`uncertainty`/`serve`.

Closes #208, #209, #210, #211, #212. Supersedes #146, #147, #148.

## Changes by issue
- #208 — skeleton: stubbed `_PredictorState.provenance`, `BasePredictor.provenance`, `_PATH_REQUIRED_WITH_SELECTOR_MSG`, `_provenance_record` (no behavior change).
- #209 — `load_predictor` now requires `--path` alongside any registry selector.
- #210 — `BasePredictor.provenance` carries the resolved `ArtifactRef` when loaded via `from_selector`.
- #211 — all four `infer` commands (`predict`/`explain`/`uncertainty`/`serve`) enforce and report provenance.
- #212 — `resolve_selector` backstop + updated `radiologist-registry`/CLI docs.

## Test plan
- [x] Each issue implemented via strict TDD in its own worktree/branch, one commit per issue.
- [x] Full suite green after each merge: `make test` → 863 passed, 2 deselected.
- [x] `mypy` clean on all touched files.
- [x] No mocks of owned (`radiologist.*`) code; only true process boundaries (`radiologist.registry.resolver._wandb`, `radiologist.inference.optional._uvicorn`) are patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)