### PR TITLE
refactor(ci): dedupe test gate between ci.yml and publish.yml

### DIFF
--- a/.github/actions/setup-and-test/action.yml
+++ b/.github/actions/setup-and-test/action.yml
@@ -1,0 +1,37 @@
+name: Setup and test
+description: >-
+  Checkout, install the uv-managed workspace (Ray excluded — see #188) and run
+  the test suite. Shared by ci.yml's and publish.yml's test-gate jobs so both
+  install and run tests identically.
+
+inputs:
+  ref:
+    description: Git ref to check out. Empty uses actions/checkout's own default.
+    required: false
+    default: ""
+  pytest-flags:
+    description: >-
+      Value passed through to `make test PYTEST_FLAGS=...`. Defaults to the
+      Makefile's own default (-q); ci.yml overrides it to also emit a
+      coverage.xml for Codecov.
+    required: false
+    default: "-q"
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/checkout@v4
+      with:
+        ref: ${{ inputs.ref }}
+    - uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+    - uses: astral-sh/setup-uv@v3
+      with:
+        enable-cache: true
+    # ray is excluded on purpose: the Ray execution family is still under
+    # development (#188) and no test requires it.
+    - run: uv sync --active --all-groups --all-packages --all-extras --no-extra ray
+      shell: bash
+    - run: make test PYTEST_FLAGS="${{ inputs.pytest-flags }}"
+      shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,10 @@ jobs:
     env:
       VIRTUAL_ENV: ${{ github.workspace }}/.venv
     steps:
+      # A local composite action can't be resolved until the repo containing
+      # it is checked out — this bootstraps that; setup-and-test then does
+      # its own checkout for the ref it's actually asked to test.
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-and-test
         with:
           pytest-flags: "-q --cov-report=xml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,17 +22,9 @@ jobs:
     env:
       VIRTUAL_ENV: ${{ github.workspace }}/.venv
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: ./.github/actions/setup-and-test
         with:
-          python-version: "3.10"
-      - uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-      # ray is excluded on purpose: the Ray execution family is still under
-      # development (#188) and no test requires it.
-      - run: uv sync --active --all-groups --all-packages --all-extras --no-extra ray
-      - run: make test PYTEST_FLAGS="-q --cov-report=xml"
+          pytest-flags: "-q --cov-report=xml"
       - uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,6 +118,10 @@ jobs:
     env:
       VIRTUAL_ENV: ${{ github.workspace }}/.venv
     steps:
+      # A local composite action can't be resolved until the repo containing
+      # it is checked out — this bootstraps that; setup-and-test then does
+      # its own checkout at the resolved sha.
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-and-test
         with:
           ref: ${{ needs.resolve.outputs.sha }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -118,19 +118,9 @@ jobs:
     env:
       VIRTUAL_ENV: ${{ github.workspace }}/.venv
     steps:
-      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-and-test
         with:
           ref: ${{ needs.resolve.outputs.sha }}
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.10"
-      - uses: astral-sh/setup-uv@v3
-        with:
-          enable-cache: true
-      # ray is excluded on purpose: the Ray execution family is still under
-      # development (#188) and no test requires it.
-      - run: uv sync --active --all-groups --all-packages --all-extras --no-extra ray
-      - run: make test
 
   build:
     needs: [resolve, test]

--- a/scripts_tests/test_ci_workflows_exclude_ray.py
+++ b/scripts_tests/test_ci_workflows_exclude_ray.py
@@ -129,6 +129,29 @@ def test_test_job_delegates_to_the_shared_setup_and_test_action(
     )
 
 
+@pytest.mark.parametrize("workflow", ["ci.yml", "publish.yml"])
+def test_test_job_checks_out_before_calling_the_local_composite_action(
+    workflow: str,
+) -> None:
+    """A local `uses: ./...` action can't be resolved before a checkout.
+
+    GitHub loads a same-repo composite action off the runner's local
+    filesystem, which is empty until something checks the repository out --
+    the composite action's own internal checkout runs too late to bootstrap
+    itself. Each `test` job must therefore run `actions/checkout` before
+    invoking `setup-and-test`.
+    """
+    lines = _job_lines(_read_workflow(workflow), "test")
+    composite_index = next(
+        index for index, line in enumerate(lines) if "uses: ./.github/actions" in line
+    )
+    preceding = "\n".join(lines[:composite_index])
+    assert "uses: actions/checkout" in preceding, (
+        f"{workflow}: the test job must check out the repo before invoking "
+        "the local setup-and-test composite action"
+    )
+
+
 def test_ci_and_publish_test_jobs_call_the_identical_composite_action() -> None:
     """The two `test` jobs reference the exact same action, byte-for-byte.
 

--- a/scripts_tests/test_ci_workflows_exclude_ray.py
+++ b/scripts_tests/test_ci_workflows_exclude_ray.py
@@ -31,8 +31,21 @@ must exclude it identically, while ``docs.yml`` -- which needs every module
 importable, including Ray-referencing Hydra config targets -- must keep
 installing it, untouched.
 
-These tests parse the workflow YAML as text (no ``pyyaml`` dependency) so
-they stay green on a checkout where no extra at all is installed.
+Issue #167 later extracted the shared install/test steps out of each
+workflow's ``test`` job into the composite action
+``.github/actions/setup-and-test/action.yml``, so the ray-exclusion install
+line now lives in that single shared file instead of being duplicated
+inline in each workflow. This is a deliberate, explicit deviation from
+issue #167's own "no test may be changed" acceptance criterion -- the user
+decided, after being shown that the extraction could not otherwise leave
+these tests passing unmodified, to relocate what these tests check rather
+than block the refactor or leave the install command duplicated. The
+assertions below preserve the same behavioral coverage as before, just
+pointed at the new location.
+
+These tests parse the workflow/action YAML as text (no ``pyyaml``
+dependency) so they stay green on a checkout where no extra at all is
+installed.
 """
 
 import re
@@ -41,13 +54,23 @@ from typing import List
 
 import pytest
 
-_WORKFLOWS_DIR = Path(__file__).resolve().parents[1] / ".github" / "workflows"
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_WORKFLOWS_DIR = _REPO_ROOT / ".github" / "workflows"
+_COMPOSITE_ACTION = _REPO_ROOT / ".github" / "actions" / "setup-and-test" / "action.yml"
 
 _JOB_HEADER_RE = re.compile(r"^  (\S+):\s*$")
 
 
 def _read_workflow(name: str) -> str:
     return (_WORKFLOWS_DIR / name).read_text()
+
+
+def _read_composite_action() -> str:
+    return _COMPOSITE_ACTION.read_text()
+
+
+def _composite_action_lines() -> List[str]:
+    return _read_composite_action().splitlines()
 
 
 def _job_lines(workflow_text: str, job_name: str) -> List[str]:
@@ -88,18 +111,48 @@ def _install_step_line(job_lines: List[str]) -> str:
 
 
 @pytest.mark.parametrize("workflow", ["ci.yml", "publish.yml"])
-def test_test_job_install_step_excludes_ray(workflow: str) -> None:
+def test_test_job_delegates_to_the_shared_setup_and_test_action(
+    workflow: str,
+) -> None:
+    """Each workflow's `test` job installs/tests via the composite action.
+
+    The install command itself no longer lives inline in the job body (see
+    module docstring) -- what each job body must still show is that it calls
+    the one shared action rather than re-declaring its own steps.
+    """
     lines = _job_lines(_read_workflow(workflow), "test")
+    block = "\n".join(lines)
+    assert "uses: ./.github/actions/setup-and-test" in block
+    assert "uv sync" not in block, (
+        f"{workflow}: the install command should live only in the composite "
+        "action, not duplicated inline in the job body"
+    )
+
+
+def test_ci_and_publish_test_jobs_call_the_identical_composite_action() -> None:
+    """The two `test` jobs reference the exact same action, byte-for-byte.
+
+    Replaces the old "install the same dependency set" check: since the
+    install command now lives in a single shared file, the dependency set is
+    identical by construction. What can still drift is *which* action --
+    or which pinned ref of it -- each workflow calls.
+    """
+
+    def _uses_line(workflow: str) -> str:
+        lines = _job_lines(_read_workflow(workflow), "test")
+        candidates = [
+            line.strip() for line in lines if "uses: ./.github/actions" in line
+        ]
+        assert len(candidates) == 1
+        return candidates[0]
+
+    assert _uses_line("ci.yml") == _uses_line("publish.yml")
+
+
+def test_composite_action_install_step_excludes_ray() -> None:
+    lines = _composite_action_lines()
     install_line = _install_step_line(lines)
     assert "--no-extra ray" in install_line
-
-
-def test_ci_and_publish_test_jobs_install_the_same_dependency_set() -> None:
-    ci_install = _install_step_line(_job_lines(_read_workflow("ci.yml"), "test"))
-    publish_install = _install_step_line(
-        _job_lines(_read_workflow("publish.yml"), "test")
-    )
-    assert ci_install == publish_install
 
 
 def _preceding_comment_block(job_lines: List[str], step_index: int) -> str:
@@ -110,18 +163,11 @@ def _preceding_comment_block(job_lines: List[str], step_index: int) -> str:
     return "\n".join(job_lines[start:step_index]).lower()
 
 
-@pytest.mark.parametrize("workflow", ["ci.yml", "publish.yml"])
-def test_ray_exclusion_reason_is_documented_next_to_the_install_step(
-    workflow: str,
-) -> None:
-    lines = _job_lines(_read_workflow(workflow), "test")
+def test_ray_exclusion_reason_is_documented_next_to_the_install_step() -> None:
+    lines = _composite_action_lines()
     preceding = _preceding_comment_block(lines, _install_step_index(lines))
-    assert (
-        "ray" in preceding
-    ), f"{workflow}: no comment mentions ray above the install step"
-    assert (
-        "188" in preceding
-    ), f"{workflow}: no comment references issue #188 above the install step"
+    assert "ray" in preceding, "no comment mentions ray above the install step"
+    assert "188" in preceding, "no comment references issue #188 above the install step"
 
 
 def test_publish_build_job_still_gates_on_the_test_job() -> None:


### PR DESCRIPTION
## Summary

- Extracts the duplicated checkout/setup-python/setup-uv/uv-sync/make-test steps from `ci.yml`'s and `publish.yml`'s `test` jobs into a new composite action `.github/actions/setup-and-test/action.yml`, parameterized by `ref` and `pytest-flags`.
- `ci.yml` keeps its Codecov-specific pytest flags (`-q --cov-report=xml`); `publish.yml` keeps its release-ref checkout (`needs.resolve.outputs.sha`).
- `scripts_tests/test_ci_workflows_exclude_ray.py`'s 8 assertions were relocated to check the composite action file instead of each workflow's inline job body — same behavioral coverage, no assertions dropped.

## Deviation from the issue's own guidance (explicitly user-authorized)

Issue #167 was filed as a parked refactor whose own text said "don't start until duplication causes a real problem, won't-do is a fine outcome," and separately said "no existing test may be changed to accommodate this refactor." This PR deviates from both statements — deliberately, and with the user's explicit sign-off at two checkpoints:

1. Before starting any implementation, the user was asked whether to proceed with the refactor despite the issue's "won't-do is fine" framing, and chose to proceed.
2. Mid-implementation, it became clear the extraction would require relocating assertions in `scripts_tests/test_ci_workflows_exclude_ray.py` (added by #216) from checking each workflow's inline job body to checking the new composite action file. The user was consulted again on this specific point and explicitly chose to proceed with the full extraction rather than stop short of it.

No assertions were dropped — the 8 checks from #216 were moved, not removed, and still assert the same Ray-exclusion behavior, now against the composite action instead of duplicated inline steps.

Closes #167

## Test plan

- [x] Full test suite green independently (882 passed, 2 deselected)
- [x] `scripts_tests` suite green, assertion count unchanged (37 passed)
- [x] Real dry-run of the composite action's shell steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)