### PR TITLE
fix(etl): drop deferred Ray backend from default install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,9 @@ jobs:
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
-      - run: uv sync --active --all-groups --all-packages --all-extras
+      # ray is excluded on purpose: the Ray execution family is still under
+      # development (#188) and no test requires it.
+      - run: uv sync --active --all-groups --all-packages --all-extras --no-extra ray
       - run: make test PYTEST_FLAGS="-q --cov-report=xml"
       - uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,7 +127,9 @@ jobs:
       - uses: astral-sh/setup-uv@v3
         with:
           enable-cache: true
-      - run: uv sync --active --all-groups --all-packages --all-extras
+      # ray is excluded on purpose: the Ray execution family is still under
+      # development (#188) and no test requires it.
+      - run: uv sync --active --all-groups --all-packages --all-extras --no-extra ray
       - run: make test
 
   build:

--- a/Makefile
+++ b/Makefile
@@ -245,8 +245,8 @@ reload:  ## remind to reload shell
 sync:  ## sync all dep-groups + all workspace packages (no optional extras)
 	@uv sync --active --all-groups --all-packages
 
-sync-all:  ## sync all dep-groups + all workspace packages + all optional extras
-	@uv sync --active --all-groups --all-packages --all-extras
+sync-all:  ## sync all dep-groups + all workspace packages + all optional extras except ray (deferred backend, see #188)
+	@uv sync --active --all-groups --all-packages --all-extras --no-extra ray
 
 dev-install: sync-all  ## sync deps + install pre-commit hooks (run once after clone)
 	@uv run --active pre-commit install

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ test = [
     "pytest>=8.0.0",
     "pytest-cov>=6.0.0",
     "pytest-mock>=3.0.0",
+    "tomli>=2.0.1; python_version < '3.11'",
 ]
 docs = [
     "mkdocs>=1.6",

--- a/radiologist-etl/README.md
+++ b/radiologist-etl/README.md
@@ -181,14 +181,49 @@ Common ones:
 `extract` and `build` accept `runner=<family>`, selecting the Prefect task
 runner the stage's batches/shards are dispatched through:
 
-| Family | Config | Extra |
-|---|---|---|
-| `local` (default) | `runner=local` | none |
-| Dask | `runner=dask_local` / `runner=dask_cluster` / `runner=dask_address` | `radiologist-etl[dask]` |
-| Ray | `runner=ray_local` / `runner=ray_cluster` | `radiologist-etl[ray]` |
-| Beam | `runner=beam_direct` / `runner=beam_dataflow` | `radiologist-etl[beam]` |
+| Family | Config | Extra | In `all`? |
+|---|---|---|---|
+| `local` (default) | `runner=local` | none | — |
+| Dask | `runner=dask_local` / `runner=dask_cluster` / `runner=dask_address` | `radiologist-etl[dask]` | Yes |
+| Ray | `runner=ray_local` / `runner=ray_cluster` | `radiologist-etl[ray]` | No — opt-in only |
+| Beam | `runner=beam_direct` / `runner=beam_dataflow` | `radiologist-etl[beam]` | Yes |
 
 `assign-split` always runs locally and accepts no `runner=` override.
+
+#### What `all` installs (and why Ray is not in it)
+
+`radiologist-etl[all]` is a curated aggregate: it installs `gcs`, `prefect`,
+`dask`, and `beam`, but **deliberately excludes `ray`**. The Ray execution
+family (`runner=ray_local` / `runner=ray_cluster`) is still under
+development (see #188) — Beam, by contrast, is *not* deferred: it shipped
+(see #189) and is part of `all` like the other production-ready backends.
+
+If you installed `radiologist-etl[all]`, selected `runner=ray_local` or
+`runner=ray_cluster`, and hit an "install the ray extra" error, that is
+expected, not a bug. Opt in explicitly:
+
+```bash
+# in-repo contributor, from a workspace checkout
+uv sync --active --extra ray
+
+# external consumer
+pip install 'radiologist-etl[ray]'
+```
+
+The repo's own dev-setup (`make dev-install`) and both CI test jobs also
+exclude the Ray extra, but through a **separate mechanism**: they install
+with `--all-extras --no-extra ray`. `--all-extras` installs every extra
+named in `pyproject.toml` directly, bypassing the `all` extra's own
+composition entirely — so scoping `all` to leave Ray out is not, by itself,
+enough to keep Ray out of those installs, and `--no-extra ray` is required
+in addition. Removing `--no-extra ray` from the Makefile or CI workflows
+would silently reintroduce Ray into those installs even though `all` still
+excludes it.
+
+The documentation build (`make docs-install` / `docs-build`) is the one
+install path that still pulls in every extra, Ray included — `mkdocstrings`
+needs every optional module importable to render its API reference, so that
+target intentionally uses plain `--all-extras` with no exclusion.
 
 #### Beam
 

--- a/radiologist-etl/pyproject.toml
+++ b/radiologist-etl/pyproject.toml
@@ -37,11 +37,13 @@ prefect = ["prefect>=3.7.0"]
 dask = ["prefect-dask>=0.3.0"]
 ray = ["prefect-ray>=0.4.0"]
 beam = ["apache-beam>=2.60.0"]
+# ``all`` bundles every production-ready extra. ``ray`` is deliberately
+# excluded while the Ray execution family is still under development
+# (see issue #188); install it explicitly with ``radiologist-etl[ray]``.
 all = [
     "gcsfs>=2026.4.0",
     "prefect>=3.7.0",
     "prefect-dask>=0.3.0",
-    "prefect-ray>=0.4.0",
     "apache-beam>=2.60.0"
 ]
 

--- a/radiologist-etl/radiologist_etl_tests/test_packaging_extras.py
+++ b/radiologist-etl/radiologist_etl_tests/test_packaging_extras.py
@@ -112,3 +112,14 @@ def test_all_extra_is_superset_of_each_production_ready_extra(
         "the aggregate 'all' extra is missing distributions required by "
         f"extra {extra!r}: {missing!r}"
     )
+
+
+def test_all_extra_excludes_the_deferred_ray_backend() -> None:
+    data = _load_etl_pyproject()
+    all_names = _extra_distribution_names(data, "all")
+    ray_names = _extra_distribution_names(data, "ray")
+    offending = all_names & ray_names
+    assert not offending, (
+        "the aggregate 'all' extra must not bundle the deferred Ray "
+        f"execution backend (see #188), found {offending!r}"
+    )

--- a/radiologist-etl/radiologist_etl_tests/test_packaging_extras.py
+++ b/radiologist-etl/radiologist_etl_tests/test_packaging_extras.py
@@ -1,0 +1,114 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Executable contract pinning radiologist-etl's optional-dependency taxonomy.
+
+See issue #213: this module freezes the extras invariants that already hold
+today. It parses ``radiologist-etl/pyproject.toml`` directly -- no
+``radiologist.etl`` import -- so it stays green on a checkout where no extra
+at all is installed.
+"""
+
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Set
+
+import pytest
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - this repo pins Python 3.10
+    import tomli as tomllib  # type: ignore[import-untyped,no-redef]
+
+_SINGLE_DISTRIBUTION_EXTRAS = ("gcs", "prefect", "dask", "ray", "beam")
+_PRODUCTION_READY_EXTRAS = ("gcs", "prefect", "dask", "beam")
+_DISALLOWED_DEFAULT_DISTRIBUTIONS = (
+    "prefect",
+    "prefect-dask",
+    "prefect-ray",
+    "apache-beam",
+)
+
+_REQUIREMENT_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+")
+
+
+def _etl_pyproject_path() -> Path:
+    return Path(__file__).resolve().parents[1] / "pyproject.toml"
+
+
+def _load_etl_pyproject() -> Dict[str, Any]:
+    with _etl_pyproject_path().open("rb") as handle:
+        return tomllib.load(handle)
+
+
+def _normalise(distribution_name: str) -> str:
+    return distribution_name.lower().replace("_", "-")
+
+
+def _requirement_distribution_name(requirement: str) -> str:
+    match = _REQUIREMENT_NAME_RE.match(requirement.strip())
+    if not match:
+        raise ValueError(f"Could not parse a distribution name from {requirement!r}")
+    return _normalise(match.group(0))
+
+
+def _extra_distribution_names(data: Dict[str, Any], extra: str) -> Set[str]:
+    requirements: List[str] = data["project"]["optional-dependencies"][extra]
+    return {_requirement_distribution_name(req) for req in requirements}
+
+
+@pytest.mark.parametrize("extra", _SINGLE_DISTRIBUTION_EXTRAS)
+def test_execution_backend_extra_names_exactly_one_distribution(
+    extra: str,
+) -> None:
+    data = _load_etl_pyproject()
+    distributions = _extra_distribution_names(data, extra)
+    assert len(distributions) == 1, (
+        f"extra {extra!r} must name exactly one distribution, " f"got {distributions!r}"
+    )
+
+
+def test_default_dependencies_exclude_orchestrator_and_backends() -> None:
+    data = _load_etl_pyproject()
+    default_names = {
+        _requirement_distribution_name(req) for req in data["project"]["dependencies"]
+    }
+    disallowed = {_normalise(name) for name in _DISALLOWED_DEFAULT_DISTRIBUTIONS}
+    offending = default_names & disallowed
+    assert not offending, (
+        "radiologist-etl's default dependencies must not name an "
+        f"orchestrator or execution-backend distribution, found {offending!r}"
+    )
+
+
+@pytest.mark.parametrize("extra", _PRODUCTION_READY_EXTRAS)
+def test_all_extra_is_superset_of_each_production_ready_extra(
+    extra: str,
+) -> None:
+    data = _load_etl_pyproject()
+    all_names = _extra_distribution_names(data, "all")
+    extra_names = _extra_distribution_names(data, extra)
+    missing = extra_names - all_names
+    assert not missing, (
+        "the aggregate 'all' extra is missing distributions required by "
+        f"extra {extra!r}: {missing!r}"
+    )

--- a/scripts_tests/test_ci_workflows_exclude_ray.py
+++ b/scripts_tests/test_ci_workflows_exclude_ray.py
@@ -1,0 +1,139 @@
+# MIT License
+#
+# Copyright (c) 2026 @CedrickArmel
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+"""Behavioral tests for the CI/publish workflows' Ray-exclusion contract.
+
+See issue #216: `.github/workflows/ci.yml`'s and `.github/workflows/publish.yml`'s
+``test`` job both install the workspace with ``uv sync --all-extras`` before
+running the suite. ``--all-extras`` enumerates every named extra of every
+workspace package and ignores extra composition, so both jobs force-install
+the still-under-development Ray execution backend (issue #188). Both jobs
+must exclude it identically, while ``docs.yml`` -- which needs every module
+importable, including Ray-referencing Hydra config targets -- must keep
+installing it, untouched.
+
+These tests parse the workflow YAML as text (no ``pyyaml`` dependency) so
+they stay green on a checkout where no extra at all is installed.
+"""
+
+import re
+from pathlib import Path
+from typing import List
+
+_WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+
+_JOB_HEADER_RE = re.compile(r"^  (\S+):\s*$")
+
+
+def _read_workflow(name: str) -> str:
+    return (_WORKFLOWS_DIR / name).read_text()
+
+
+def _job_lines(workflow_text: str, job_name: str) -> List[str]:
+    """Return the raw lines belonging to a single top-level job block."""
+    lines = workflow_text.splitlines()
+    start = None
+    for index, line in enumerate(lines):
+        match = _JOB_HEADER_RE.match(line)
+        if match and match.group(1) == job_name:
+            start = index + 1
+            break
+    if start is None:
+        raise AssertionError(f"job {job_name!r} not found")
+    end = len(lines)
+    for index in range(start, len(lines)):
+        if _JOB_HEADER_RE.match(lines[index]):
+            end = index
+            break
+    return lines[start:end]
+
+
+def _install_step_index(job_lines: List[str]) -> int:
+    """Return the index, within ``job_lines``, of the ``uv sync`` install step."""
+    candidates = [
+        index
+        for index, line in enumerate(job_lines)
+        if "uv sync" in line and "--all-extras" in line
+    ]
+    assert len(candidates) == 1, (
+        "expected exactly one 'uv sync ... --all-extras' install step, got "
+        f"{[job_lines[i] for i in candidates]!r}"
+    )
+    return candidates[0]
+
+
+def _install_step_line(job_lines: List[str]) -> str:
+    return job_lines[_install_step_index(job_lines)].strip()
+
+
+def test_ci_test_job_install_step_excludes_ray() -> None:
+    lines = _job_lines(_read_workflow("ci.yml"), "test")
+    install_line = _install_step_line(lines)
+    assert "--no-extra ray" in install_line
+
+
+def test_publish_test_job_install_step_excludes_ray() -> None:
+    lines = _job_lines(_read_workflow("publish.yml"), "test")
+    install_line = _install_step_line(lines)
+    assert "--no-extra ray" in install_line
+
+
+def test_ci_and_publish_test_jobs_install_the_same_dependency_set() -> None:
+    ci_install = _install_step_line(_job_lines(_read_workflow("ci.yml"), "test"))
+    publish_install = _install_step_line(
+        _job_lines(_read_workflow("publish.yml"), "test")
+    )
+    assert ci_install == publish_install
+
+
+def test_ray_exclusion_reason_is_documented_next_to_the_install_step() -> None:
+    for workflow in ("ci.yml", "publish.yml"):
+        lines = _job_lines(_read_workflow(workflow), "test")
+        install_index = _install_step_index(lines)
+        preceding = "\n".join(lines[max(0, install_index - 3) : install_index]).lower()
+        assert (
+            "ray" in preceding
+        ), f"{workflow}: no comment mentions ray above the install step"
+        assert (
+            "188" in preceding
+        ), f"{workflow}: no comment references issue #188 above the install step"
+
+
+def test_publish_build_job_still_gates_on_the_test_job() -> None:
+    lines = _job_lines(_read_workflow("publish.yml"), "build")
+    block = "\n".join(lines)
+    assert re.search(
+        r"needs:\s*\[[^\]]*\btest\b[^\]]*\]", block
+    ), "publish.yml's build job must still depend on the test job"
+
+
+def test_publish_test_job_is_not_weakened() -> None:
+    lines = _job_lines(_read_workflow("publish.yml"), "test")
+    block = "\n".join(lines)
+    assert "continue-on-error" not in block
+    assert not re.search(r"^\s*if:", block, flags=re.MULTILINE)
+
+
+def test_docs_workflow_install_step_is_byte_for_byte_unchanged() -> None:
+    docs_text = _read_workflow("docs.yml")
+    assert "- run: uv sync --group docs --all-packages --all-extras" in docs_text
+    assert "--no-extra ray" not in docs_text

--- a/scripts_tests/test_ci_workflows_exclude_ray.py
+++ b/scripts_tests/test_ci_workflows_exclude_ray.py
@@ -39,6 +39,8 @@ import re
 from pathlib import Path
 from typing import List
 
+import pytest
+
 _WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
 
 _JOB_HEADER_RE = re.compile(r"^  (\S+):\s*$")
@@ -85,14 +87,9 @@ def _install_step_line(job_lines: List[str]) -> str:
     return job_lines[_install_step_index(job_lines)].strip()
 
 
-def test_ci_test_job_install_step_excludes_ray() -> None:
-    lines = _job_lines(_read_workflow("ci.yml"), "test")
-    install_line = _install_step_line(lines)
-    assert "--no-extra ray" in install_line
-
-
-def test_publish_test_job_install_step_excludes_ray() -> None:
-    lines = _job_lines(_read_workflow("publish.yml"), "test")
+@pytest.mark.parametrize("workflow", ["ci.yml", "publish.yml"])
+def test_test_job_install_step_excludes_ray(workflow: str) -> None:
+    lines = _job_lines(_read_workflow(workflow), "test")
     install_line = _install_step_line(lines)
     assert "--no-extra ray" in install_line
 
@@ -105,17 +102,26 @@ def test_ci_and_publish_test_jobs_install_the_same_dependency_set() -> None:
     assert ci_install == publish_install
 
 
-def test_ray_exclusion_reason_is_documented_next_to_the_install_step() -> None:
-    for workflow in ("ci.yml", "publish.yml"):
-        lines = _job_lines(_read_workflow(workflow), "test")
-        install_index = _install_step_index(lines)
-        preceding = "\n".join(lines[max(0, install_index - 3) : install_index]).lower()
-        assert (
-            "ray" in preceding
-        ), f"{workflow}: no comment mentions ray above the install step"
-        assert (
-            "188" in preceding
-        ), f"{workflow}: no comment references issue #188 above the install step"
+def _preceding_comment_block(job_lines: List[str], step_index: int) -> str:
+    """Return the contiguous run of ``#``-comment lines directly above a step."""
+    start = step_index
+    while start > 0 and job_lines[start - 1].strip().startswith("#"):
+        start -= 1
+    return "\n".join(job_lines[start:step_index]).lower()
+
+
+@pytest.mark.parametrize("workflow", ["ci.yml", "publish.yml"])
+def test_ray_exclusion_reason_is_documented_next_to_the_install_step(
+    workflow: str,
+) -> None:
+    lines = _job_lines(_read_workflow(workflow), "test")
+    preceding = _preceding_comment_block(lines, _install_step_index(lines))
+    assert (
+        "ray" in preceding
+    ), f"{workflow}: no comment mentions ray above the install step"
+    assert (
+        "188" in preceding
+    ), f"{workflow}: no comment references issue #188 above the install step"
 
 
 def test_publish_build_job_still_gates_on_the_test_job() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -5710,6 +5710,7 @@ test = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-mock" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
 typing = [
     { name = "mypy" },
@@ -5751,6 +5752,7 @@ test = [
     { name = "pytest", specifier = ">=8.0.0" },
     { name = "pytest-cov", specifier = ">=6.0.0" },
     { name = "pytest-mock", specifier = ">=3.0.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.1" },
 ]
 typing = [{ name = "mypy", specifier = ">=1.19.1" }]
 
@@ -5896,7 +5898,6 @@ all = [
     { name = "gcsfs" },
     { name = "prefect" },
     { name = "prefect-dask" },
-    { name = "prefect-ray" },
 ]
 beam = [
     { name = "apache-beam" },
@@ -5929,7 +5930,6 @@ requires-dist = [
     { name = "prefect", marker = "extra == 'prefect'", specifier = ">=3.7.0" },
     { name = "prefect-dask", marker = "extra == 'all'", specifier = ">=0.3.0" },
     { name = "prefect-dask", marker = "extra == 'dask'", specifier = ">=0.3.0" },
-    { name = "prefect-ray", marker = "extra == 'all'", specifier = ">=0.4.0" },
     { name = "prefect-ray", marker = "extra == 'ray'", specifier = ">=0.4.0" },
     { name = "pyarrow", specifier = ">=24.0.0" },
     { name = "radiologist-utils", editable = "radiologist-utils" },


### PR DESCRIPTION
## Summary

- Pins the `radiologist-etl` extras taxonomy as an executable packaging contract so the deferred Ray backend can never silently leak back into the default install (#213).
- Drops the deferred Ray backend from `radiologist-etl[all]` (#214) and excludes it from `make dev-install` (#215) and both CI test gates (#216).
- Documents that `radiologist-etl[all]` excludes the Ray extra (#217).
- Stretch issues #218 and #219 were intentionally left out of scope — optional, non-blocking, deferred.

Closes #213, #214, #215, #216, #217

## Test plan

- [x] Full test suite green (881 passed, 2 deselected)
- [x] Manually confirmed a fresh `make dev-install` installs no `ray`/`prefect-ray` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)